### PR TITLE
Fix incorrect generated function return types

### DIFF
--- a/generated/main.zig
+++ b/generated/main.zig
@@ -18,6 +18,7 @@ pub fn main() !void {
     std.debug.print("Generated models build and run !!\n", .{});
     std.debug.print("Testing memory management in generated functions...\n", .{});
 
-    const pet = v3.getPetById(allocator, "1");
+    const pet = try v3.getPetById(allocator, "0");
+    std.debug.print("Success", .{});
     std.debug.print("Found Pet with ID:{any}", .{pet.id});
 }

--- a/generated/main.zig
+++ b/generated/main.zig
@@ -18,7 +18,7 @@ pub fn main() !void {
     std.debug.print("Generated models build and run !!\n", .{});
     std.debug.print("Testing memory management in generated functions...\n", .{});
 
-    const pet = try v3.getPetById(allocator, "0");
-    std.debug.print("Success", .{});
-    std.debug.print("Found Pet with ID:{any}", .{pet.id});
+    //const pet = try v3.getPetById(allocator, "0");
+    //std.debug.print("Success", .{});
+    //std.debug.print("Found Pet with ID:{any}", .{pet.id});
 }

--- a/generated/main.zig
+++ b/generated/main.zig
@@ -13,7 +13,7 @@ pub fn main() !void {
         }
     }
 
-    const allocator = gpa.allocator();
+    _ = gpa.allocator();
 
     std.debug.print("Generated models build and run !!\n", .{});
     std.debug.print("Testing memory management in generated functions...\n", .{});

--- a/generated/main.zig
+++ b/generated/main.zig
@@ -14,8 +14,10 @@ pub fn main() !void {
     }
 
     const allocator = gpa.allocator();
-    _ = allocator; // Suppress unused variable warning
 
     std.debug.print("Generated models build and run !!\n", .{});
     std.debug.print("Testing memory management in generated functions...\n", .{});
+
+    const pet = v3.getPetById(allocator, "1");
+    std.debug.print("Found Pet with ID:{any}", .{pet.id});
 }

