### PR TITLE
Fix missing requestBody when converting OpenAPI v3 to Unified OpenAPI Document

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -64,7 +64,7 @@ pub fn build(b: *std.Build) void {
         "-o",
         "generated/generated_v2.zig",
         "--base-url",
-        "https://petstore.swagger.io/api/v2",
+        "https://petstore.swagger.io/v2",
     });
     const run_generate_v2_step = b.step("run-generate-v2", "Run the app with generate command");
     run_generate_v2_step.dependOn(&run_generate_v2_cmd.step);

--- a/generated/main.zig
+++ b/generated/main.zig
@@ -18,6 +18,9 @@ pub fn main() !void {
     std.debug.print("Generated models build and run !!\n", .{});
     std.debug.print("Testing memory management in generated functions...\n", .{});
 
-    const pet = try v3.getPetById(allocator, "1");
-    std.debug.print("Found Pet with ID:{any}\n\n", .{pet.id});
+    const pet3 = try v3.getPetById(allocator, "1");
+    std.debug.print("Found Pet v3 with ID:{any}\n\n", .{pet3.id});
+
+    const pet2 = try v2.getPetById(allocator, 1);
+    std.debug.print("Found Pet v2 with ID:{any}\n\n", .{pet2.id});
 }

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -186,8 +186,7 @@ pub const UnifiedApiGenerator = struct {
             for (parameters) |parameter| {
                 if (parameter.location != .path) continue;
                 const param = parameter.name;
-                const schemaType = parameter.type orelse .string; // Default to string if no type specified
-                const param_type = switch (schemaType) {
+                const param_type = switch (parameter.type orelse .string) {
                     .string => "s",
                     .integer => "d",
                     .number => "d",

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -186,10 +186,17 @@ pub const UnifiedApiGenerator = struct {
             for (parameters) |parameter| {
                 if (parameter.location != .path) continue;
                 const param = parameter.name;
-                const size = std.mem.replacementSize(u8, new_path, param, "s");
+                const schemaType = parameter.type orelse .string; // Default to string if no type specified
+                const param_type = switch (schemaType) {
+                    .string => "s",
+                    .integer => "d",
+                    .number => "d",
+                    else => "any",
+                };
+                const size = std.mem.replacementSize(u8, new_path, param, param_type);
                 const output = try self.allocator.alloc(u8, size);
                 try allocated_paths.append(output);
-                _ = std.mem.replace(u8, new_path, param, "s", output);
+                _ = std.mem.replace(u8, new_path, param, param_type, output);
                 new_path = output;
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for OpenAPI 3 request bodies in spec conversion, enabling endpoints with body payloads to be generated correctly.
- Bug Fixes
  - Improved path parameter substitution with type-aware placeholders, ensuring accurate URL construction for string, integer, and number parameters.
- Chores
  - Updated the base URL used for OpenAPI v2 generation in build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->