### PR TITLE
Generate API and Models from Swagger v2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ generated/generated.zig
 generated/openapi-petstore.zig
 generated/swagger-petstore-expanded.zig
 generated/swagger-petstore.zig
+generated/generated_v2.zig
+generated/generated_v3.zig

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ test/generated.zig
 src/version_info.zig
 src/openapi2zig.rc
 generated/generated.zig
+generated/openapi-petstore.zig
+generated/swagger-petstore-expanded.zig
+generated/swagger-petstore.zig

--- a/build.zig
+++ b/build.zig
@@ -62,18 +62,35 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    const run_generate_cmd = b.addRunArtifact(exe);
-    run_generate_cmd.addArgs(&.{
+    const run_generate_v3_cmd = b.addRunArtifact(exe);
+    run_generate_v3_cmd.addArgs(&.{
         "generate",
         "-i",
         "openapi/v3.0/petstore.json",
         "-o",
-        "generated/generated.zig",
+        "generated/generated_v3.zig",
         "--base-url",
         "https://petstore.swagger.io/api/v3",
     });
-    const run_generate_step = b.step("run-generate", "Run the app with generate command");
-    run_generate_step.dependOn(&run_generate_cmd.step);
+    const run_generate_v3_step = b.step("run-generate-v3", "Run the app with generate command");
+    run_generate_v3_step.dependOn(&run_generate_v3_cmd.step);
+
+    const run_generate_v2_cmd = b.addRunArtifact(exe);
+    run_generate_v2_cmd.addArgs(&.{
+        "generate",
+        "-i",
+        "openapi/v2.0/petstore.json",
+        "-o",
+        "generated/generated_v2.zig",
+        "--base-url",
+        "https://petstore.swagger.io/api/v2",
+    });
+    const run_generate_v2_step = b.step("run-generate-v2", "Run the app with generate command");
+    run_generate_v2_step.dependOn(&run_generate_v2_cmd.step);
+
+    const run_generate = b.step("run-generate", "Run the app with generate commands");
+    run_generate.dependOn(&run_generate_v3_cmd.step);
+    run_generate.dependOn(&run_generate_v2_cmd.step);
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.

--- a/generated/main.zig
+++ b/generated/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
-const models = @import("generated.zig");
+const v2 = @import("generated_v2.zig");
+const v3 = @import("generated_v3.zig");
 
 pub fn main() !void {
     std.debug.print("Generated models build and run !!\n", .{});

--- a/src/generators/v2.0/apigenerator.zig
+++ b/src/generators/v2.0/apigenerator.zig
@@ -1,1 +1,230 @@
-// TODO: Implement the API generator for SwaggerDocument
+const std = @import("std");
+const models = @import("../../models.zig");
+const cli = @import("../../cli.zig");
+const detector = @import("../../detector.zig");
+const converter = @import("../converter.zig");
+
+const default_output_file: []const u8 = "generated.zig";
+
+pub const ApiCodeGenerator = struct {
+    allocator: std.mem.Allocator,
+    args: cli.CliArgs,
+
+    pub fn init(allocator: std.mem.Allocator, args: cli.CliArgs) ApiCodeGenerator {
+        return ApiCodeGenerator{
+            .allocator = allocator,
+            .args = args,
+        };
+    }
+
+    pub fn deinit(self: *ApiCodeGenerator) void {
+        _ = self;
+    }
+
+    pub fn generate(self: *ApiCodeGenerator, document: models.SwaggerDocument) ![]const u8 {
+        var parts = std.ArrayList([]const u8).init(self.allocator);
+        defer parts.deinit();
+
+        try parts.append("///////////////////////////////////////////\n");
+        try parts.append("// Generated Zig API client from Swagger v2.0\n");
+        try parts.append("///////////////////////////////////////////\n\n");
+        try parts.append("const std = @import(\"std\");\n\n");
+
+        var path_iterator = document.paths.path_items.iterator();
+        while (path_iterator.next()) |entry| {
+            const path_key = entry.key_ptr.*;
+            const path_item = entry.value_ptr.*;
+
+            // Build the full URL path
+            var base_url: []const u8 = "";
+            var allocated_base_url = false;
+            if (self.args.base_url) |base| {
+                base_url = base;
+            } else if (document.host) |host| {
+                // Construct base URL from Swagger host, basePath, and schemes
+                const scheme = if (document.schemes != null and document.schemes.?.len > 0) document.schemes.?[0] else "https";
+                const base_path = document.basePath orelse "";
+                base_url = try std.fmt.allocPrint(self.allocator, "{s}://{s}{s}", .{ scheme, host, base_path });
+                allocated_base_url = true;
+            }
+            defer if (allocated_base_url) self.allocator.free(base_url);
+
+            const path = if (base_url.len > 0) try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ base_url, path_key }) else path_key;
+            defer if (base_url.len > 0) self.allocator.free(path);
+
+            if (path_item.get) |op| {
+                try parts.append(try self.generateMethod(op, path, "GET"));
+            }
+
+            if (path_item.post) |op| {
+                try parts.append(try self.generateMethod(op, path, "POST"));
+            }
+
+            if (path_item.put) |op| {
+                try parts.append(try self.generateMethod(op, path, "PUT"));
+            }
+
+            if (path_item.delete) |op| {
+                try parts.append(try self.generateMethod(op, path, "DELETE"));
+            }
+
+            if (path_item.patch) |op| {
+                try parts.append(try self.generateMethod(op, path, "PATCH"));
+            }
+
+            if (path_item.head) |op| {
+                try parts.append(try self.generateMethod(op, path, "HEAD"));
+            }
+
+            if (path_item.options) |op| {
+                try parts.append(try self.generateMethod(op, path, "OPTIONS"));
+            }
+        }
+
+        return try std.mem.join(self.allocator, "", parts.items);
+    }
+
+    pub fn generateMethod(self: *ApiCodeGenerator, op: models.v2.Operation, path: []const u8, method: []const u8) ![]const u8 {
+        var parts = std.ArrayList([]const u8).init(self.allocator);
+        defer parts.deinit();
+
+        try parts.append(try generateMethodDocs(self.allocator, op));
+        try parts.append("pub fn ");
+        try parts.append(op.operationId orelse path);
+        try parts.append("(allocator: std.mem.Allocator");
+
+        var parameters = std.ArrayList([]const u8).init(self.allocator);
+        defer parameters.deinit();
+
+        var has_body_param = false;
+
+        if (op.parameters) |params| {
+            if (params.len > 0) try parts.append(", ");
+            var first = true;
+            for (params) |param| {
+                if (!first) try parts.append(", ");
+                first = false;
+
+                try parameters.append(param.name);
+                try parts.append(param.name);
+                try parts.append(": ");
+
+                // Determine parameter type based on Swagger v2.0 parameter
+                var data_type: []const u8 = "[]const u8"; // Default to string
+
+                if (param.in == .body) {
+                    has_body_param = true;
+                    data_type = "[]const u8"; // For body parameters, assume JSON string
+                } else if (param.type) |param_type| {
+                    data_type = try converter.getDataType(@tagName(param_type));
+                }
+
+                try parts.append(data_type);
+            }
+        }
+
+        try parts.append(") !void {\n");
+
+        const method_body = try generateImplementation(self.allocator, path, method, parameters.items, has_body_param);
+        try parts.append(method_body);
+
+        try parts.append("}\n\n");
+
+        return try std.mem.join(self.allocator, "", parts.items);
+    }
+
+    fn extractTypeFromReference(self: *ApiCodeGenerator, ref: []const u8) ?[]const u8 {
+        _ = self;
+        // Extract type name from $ref like "#/definitions/Pet" -> "Pet"
+        const prefix = "#/definitions/";
+        if (std.mem.startsWith(u8, ref, prefix)) {
+            return ref[prefix.len..];
+        }
+        return null;
+    }
+};
+
+fn generateMethodDocs(allocator: std.mem.Allocator, op: models.v2.Operation) ![]const u8 {
+    var parts = std.ArrayList([]const u8).init(allocator);
+    defer parts.deinit();
+
+    if (op.summary) |summary| {
+        try parts.append("/// ");
+        try parts.append(summary);
+        try parts.append("\n");
+    }
+
+    if (op.description) |description| {
+        try parts.append("/// ");
+        try parts.append(description);
+        try parts.append("\n");
+    }
+
+    return try std.mem.join(allocator, "", parts.items);
+}
+
+fn generateImplementation(allocator: std.mem.Allocator, path: []const u8, method: []const u8, parameters: [][]const u8, has_request_body: bool) ![]const u8 {
+    var parts = std.ArrayList([]const u8).init(allocator);
+    defer parts.deinit();
+
+    try parts.append("    var client = std.http.Client.init(allocator);\n");
+    try parts.append("    defer client.deinit();\n\n");
+
+    if (parameters.len > 0) {
+        var new_path = path;
+        for (parameters) |param| {
+            // Replace path parameters (assuming they're in curly braces like {id})
+            const param_placeholder = try std.fmt.allocPrint(allocator, "{{{s}}}", .{param});
+            defer allocator.free(param_placeholder);
+
+            const size = std.mem.replacementSize(u8, new_path, param_placeholder, "{s}");
+            if (size != new_path.len) {
+                const output = try allocator.alloc(u8, size);
+                _ = std.mem.replace(u8, new_path, param_placeholder, "{s}", output);
+                new_path = output;
+            }
+        }
+
+        try parts.append("    const url = try std.fmt.allocPrint(allocator, \"");
+        try parts.append(new_path);
+        try parts.append("\"");
+
+        // Add parameter formatting
+        if (parameters.len > 0) {
+            try parts.append(", .{");
+            for (parameters, 0..) |param, i| {
+                if (i > 0) try parts.append(", ");
+                try parts.append(param);
+            }
+            try parts.append("}");
+        }
+        try parts.append(");\n");
+        try parts.append("    defer allocator.free(url);\n\n");
+    } else {
+        try parts.append("    const url = \"");
+        try parts.append(path);
+        try parts.append("\";\n\n");
+    }
+
+    try parts.append("    var uri = try std.Uri.parse(url);\n");
+    try parts.append("    var request = try client.request(std.http.Method.");
+    try parts.append(method);
+    try parts.append(", uri, .{}, .{});\n");
+    try parts.append("    defer request.deinit();\n\n");
+
+    if (has_request_body) {
+        try parts.append("    request.headers.content_type = std.http.Header.ContentType{ .override = \"application/json\" };\n");
+        try parts.append("    request.headers.content_length = requestBody.len;\n");
+        try parts.append("    try request.send(.{});\n");
+        try parts.append("    try request.writer().writeAll(requestBody);\n");
+    } else {
+        try parts.append("    try request.send(.{});\n");
+    }
+
+    try parts.append("    try request.finish();\n");
+    try parts.append("    try request.wait();\n\n");
+    try parts.append("    // Handle response\n");
+    try parts.append("    // TODO: Process response based on status code and content\n");
+
+    return try std.mem.join(allocator, "", parts.items);
+}

--- a/src/generators/v2.0/modelgenerator.zig
+++ b/src/generators/v2.0/modelgenerator.zig
@@ -1,1 +1,90 @@
-// TODO: Implement model code generator for SwaggerDocument
+const std = @import("std");
+const models = @import("../../models.zig");
+const cli = @import("../../cli.zig");
+const detector = @import("../../detector.zig");
+const converter = @import("../converter.zig");
+
+const default_output_file: []const u8 = "generated.zig";
+
+pub const ModelCodeGenerator = struct {
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator) ModelCodeGenerator {
+        return ModelCodeGenerator{
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *ModelCodeGenerator) void {
+        _ = self;
+    }
+
+    pub fn generate(self: *ModelCodeGenerator, document: models.SwaggerDocument) ![]const u8 {
+        var parts = std.ArrayList([]const u8).init(self.allocator);
+        defer parts.deinit();
+
+        try parts.append("///////////////////////////////////////////\n");
+        try parts.append("// Generated Zig structures from Swagger v2.0\n");
+        try parts.append("///////////////////////////////////////////\n\n");
+
+        if (document.definitions) |definitions| {
+            try self.generateSchemas(&parts, definitions);
+        }
+
+        return try std.mem.join(self.allocator, "", parts.items);
+    }
+
+    fn generateSchemas(self: *ModelCodeGenerator, parts: *std.ArrayList([]const u8), schemas: std.StringHashMap(models.v2.Schema)) !void {
+        var iterator = schemas.iterator();
+        while (iterator.next()) |entry| {
+            const schema_name = entry.key_ptr.*;
+            const schema = entry.value_ptr.*;
+            try self.generateSchema(parts, schema_name, schema);
+        }
+    }
+
+    fn generateSchema(self: *ModelCodeGenerator, parts: *std.ArrayList([]const u8), name: []const u8, schema: models.v2.Schema) !void {
+        try parts.append(try std.fmt.allocPrint(self.allocator, "pub const {s} = struct {{\n", .{name}));
+
+        if (schema.properties) |properties| {
+            var property_iterator = properties.iterator();
+            while (property_iterator.next()) |property| {
+                const field_name = property.key_ptr.*;
+                const field_schema = property.value_ptr.*;
+                try self.generateField(parts, field_name, field_schema, schema.required);
+            }
+        }
+
+        try parts.append("};\n\n");
+    }
+
+    fn generateField(self: *ModelCodeGenerator, parts: *std.ArrayList([]const u8), field_name: []const u8, field_schema: models.v2.Schema, required_fields: ?[]const []const u8) !void {
+        const name = try self.allocator.dupe(u8, field_name);
+
+        const is_required = if (required_fields) |req_fields| blk: {
+            for (req_fields) |req_field| {
+                if (std.mem.eql(u8, req_field, field_name)) {
+                    break :blk true;
+                }
+            }
+            break :blk false;
+        } else false;
+
+        // Determine the Zig type based on the schema type
+        var data_type: []const u8 = "[]const u8"; // Default to string
+
+        if (field_schema.type) |schema_type| {
+            data_type = try converter.getDataType(schema_type);
+        } else if (field_schema.ref) |_| {
+            // For $ref, we'll use the referenced type name
+            // For now, default to string
+            data_type = "[]const u8";
+        }
+
+        if (is_required) {
+            try parts.append(try std.fmt.allocPrint(self.allocator, "    {s}: {s},\n", .{ name, data_type }));
+        } else {
+            try parts.append(try std.fmt.allocPrint(self.allocator, "    {s}: ?{s} = null,\n", .{ name, data_type }));
+        }
+    }
+};


### PR DESCRIPTION
Introduce support for generating API and model code from Swagger v2.0 and OpenAPI v3.0 specifications. Update build commands to handle both versions and ensure generated files are properly managed. Adjust .gitignore to exclude unnecessary files.