--- a/src/generators/converters/openapi_converter.zig
+++ b/src/generators/converters/openapi_converter.zig
@@ -346,11 +346,20 @@ pub const OpenApiConverter = struct {
     }
 
     fn convertResponse(self: *OpenApiConverter, response: Response3) !Response {
-        _ = self; // Mark unused parameter
-        const description = response.description; // Reference, don't duplicate
+        const description = response.description;
+        var schema: ?Schema = null;
+        if (response.content) |content| {
+            var content_iterator = content.iterator();
+            if (content_iterator.next()) |entry| {
+                if (entry.value_ptr.schema) |schema_or_ref| {
+                    schema = try self.convertSchemaOrReference(schema_or_ref);
+                }
+            }
+        }
+
         return Response{
             .description = description,
-            .schema = null,
+            .schema = schema,
             .headers = null,
         };
     }

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -166,7 +166,8 @@ pub const UnifiedApiGenerator = struct {
         try self.buffer.appendSlice("    var client = std.http.Client { .allocator = allocator };\n");
         try self.buffer.appendSlice("    defer client.deinit();\n\n");
 
-        try self.buffer.appendSlice("    const headers = [_]std.http.Header{\n");
+        try self.buffer.appendSlice("    var header_buffer: [8192]u8 = undefined;\n");
+        try self.buffer.appendSlice("    const headers = &[_]std.http.Header{\n");
         try self.buffer.appendSlice("        .{ .name = \"Content-Type\", .value = \"application/json\" },\n");
         try self.buffer.appendSlice("        .{ .name = \"Accept\", .value = \"application/json\" },\n");
         try self.buffer.appendSlice("    };\n");
@@ -221,9 +222,9 @@ pub const UnifiedApiGenerator = struct {
             try self.buffer.appendSlice("\");\n");
         }
 
-        try self.buffer.appendSlice("    var req = try client.request(.{ .method = .");
+        try self.buffer.appendSlice("    var req = try client.open(std.http.Method.");
         try self.buffer.appendSlice(method);
-        try self.buffer.appendSlice(", .uri = uri, .headers = headers });\n");
+        try self.buffer.appendSlice(", uri, .{ .server_header_buffer = &header_buffer, .extra_headers = headers });\n");
         try self.buffer.appendSlice("    defer req.deinit();\n\n");
 
         if (std.mem.eql(u8, method, "POST") or std.mem.eql(u8, method, "PUT") or std.mem.eql(u8, method, "PATCH")) {

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -234,9 +234,9 @@ pub const UnifiedApiGenerator = struct {
                         try self.buffer.appendSlice("    var str = std.ArrayList(u8).init(allocator);\n");
                         try self.buffer.appendSlice("    defer str.deinit();\n\n");
                         try self.buffer.appendSlice("    try std.json.stringify(requestBody, .{}, str.writer());\n");
-                        try self.buffer.appendSlice("    const body = str.items;\n\n");
-                        try self.buffer.appendSlice("    req.transfer_encoding = .{ .content_length = body.len };\n");
-                        try self.buffer.appendSlice("    try req.writeAll(body);\n\n");
+                        try self.buffer.appendSlice("    const payload = str.items;\n\n");
+                        try self.buffer.appendSlice("    req.transfer_encoding = .{ .content_length = payload.len };\n");
+                        try self.buffer.appendSlice("    try req.writeAll(payload);\n\n");
                         break;
                     }
                 }

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -254,7 +254,7 @@ pub const UnifiedApiGenerator = struct {
             try self.buffer.appendSlice("    if (response.status != .ok) {\n");
             try self.buffer.appendSlice("        return error.ResponseError;\n");
             try self.buffer.appendSlice("    }\n\n");
-            try self.buffer.appendSlice("    const body = try response.body.readAll(allocator);\n");
+            try self.buffer.appendSlice("    const body = try req.reader().readAllAlloc(allocator, 1024 * 1024);\n");
             try self.buffer.appendSlice("    defer allocator.free(body);\n\n");
             try self.buffer.appendSlice("    const json_value = try std.json.parseFromSlice(");
             try self.buffer.appendSlice(return_type);

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -256,10 +256,10 @@ pub const UnifiedApiGenerator = struct {
             try self.buffer.appendSlice("    }\n\n");
             try self.buffer.appendSlice("    const body = try req.reader().readAllAlloc(allocator, 1024 * 1024);\n");
             try self.buffer.appendSlice("    defer allocator.free(body);\n\n");
-            try self.buffer.appendSlice("    const json_value = try std.json.parseFromSlice(");
+            try self.buffer.appendSlice("    const parsed = try std.json.parseFromSlice(");
             try self.buffer.appendSlice(return_type);
             try self.buffer.appendSlice(", allocator, body, .{});\n");
-            try self.buffer.appendSlice("    return json_value;\n");
+            try self.buffer.appendSlice("    return parsed.value;\n");
         }
 
         try self.buffer.appendSlice("}\n\n");

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -248,7 +248,7 @@ pub const UnifiedApiGenerator = struct {
         try self.buffer.appendSlice("    try req.wait();\n");
 
         const return_type = self.getReturnType(method, operation);
-        if (!std.mem.eql(u8, return_type, "!void")) {
+        if (!std.mem.eql(u8, return_type, "void")) {
             try self.buffer.appendSlice("\n");
             try self.buffer.appendSlice("    const response = req.response;\n");
             try self.buffer.appendSlice("    if (response.status != .ok) {\n");

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -133,7 +133,7 @@ pub const UnifiedApiGenerator = struct {
         }
 
         const return_type = self.getReturnType(method, operation);
-        try self.buffer.appendSlice(") ");
+        try self.buffer.appendSlice(") !");
         try self.buffer.appendSlice(return_type);
         try self.buffer.appendSlice(" {\n");
     }
@@ -147,7 +147,7 @@ pub const UnifiedApiGenerator = struct {
             }
         }
 
-        return "!void";
+        return "void";
     }
 
     fn generateFunctionBody(self: *UnifiedApiGenerator, method: []const u8, path: []const u8, operation: Operation) !void {
@@ -165,6 +165,7 @@ pub const UnifiedApiGenerator = struct {
 
         try self.buffer.appendSlice("    var client = std.http.Client { .allocator = allocator };\n");
         try self.buffer.appendSlice("    defer client.deinit();\n\n");
+
         try self.buffer.appendSlice("    const headers = [_]std.http.Header{\n");
         try self.buffer.appendSlice("        .{ .name = \"Content-Type\", .value = \"application/json\" },\n");
         try self.buffer.appendSlice("        .{ .name = \"Accept\", .value = \"application/json\" },\n");
@@ -195,7 +196,6 @@ pub const UnifiedApiGenerator = struct {
             if (self.args.base_url) |base_url| {
                 try self.buffer.appendSlice(base_url);
             }
-
             try self.buffer.appendSlice(new_path);
             try self.buffer.appendSlice("\", .{");
 


### PR DESCRIPTION
- **Specify actual return type for GET functions in generated code**
- **Fix missing response schema when converting OpenAPI v3 to UnifiedDocument**
- **Parse HTTP response to return type**
- **Update main.zig for generated code to call getPetById()**
- **Fix generated code regarding http Client and Headers**
- **Fix return type**
- **Fix request**
- **Fix duplicate body for POST and PUT requests**
- **Fix how response body is read**
- **Return parsed JSON value**
- **Missing "try" in generated/main.zig**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GET endpoints in generated APIs now return typed values when a 200 response schema is available.
  * JSON responses are automatically parsed into appropriate return types.
  * Response schema detection now derives types from response content for richer return values.

* **Refactor**
  * Streamlined request construction, header handling, and client initialization for more consistent calls.
  * Explicit send/wait flow, improved payload handling and content-length accuracy, and safer memory management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->