### PR TITLE
Detect OpenAPI Version

### DIFF
--- a/src/detector.zig
+++ b/src/detector.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+
+const Document = struct {
+    openapi: ?[]const u8 = null,
+    swagger: ?[]const u8 = null,
+};
+
+pub const OpenApiVersion = enum {
+    Unsupported,
+    v2_0,
+    v3_0,
+    v3_1,
+};
+
+pub fn getOpenApiVersionString(version: OpenApiVersion) []const u8 {
+    return switch (version) {
+        .Unsupported => "Unsupported",
+        .v2_0 => "v2.0",
+        .v3_0 => "v3.0",
+        .v3_1 => "v3.1",
+    };
+}
+
+pub fn getOpenApiVersion(allocator: std.mem.Allocator, json: []const u8) !OpenApiVersion {
+    const parsed = try std.json.parseFromSlice(Document, allocator, json, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+
+    const root = parsed.value;
+    if (root.openapi) |version| {
+        if (std.mem.startsWith(u8, version, "3.1")) {
+            return OpenApiVersion.v3_1;
+        } else if (std.mem.startsWith(u8, version, "3.0")) {
+            return OpenApiVersion.v3_0;
+        }
+    }
+
+    if (root.swagger) |version| {
+        if (std.mem.startsWith(u8, version, "2.0")) {
+            return OpenApiVersion.v2_0;
+        }
+    }
+
+    return OpenApiVersion.Unsupported;
+}


### PR DESCRIPTION
This pull request introduces OpenAPI version detection and parsing enhancements, along with updates to support Swagger v2.0 and OpenAPI v3.0 documents. It also refactors code generation logic to accommodate these changes while maintaining compatibility with existing models.

### OpenAPI Version Detection and Parsing:
* Introduced `OpenApiVersion` enum and `getOpenApiVersion` function in `src/detector.zig` to detect and handle OpenAPI versions (v2.0, v3.0, v3.1) and unsupported versions.
* Added logic in `generateCode` in `src/generator.zig` to utilize the `detector` module for identifying OpenAPI version and conditionally parsing Swagger v2.0 or OpenAPI v3.0 documents.

### Code Generation Enhancements:
* Refactored `generateCode` to separate version-specific parsing and code generation, including a new `generateCodeFromOpenApiDocument` function for OpenAPI v3.0 documents.
* Updated `ApiCodeGenerator` and `ModelCodeGenerator` methods to explicitly use `models.v3` types for OpenAPI v3.0 compatibility. [[1]](diffhunk://#diff-649f150395b46e36b8af76819ace4aecd118c344a329e10a70c40b8a1616262bL155-R174) [[2]](diffhunk://#diff-649f150395b46e36b8af76819ace4aecd118c344a329e10a70c40b8a1616262bL372-R391) [[3]](diffhunk://#diff-649f150395b46e36b8af76819ace4aecd118c344a329e10a70c40b8a1616262bL389-R408) [[4]](diffhunk://#diff-649f150395b46e36b8af76819ace4aecd118c344a329e10a70c40b8a1616262bL404-R423)

### Codebase Maintenance:
* Removed unused variable `openapi` from `generateCode` to streamline the function.
* Updated imports in `src/generator.zig` to include the new `detector` module.