### PR TITLE
Update Zig version to 0.15.1 and fix related build issues

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -5,7 +5,7 @@ This directory contains the development container configuration for the openapi2
 ## What's Included
 
 ### Software
-- **Zig 0.14.1** - The Zig programming language compiler
+- **Zig 0.15.1** - The Zig programming language compiler
 - **ZLS (Zig Language Server)** - Language server for Zig with IntelliSense support
 - **Git** - Version control
 - **Build tools** - Essential build utilities
@@ -74,7 +74,7 @@ If the Zig Language Server isn't providing IntelliSense:
 3. Verify ZLS config at `~/.config/zls/zls.json`
 
 ### Zig Version Issues
-The container is configured for Zig 0.14.1. If you need a different version:
+The container is configured for Zig 0.15.1. If you need a different version:
 1. Modify `ZIG_VERSION` in `.devcontainer/setup.sh`
 2. Rebuild the container: Command Palette → "Dev Containers: Rebuild Container"
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/cpp",
   "features": {
     "ghcr.io/devcontainers-extra/features/zig:1": {
-      "version": "0.14.1"
+      "version": "0.15.1"
     }
   },
   "customizations": {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,31 +9,31 @@ This is a CLI tool written in Zig that generates type-safe Zig API client code f
 ## Working Effectively
 
 ### Prerequisites and Installation
-Install Zig 0.14.1 exactly (other versions will NOT work):
+Install Zig 0.15.1 exactly (other versions will NOT work):
 
 **Option 1: GitHub Codespaces (RECOMMENDED for development)**
 ```bash
 # Navigate to repository on GitHub → Code → Codespaces → Create codespace
-# Everything is pre-configured with Zig 0.14.1, takes 2-3 minutes to set up
+# Everything is pre-configured with Zig 0.15.1, takes 2-3 minutes to set up
 ```
 
 **Option 2: Dev Containers (local with Docker)**
 ```bash
 # Install VS Code + Dev Containers extension
 # Open project in VS Code → "Reopen in Container"
-# Uses .devcontainer/devcontainer.json with Zig 0.14.1
+# Uses .devcontainer/devcontainer.json with Zig 0.15.1
 ```
 
 **Option 3: Manual Installation**
 ```bash
-# Download Zig 0.14.1 from https://ziglang.org/download/0.14.1/
+# Download Zig 0.15.1 from https://ziglang.org/download/0.15.1/
 # Linux x86_64:
-wget https://ziglang.org/download/0.14.1/zig-linux-x86_64-0.14.1.tar.xz
-tar -xf zig-linux-x86_64-0.14.1.tar.xz
-export PATH="$PWD/zig-linux-x86_64-0.14.1:$PATH"
+wget https://ziglang.org/download/0.15.1/zig-linux-x86_64-0.15.1.tar.xz
+tar -xf zig-linux-x86_64-0.15.1.tar.xz
+export PATH="$PWD/zig-linux-x86_64-0.15.1:$PATH"
 
 # Verify installation
-zig version  # Must output "0.14.1"
+zig version  # Must output "0.15.1"
 ```
 
 ### Bootstrap, Build, and Test the Repository
@@ -362,9 +362,9 @@ generated/
 ## Troubleshooting
 
 ### Installation Issues
-- **"zig: command not found"**: Install Zig 0.14.1 exactly using methods above
-- **Wrong Zig version**: Uninstall other versions, install 0.14.1 specifically  
-- **Build failures**: Ensure you're using Zig 0.14.1, not 0.13.x or 0.15.x
+- **"zig: command not found"**: Install Zig 0.15.1 exactly using methods above
+- **Wrong Zig version**: Uninstall other versions, install 0.15.1 specifically  
+- **Build failures**: Ensure you're using Zig 0.15.1, not 0.13.x or 0.15.x
 - **Docker issues**: Use GitHub Codespaces or dev containers instead
 
 ### Build and Test Issues  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: christianhelle/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
 
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: christianhelle/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
 
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: christianhelle/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
 
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: christianhelle/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: ["*"]
 
 env:
-  ZIG_VERSION: "0.14.1"
+  ZIG_VERSION: "0.15.1"
 
 jobs:
   lint-and-format:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: christianhelle/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 env:
-  ZIG_VERSION: "0.14.1"
+  ZIG_VERSION: "0.15.1"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # openapi2zig
 
 [![CI](https://github.com/christianhelle/openapi2zig/actions/workflows/ci.yml/badge.svg)](https://github.com/christianhelle/openapi2zig/actions/workflows/ci.yml)
-[![Zig Version](https://img.shields.io/badge/zig-0.14.1-orange.svg)](https://ziglang.org/download/)
+[![Zig Version](https://img.shields.io/badge/zig-0.15.1-orange.svg)](https://ziglang.org/download/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A CLI tool and Zig library that generates type-safe API client code from OpenAPI specifications.
@@ -19,7 +19,7 @@ A CLI tool and Zig library that generates type-safe API client code from OpenAPI
 
 ## Prerequisites
 
-- [Zig](https://ziglang.org/download/) v0.14.1
+- [Zig](https://ziglang.org/download/) v0.15.1
 
 ## Development Environment
 

--- a/build.zig
+++ b/build.zig
@@ -14,22 +14,29 @@ pub fn build(b: *std.Build) void {
     openapi2zig_mod.addIncludePath(b.path("src"));
 
     // CLI executable
-    const exe = b.addExecutable(.{
-        .name = "openapi2zig",
+    const exe_root_module = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+    });
+    const exe = b.addExecutable(.{
+        .name = "openapi2zig",
+        .root_module = exe_root_module,
     });
     exe.step.dependOn(version_step);
     exe.root_module.addImport("openapi2zig", openapi2zig_mod);
     b.installArtifact(exe);
 
     // Static library for linking
-    const lib = b.addStaticLibrary(.{
-        .name = "openapi2zig",
+    const lib_root_module = b.createModule(.{
         .root_source_file = b.path("src/lib.zig"),
         .target = target,
         .optimize = optimize,
+    });
+    const lib = b.addLibrary(.{
+        .name = "openapi2zig",
+        .root_module = lib_root_module,
+        .linkage = .static,
     });
     lib.step.dependOn(version_step);
     b.installArtifact(lib);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,7 +28,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.1",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -91,7 +91,7 @@
               alt="CI Status"
             />
             <img
-              src="https://img.shields.io/badge/zig-0.14.1-orange.svg"
+              src="https://img.shields.io/badge/zig-0.15.1-orange.svg"
               alt="Zig Version"
             />
             <img
@@ -253,7 +253,7 @@ zig build</code></pre>
 
               <div class="codespaces-features">
                 <ul>
-                  <li>✅ Zig 0.14.1 pre-installed</li>
+                  <li>✅ Zig 0.15.1 pre-installed</li>
                   <li>✅ ZLS Language Server for IntelliSense</li>
                   <li>✅ VS Code extensions optimized for Zig</li>
                   <li>✅ Zero setup time - ready in 2-3 minutes</li>
@@ -329,7 +329,7 @@ zig build</code></pre>
               </p>
 
               <div class="manual-setup-note">
-                <strong>Prerequisites:</strong> Zig v0.14.1 or later
+                <strong>Prerequisites:</strong> Zig v0.15.1 or later
               </div>
             </div>
           </div>

--- a/examples/PACKAGE.md
+++ b/examples/PACKAGE.md
@@ -6,7 +6,7 @@ This document explains how to publish and use openapi2zig as a Zig package.
 
 ### Prerequisites
 
-1. Ensure you have Zig 0.14.1 installed
+1. Ensure you have Zig 0.15.1 installed
 2. All tests are passing: `zig build test`
 3. All builds work: `zig build -Doptimize=Debug`, `zig build -Doptimize=ReleaseFast`
 
@@ -98,7 +98,7 @@ From build.zig.zon `.paths`:
 
 ## Version Compatibility
 
-- **Zig Version**: Requires exactly Zig 0.14.1
+- **Zig Version**: Requires exactly Zig 0.15.1
 - **API Stability**: The library API is considered stable as of v1.0.0
 - **Semantic Versioning**: We follow semver for breaking changes
 
@@ -110,7 +110,7 @@ From build.zig.zon `.paths`:
    ```
    error: invalid build.zig.zon
    ```
-   Solution: Use exactly Zig 0.14.1
+   Solution: Use exactly Zig 0.15.1
 
 2. **Hash Mismatch**
    ```

--- a/generated/main.zig
+++ b/generated/main.zig
@@ -18,9 +18,15 @@ pub fn main() !void {
     std.debug.print("Generated models build and run !!\n", .{});
     std.debug.print("Testing memory management in generated functions...\n", .{});
 
-    const pet3 = try v3.getPetById(allocator, "1");
-    std.debug.print("Found Pet v3 with ID:{any}\n\n", .{pet3.id});
+    if (v3.getPetById(allocator, "1")) |pet3| {
+        std.debug.print("Found Pet v3 with ID:{any}\n\n", .{pet3.id});
+    } else |err| {
+        std.debug.print("Failed to get Pet v3: {any}\n", .{err});
+    }
 
-    const pet2 = try v2.getPetById(allocator, 1);
-    std.debug.print("Found Pet v2 with ID:{any}\n\n", .{pet2.id});
+    if (v2.getPetById(allocator, 1)) |pet2| {
+        std.debug.print("Found Pet v2 with ID:{any}\n\n", .{pet2.id});
+    } else |err| {
+        std.debug.print("Failed to get Pet v2: {any}\n", .{err});
+    }
 }

--- a/src/generators/converters/openapi_converter.zig
+++ b/src/generators/converters/openapi_converter.zig
@@ -260,21 +260,21 @@ pub const OpenApiConverter = struct {
         const description = operation.description;
         const operationId = operation.operationId;
 
-        var parameters_list = std.ArrayList(Parameter).init(self.allocator);
-        defer parameters_list.deinit();
+        var parameters_list = std.ArrayList(Parameter){};
+        defer parameters_list.deinit(self.allocator);
 
         if (operation.parameters) |params| {
             for (params) |*param_ref| {
-                try parameters_list.append(try self.convertParameterOrReference(param_ref));
+                try parameters_list.append(self.allocator, try self.convertParameterOrReference(param_ref));
             }
         }
 
         if (operation.requestBody) |*request_body_or_ref| {
             const request_body_param = try self.convertRequestBodyOrReference(request_body_or_ref);
-            try parameters_list.append(request_body_param);
+            try parameters_list.append(self.allocator, request_body_param);
         }
 
-        const parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice() else null;
+        const parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice(self.allocator) else null;
 
         var responses = std.StringHashMap(Response).init(self.allocator);
         if (operation.responses.default) |default_response| {

--- a/src/generators/v2.0/apigenerator.zig
+++ b/src/generators/v2.0/apigenerator.zig
@@ -21,10 +21,10 @@ pub const ApiCodeGenerator = struct {
     }
 
     pub fn generate(self: *ApiCodeGenerator, document: models.SwaggerDocument) ![]const u8 {
-        var parts = std.ArrayList([]const u8).init(self.allocator);
-        defer parts.deinit();
-        var methods = std.ArrayList([]const u8).init(self.allocator);
-        defer methods.deinit();
+        var parts = std.ArrayList([]const u8){};
+        defer parts.deinit(self.allocator);
+        var methods = std.ArrayList([]const u8){};
+        defer methods.deinit(self.allocator);
         try parts.append("///////////////////////////////////////////\n");
         try parts.append("// Generated Zig API client from Swagger v2.0\n");
         try parts.append("///////////////////////////////////////////\n\n");
@@ -79,16 +79,16 @@ pub const ApiCodeGenerator = struct {
     }
 
     pub fn generateMethod(self: *ApiCodeGenerator, op: models.v2.Operation, path: []const u8, method: []const u8) ![]const u8 {
-        var parts = std.ArrayList([]const u8).init(self.allocator);
-        defer parts.deinit();
+        var parts = std.ArrayList([]const u8){};
+        defer parts.deinit(self.allocator);
         const comments = try generateMethodDocs(self.allocator, op);
         defer self.allocator.free(comments);
         try parts.append(comments);
         try parts.append("pub fn ");
         try parts.append(op.operationId orelse path);
         try parts.append("(allocator: std.mem.Allocator");
-        var path_parameters = std.ArrayList([]const u8).init(self.allocator);
-        defer path_parameters.deinit();
+        var path_parameters = std.ArrayList([]const u8){};
+        defer path_parameters.deinit(self.allocator);
         var has_body_param = false;
         if (op.parameters) |params| {
             if (params.len > 0) try parts.append(", ");
@@ -135,8 +135,8 @@ fn extractTypeFromReference(ref: []const u8) ?[]const u8 {
 }
 
 fn generateMethodDocs(allocator: std.mem.Allocator, op: models.v2.Operation) ![]const u8 {
-    var parts = std.ArrayList([]const u8).init(allocator);
-    defer parts.deinit();
+    var parts = std.ArrayList([]const u8){};
+    defer parts.deinit(self.allocator);
     if (op.summary) |summary| {
         try parts.append("/// ");
         try parts.append(summary);
@@ -151,8 +151,8 @@ fn generateMethodDocs(allocator: std.mem.Allocator, op: models.v2.Operation) ![]
 }
 
 fn generateImplementation(allocator: std.mem.Allocator, path: []const u8, method: []const u8, op: models.v2.Operation, has_request_body: bool) ![]const u8 {
-    var parts = std.ArrayList([]const u8).init(allocator);
-    defer parts.deinit();
+    var parts = std.ArrayList([]const u8){};
+    defer parts.deinit(self.allocator);
     if (op.parameters) |parameters| {
         if (parameters.len > 0) {
             for (parameters) |parameter| {
@@ -170,8 +170,8 @@ fn generateImplementation(allocator: std.mem.Allocator, path: []const u8, method
     }
     try parts.append("    var client = std.http.Client { .allocator = allocator };\n");
     try parts.append("    defer client.deinit();\n\n");
-    var allocations = std.ArrayList([]const u8).init(allocator);
-    defer allocations.deinit();
+    var allocations = std.ArrayList([]const u8){};
+    defer allocations.deinit(self.allocator);
     if (op.parameters) |parameters| {
         if (parameters.len > 0) {
             var new_path = path;
@@ -222,7 +222,7 @@ fn generateImplementation(allocator: std.mem.Allocator, path: []const u8, method
     );
     if (has_request_body) {
         try parts.append("\n\n");
-        try parts.append("    var str = std.ArrayList(u8).init(allocator);\n");
+        try parts.append("    var str = std.ArrayList([]const u8){};\n");
         try parts.append("    defer str.deinit();\n\n");
         try parts.append("    try std.json.stringify(requestBody, .{}, str.writer());\n");
         try parts.append("    const body = try std.mem.join(allocator, \"\", str.items);\n");

--- a/src/generators/v2.0/modelgenerator.zig
+++ b/src/generators/v2.0/modelgenerator.zig
@@ -19,8 +19,8 @@ pub const ModelCodeGenerator = struct {
     }
 
     pub fn generate(self: *ModelCodeGenerator, document: models.SwaggerDocument) ![]const u8 {
-        var parts = std.ArrayList([]const u8).init(self.allocator);
-        defer parts.deinit();
+        var parts = std.ArrayList([]const u8){};
+        defer parts.deinit(self.allocator);
         try parts.append("///////////////////////////////////////////\n");
         try parts.append("// Generated Zig structures from Swagger v2.0\n");
         try parts.append("///////////////////////////////////////////\n\n");

--- a/src/generators/v3.0/apigenerator.zig
+++ b/src/generators/v3.0/apigenerator.zig
@@ -21,14 +21,14 @@ pub const ApiCodeGenerator = struct {
     }
 
     pub fn generate(self: *ApiCodeGenerator, document: models.OpenApiDocument) ![]const u8 {
-        var parts = std.ArrayList([]const u8).init(self.allocator);
-        defer parts.deinit();
+        var parts = std.ArrayList([]const u8){};
+        defer parts.deinit(self.allocator);
         try parts.append("///////////////////////////////////////////\n");
         try parts.append("// Generated Zig API client from OpenAPI\n");
         try parts.append("///////////////////////////////////////////\n\n");
         try parts.append("const std = @import(\"std\");\n\n");
-        var methods = std.ArrayList([]const u8).init(self.allocator);
-        defer methods.deinit();
+        var methods = std.ArrayList([]const u8){};
+        defer methods.deinit(self.allocator);
         var path_iterator = document.paths.path_items.iterator();
         while (path_iterator.next()) |entry| {
             const path_key = entry.key_ptr.*;
@@ -68,16 +68,16 @@ pub const ApiCodeGenerator = struct {
     }
 
     pub fn generateMethod(self: *ApiCodeGenerator, op: models.v3.Operation, path: []const u8, method: []const u8) ![]const u8 {
-        var parts = std.ArrayList([]const u8).init(self.allocator);
-        defer parts.deinit();
+        var parts = std.ArrayList([]const u8){};
+        defer parts.deinit(self.allocator);
         const docs = try generateMethodDocs(self.allocator, op);
         defer self.allocator.free(docs);
         try parts.append(docs);
         try parts.append("pub fn ");
         try parts.append(op.operationId orelse path);
         try parts.append("(allocator: std.mem.Allocator");
-        var parameters = std.ArrayList([]const u8).init(self.allocator);
-        defer parameters.deinit();
+        var parameters = std.ArrayList([]const u8){};
+        defer parameters.deinit(self.allocator);
         if (op.parameters) |params| {
             if (params.len > 0) try parts.append(", ");
             var first = true;
@@ -133,8 +133,8 @@ pub const ApiCodeGenerator = struct {
     }
 
     fn generateImplementation(allocator: std.mem.Allocator, path: []const u8, method: []const u8, op: models.v3.Operation) ![]const u8 {
-        var parts = std.ArrayList([]const u8).init(allocator);
-        defer parts.deinit();
+        var parts = std.ArrayList([]const u8){};
+        defer parts.deinit(self.allocator);
         const has_request_body = op.requestBody != null;
         if (op.parameters) |params| {
             if (params.len > 0) {
@@ -153,8 +153,8 @@ pub const ApiCodeGenerator = struct {
         }
         try parts.append("    var client = std.http.Client { .allocator = allocator };\n");
         try parts.append("    defer client.deinit();\n\n");
-        var allocations = std.ArrayList([]const u8).init(allocator);
-        defer allocations.deinit();
+        var allocations = std.ArrayList([]const u8){};
+        defer allocations.deinit(self.allocator);
         if (op.parameters) |params| {
             var new_path = path;
             for (params) |paramOrReference| {
@@ -205,7 +205,7 @@ pub const ApiCodeGenerator = struct {
         );
         if (has_request_body) {
             try parts.append("\n\n");
-            try parts.append("    var str = std.ArrayList(u8).init(allocator);\n");
+            try parts.append("    var str = std.ArrayList([]const u8){};\n");
             try parts.append("    defer str.deinit();\n\n");
             try parts.append("    try std.json.stringify(requestBody, .{}, str.writer());\n");
             try parts.append("    const body = try std.mem.join(allocator, \"\", str.items);\n");
@@ -238,8 +238,8 @@ pub const ApiCodeGenerator = struct {
     }
 
     fn generateMethodDocs(allocator: std.mem.Allocator, op: models.v3.Operation) ![]const u8 {
-        var parts = std.ArrayList([]const u8).init(allocator);
-        defer parts.deinit();
+        var parts = std.ArrayList([]const u8){};
+        defer parts.deinit(self.allocator);
         if (op.summary != null or op.description != null) {
             try parts.append("/////////////////");
             try parts.append("\n");

--- a/src/models/v2.0/models.zig
+++ b/src/models/v2.0/models.zig
@@ -1,10 +1,27 @@
 pub const SwaggerDocument = @import("swagger.zig").SwaggerDocument;
-pub usingnamespace @import("info.zig");
-pub usingnamespace @import("externaldocs.zig");
-pub usingnamespace @import("tag.zig");
-pub usingnamespace @import("schema.zig");
-pub usingnamespace @import("parameter.zig");
-pub usingnamespace @import("response.zig");
-pub usingnamespace @import("paths.zig");
-pub usingnamespace @import("operation.zig");
-pub usingnamespace @import("security.zig");
+
+// Export all types from the various modules
+pub const Info = @import("info.zig").Info;
+pub const License = @import("info.zig").License;
+pub const Contact = @import("info.zig").Contact;
+
+pub const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
+
+pub const Tag = @import("tag.zig").Tag;
+
+pub const Schema = @import("schema.zig").Schema;
+pub const Property = @import("schema.zig").Property;
+
+pub const Parameter = @import("parameter.zig").Parameter;
+
+pub const Response = @import("response.zig").Response;
+pub const Responses = @import("response.zig").Responses;
+
+pub const PathItem = @import("paths.zig").PathItem;
+pub const Paths = @import("paths.zig").Paths;
+
+pub const Operation = @import("operation.zig").Operation;
+
+pub const SecurityDefinition = @import("security.zig").SecurityDefinition;
+pub const SecurityDefinitions = @import("security.zig").SecurityDefinitions;
+pub const SecurityRequirement = @import("security.zig").SecurityRequirement;

--- a/src/models/v2.0/operation.zig
+++ b/src/models/v2.0/operation.zig
@@ -105,12 +105,12 @@ pub const Operation = struct {
         };
     }
     fn parseStringArray(allocator: std.mem.Allocator, value: json.Value) anyerror![][]const u8 {
-        var array_list = std.ArrayList([]const u8).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList([]const u8){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try allocator.dupe(u8, item.string));
+            try array_list.append(allocator, try allocator.dupe(u8, item.string));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
     fn parseResponses(allocator: std.mem.Allocator, value: json.Value) anyerror!std.StringHashMap(Response) {
         var map = std.StringHashMap(Response).init(allocator);
@@ -124,19 +124,19 @@ pub const Operation = struct {
         return map;
     }
     fn parseParameters(allocator: std.mem.Allocator, value: json.Value) anyerror![]Parameter {
-        var array_list = std.ArrayList(Parameter).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(Parameter){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try Parameter.parseFromJson(allocator, item));
+            try array_list.append(allocator, try Parameter.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
     fn parseSecurityRequirements(allocator: std.mem.Allocator, value: json.Value) anyerror![]SecurityRequirement {
-        var array_list = std.ArrayList(SecurityRequirement).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(SecurityRequirement){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try SecurityRequirement.parseFromJson(allocator, item));
+            try array_list.append(allocator, try SecurityRequirement.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 };

--- a/src/models/v2.0/parameter.zig
+++ b/src/models/v2.0/parameter.zig
@@ -128,12 +128,12 @@ pub const Items = struct {
         };
     }
     fn parseJsonValueArray(allocator: std.mem.Allocator, value: json.Value) anyerror![]json.Value {
-        var array_list = std.ArrayList(json.Value).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(json.Value){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(item);
+            try array_list.append(allocator, item);
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 };
 pub const Parameter = struct {
@@ -246,11 +246,11 @@ pub const Parameter = struct {
         }
     }
     fn parseJsonValueArray(allocator: std.mem.Allocator, value: json.Value) anyerror![]json.Value {
-        var array_list = std.ArrayList(json.Value).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(json.Value){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(item);
+            try array_list.append(allocator, item);
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 };

--- a/src/models/v2.0/paths.zig
+++ b/src/models/v2.0/paths.zig
@@ -70,12 +70,12 @@ pub const PathItem = struct {
         };
     }
     fn parseParameters(allocator: std.mem.Allocator, value: json.Value) anyerror![]Parameter {
-        var array_list = std.ArrayList(Parameter).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(Parameter){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try Parameter.parseFromJson(allocator, item));
+            try array_list.append(allocator, try Parameter.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 };
 

--- a/src/models/v2.0/schema.zig
+++ b/src/models/v2.0/schema.zig
@@ -204,12 +204,12 @@ pub const Schema = struct {
         };
     }
     fn parseStringArray(allocator: std.mem.Allocator, value: json.Value) anyerror![][]const u8 {
-        var array_list = std.ArrayList([]const u8).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList([]const u8){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try allocator.dupe(u8, item.string));
+            try array_list.append(allocator, try allocator.dupe(u8, item.string));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
     fn parseProperties(allocator: std.mem.Allocator, value: json.Value) anyerror!std.StringHashMap(Schema) {
         var map = std.StringHashMap(Schema).init(allocator);
@@ -223,19 +223,19 @@ pub const Schema = struct {
         return map;
     }
     fn parseSchemaArray(allocator: std.mem.Allocator, value: json.Value) anyerror![]Schema {
-        var array_list = std.ArrayList(Schema).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(Schema){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try Schema.parseFromJson(allocator, item));
+            try array_list.append(allocator, try Schema.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
     fn parseJsonValueArray(allocator: std.mem.Allocator, value: json.Value) anyerror![]json.Value {
-        var array_list = std.ArrayList(json.Value).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(json.Value){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(item);
+            try array_list.append(allocator, item);
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 };

--- a/src/models/v2.0/security.zig
+++ b/src/models/v2.0/security.zig
@@ -169,11 +169,11 @@ pub const SecurityRequirement = struct {
         };
     }
     fn parseStringArray(allocator: std.mem.Allocator, value: json.Value) anyerror![][]const u8 {
-        var array_list = std.ArrayList([]const u8).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList([]const u8){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try allocator.dupe(u8, item.string));
+            try array_list.append(allocator, try allocator.dupe(u8, item.string));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 };

--- a/src/models/v2.0/swagger.zig
+++ b/src/models/v2.0/swagger.zig
@@ -137,12 +137,12 @@ pub const SwaggerDocument = struct {
     }
 
     fn parseStringArray(allocator: std.mem.Allocator, value: json.Value) anyerror![][]const u8 {
-        var array_list = std.ArrayList([]const u8).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList([]const u8){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try allocator.dupe(u8, item.string));
+            try array_list.append(allocator, try allocator.dupe(u8, item.string));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 
     fn parseDefinitions(allocator: std.mem.Allocator, value: json.Value) anyerror!std.StringHashMap(Schema) {
@@ -182,20 +182,20 @@ pub const SwaggerDocument = struct {
     }
 
     fn parseSecurityRequirements(allocator: std.mem.Allocator, value: json.Value) anyerror![]SecurityRequirement {
-        var array_list = std.ArrayList(SecurityRequirement).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(SecurityRequirement){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try SecurityRequirement.parseFromJson(allocator, item));
+            try array_list.append(allocator, try SecurityRequirement.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 
     fn parseTags(allocator: std.mem.Allocator, value: json.Value) anyerror![]Tag {
-        var array_list = std.ArrayList(Tag).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(Tag){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try Tag.parseFromJson(allocator, item));
+            try array_list.append(allocator, try Tag.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 };

--- a/src/models/v3.0/components.zig
+++ b/src/models/v3.0/components.zig
@@ -23,15 +23,15 @@ pub const Components = struct {
     _allocated_strings: std.ArrayList([]const u8),
 
     pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Components {
-        var _allocated_strings = std.ArrayList([]const u8).init(allocator);
-        errdefer _allocated_strings.deinit();
+        var _allocated_strings = std.ArrayList([]const u8){};
+        errdefer _allocated_strings.deinit(allocator);
         const obj = value.object;
         var schemas_map = std.StringHashMap(SchemaOrReference).init(allocator);
         errdefer schemas_map.deinit();
         if (obj.get("schemas")) |schemas_val| {
             for (schemas_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try schemas_map.put(k, try SchemaOrReference.parseFromJson(allocator, schemas_val.object.get(key).?));
             }
         }
@@ -40,7 +40,7 @@ pub const Components = struct {
         if (obj.get("responses")) |responses_val| {
             for (responses_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try responses_map.put(k, try ResponseOrReference.parseFromJson(allocator, responses_val.object.get(key).?));
             }
         }
@@ -49,7 +49,7 @@ pub const Components = struct {
         if (obj.get("parameters")) |parameters_val| {
             for (parameters_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try parameters_map.put(k, try ParameterOrReference.parseFromJson(allocator, parameters_val.object.get(key).?));
             }
         }
@@ -58,7 +58,7 @@ pub const Components = struct {
         if (obj.get("examples")) |examples_val| {
             for (examples_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try examples_map.put(k, try ExampleOrReference.parseFromJson(allocator, examples_val.object.get(key).?));
             }
         }
@@ -67,7 +67,7 @@ pub const Components = struct {
         if (obj.get("requestBodies")) |request_bodies_val| {
             for (request_bodies_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try request_bodies_map.put(k, try RequestBodyOrReference.parseFromJson(allocator, request_bodies_val.object.get(key).?));
             }
         }
@@ -76,7 +76,7 @@ pub const Components = struct {
         if (obj.get("headers")) |headers_val| {
             for (headers_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try headers_map.put(k, try HeaderOrReference.parseFromJson(allocator, headers_val.object.get(key).?));
             }
         }
@@ -85,7 +85,7 @@ pub const Components = struct {
         if (obj.get("securitySchemes")) |security_schemes_val| {
             for (security_schemes_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try security_schemes_map.put(k, try SecuritySchemeOrReference.parseFromJson(allocator, security_schemes_val.object.get(key).?));
             }
         }
@@ -94,7 +94,7 @@ pub const Components = struct {
         if (obj.get("links")) |links_val| {
             for (links_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try links_map.put(k, try LinkOrReference.parseFromJson(allocator, links_val.object.get(key).?));
             }
         }
@@ -103,7 +103,7 @@ pub const Components = struct {
         if (obj.get("callbacks")) |callbacks_val| {
             for (callbacks_val.object.keys()) |key| {
                 const k = try allocator.dupe(u8, key);
-                try _allocated_strings.append(k);
+                try _allocated_strings.append(allocator, k);
                 try callbacks_map.put(k, try CallbackOrReference.parseFromJson(allocator, callbacks_val.object.get(key).?));
             }
         }
@@ -125,7 +125,7 @@ pub const Components = struct {
         for (self._allocated_strings.items) |str| {
             allocator.free(str);
         }
-        defer self._allocated_strings.deinit();
+        defer self._allocated_strings.deinit(allocator);
         if (self.schemas) |*schemas| {
             var iterator = schemas.iterator();
             while (iterator.next()) |entry| {

--- a/src/models/v3.0/models.zig
+++ b/src/models/v3.0/models.zig
@@ -1,17 +1,64 @@
 pub const OpenApiDocument = @import("openapi.zig").OpenApiDocument;
-pub usingnamespace @import("info.zig");
-pub usingnamespace @import("server.zig");
-pub usingnamespace @import("externaldocs.zig");
-pub usingnamespace @import("tag.zig");
-pub usingnamespace @import("reference.zig");
-pub usingnamespace @import("schema.zig");
-pub usingnamespace @import("media.zig");
-pub usingnamespace @import("parameter.zig");
-pub usingnamespace @import("requestbody.zig");
-pub usingnamespace @import("response.zig");
-pub usingnamespace @import("paths.zig");
-pub usingnamespace @import("operation.zig");
-pub usingnamespace @import("link.zig");
-pub usingnamespace @import("callback.zig");
-pub usingnamespace @import("security.zig");
-pub usingnamespace @import("components.zig");
+
+// Export all types from the various modules
+pub const Info = @import("info.zig").Info;
+pub const Contact = @import("info.zig").Contact;
+pub const License = @import("info.zig").License;
+
+pub const Server = @import("server.zig").Server;
+pub const ServerVariable = @import("server.zig").ServerVariable;
+
+pub const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
+
+pub const Tag = @import("tag.zig").Tag;
+
+pub const Reference = @import("reference.zig").Reference;
+
+pub const Schema = @import("schema.zig").Schema;
+pub const SchemaOrReference = @import("schema.zig").SchemaOrReference;
+pub const XML = @import("schema.zig").XML;
+pub const Discriminator = @import("schema.zig").Discriminator;
+pub const AdditionalProperties = @import("schema.zig").AdditionalProperties;
+
+pub const Example = @import("media.zig").Example;
+pub const ExampleOrReference = @import("media.zig").ExampleOrReference;
+pub const Header = @import("media.zig").Header;
+pub const HeaderOrReference = @import("media.zig").HeaderOrReference;
+pub const Encoding = @import("media.zig").Encoding;
+pub const MediaType = @import("media.zig").MediaType;
+
+pub const Parameter = @import("parameter.zig").Parameter;
+pub const ParameterOrReference = @import("parameter.zig").ParameterOrReference;
+
+pub const RequestBody = @import("requestbody.zig").RequestBody;
+pub const RequestBodyOrReference = @import("requestbody.zig").RequestBodyOrReference;
+
+pub const Response = @import("response.zig").Response;
+pub const ResponseOrReference = @import("response.zig").ResponseOrReference;
+pub const Responses = @import("response.zig").Responses;
+
+pub const PathItem = @import("paths.zig").PathItem;
+pub const Paths = @import("paths.zig").Paths;
+
+pub const Operation = @import("operation.zig").Operation;
+
+pub const Link = @import("link.zig").Link;
+pub const LinkOrReference = @import("link.zig").LinkOrReference;
+
+pub const Callback = @import("callback.zig").Callback;
+pub const CallbackOrReference = @import("callback.zig").CallbackOrReference;
+
+pub const SecurityRequirement = @import("security.zig").SecurityRequirement;
+pub const SecurityScheme = @import("security.zig").SecurityScheme;
+pub const SecuritySchemeOrReference = @import("security.zig").SecuritySchemeOrReference;
+pub const OAuthFlows = @import("security.zig").OAuthFlows;
+pub const ImplicitOAuthFlow = @import("security.zig").ImplicitOAuthFlow;
+pub const PasswordOAuthFlow = @import("security.zig").PasswordOAuthFlow;
+pub const ClientCredentialsFlow = @import("security.zig").ClientCredentialsFlow;
+pub const AuthorizationCodeOAuthFlow = @import("security.zig").AuthorizationCodeOAuthFlow;
+pub const APIKeySecurityScheme = @import("security.zig").APIKeySecurityScheme;
+pub const HTTPSecurityScheme = @import("security.zig").HTTPSecurityScheme;
+pub const OAuth2SecurityScheme = @import("security.zig").OAuth2SecurityScheme;
+pub const OpenIdConnectSecurityScheme = @import("security.zig").OpenIdConnectSecurityScheme;
+
+pub const Components = @import("components.zig").Components;

--- a/src/models/v3.0/openapi.zig
+++ b/src/models/v3.0/openapi.zig
@@ -71,27 +71,27 @@ pub const OpenApiDocument = struct {
         };
     }
     fn parseServers(allocator: std.mem.Allocator, value: json.Value) anyerror![]Server {
-        var array_list = std.ArrayList(Server).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(Server){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try Server.parseFromJson(allocator, item));
+            try array_list.append(allocator, try Server.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
     fn parseSecurityRequirements(allocator: std.mem.Allocator, value: json.Value) anyerror![]SecurityRequirement {
-        var array_list = std.ArrayList(SecurityRequirement).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(SecurityRequirement){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try SecurityRequirement.parseFromJson(allocator, item));
+            try array_list.append(allocator, try SecurityRequirement.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
     fn parseTags(allocator: std.mem.Allocator, value: json.Value) anyerror![]const Tag {
-        var array_list = std.ArrayList(Tag).init(allocator);
-        errdefer array_list.deinit();
+        var array_list = std.ArrayList(Tag){};
+        errdefer array_list.deinit(allocator);
         for (value.array.items) |item| {
-            try array_list.append(try Tag.parseFromJson(allocator, item));
+            try array_list.append(allocator, try Tag.parseFromJson(allocator, item));
         }
-        return array_list.toOwnedSlice();
+        return array_list.toOwnedSlice(allocator);
     }
 };

--- a/src/models/v3.0/operation.zig
+++ b/src/models/v3.0/operation.zig
@@ -24,18 +24,18 @@ pub const Operation = struct {
 
     pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Operation {
         const obj = value.object;
-        var tags_list = std.ArrayList([]const u8).init(allocator);
-        errdefer tags_list.deinit();
+        var tags_list = std.ArrayList([]const u8){};
+        errdefer tags_list.deinit(allocator);
         if (obj.get("tags")) |tags_val| {
             for (tags_val.array.items) |item| {
-                try tags_list.append(try allocator.dupe(u8, item.string));
+                try tags_list.append(allocator, try allocator.dupe(u8, item.string));
             }
         }
-        var parameters_list = std.ArrayList(ParameterOrReference).init(allocator);
-        errdefer parameters_list.deinit();
+        var parameters_list = std.ArrayList(ParameterOrReference){};
+        errdefer parameters_list.deinit(allocator);
         if (obj.get("parameters")) |params_val| {
             for (params_val.array.items) |item| {
-                try parameters_list.append(try ParameterOrReference.parseFromJson(allocator, item));
+                try parameters_list.append(allocator, try ParameterOrReference.parseFromJson(allocator, item));
             }
         }
         var callbacks_map = std.StringHashMap(CallbackOrReference).init(allocator);
@@ -45,33 +45,33 @@ pub const Operation = struct {
                 try callbacks_map.put(try allocator.dupe(u8, key), try CallbackOrReference.parseFromJson(allocator, callbacks_val.object.get(key).?));
             }
         }
-        var security_list = std.ArrayList(SecurityRequirement).init(allocator);
-        errdefer security_list.deinit();
+        var security_list = std.ArrayList(SecurityRequirement){};
+        errdefer security_list.deinit(allocator);
         if (obj.get("security")) |security_val| {
             for (security_val.array.items) |item| {
-                try security_list.append(try SecurityRequirement.parseFromJson(allocator, item));
+                try security_list.append(allocator, try SecurityRequirement.parseFromJson(allocator, item));
             }
         }
-        var servers_list = std.ArrayList(Server).init(allocator);
-        errdefer servers_list.deinit();
+        var servers_list = std.ArrayList(Server){};
+        errdefer servers_list.deinit(allocator);
         if (obj.get("servers")) |servers_val| {
             for (servers_val.array.items) |item| {
-                try servers_list.append(try Server.parseFromJson(allocator, item));
+                try servers_list.append(allocator, try Server.parseFromJson(allocator, item));
             }
         }
         return Operation{
             .responses = try Responses.parseFromJson(allocator, obj.get("responses").?),
-            .tags = if (tags_list.items.len > 0) try tags_list.toOwnedSlice() else null,
+            .tags = if (tags_list.items.len > 0) try tags_list.toOwnedSlice(allocator) else null,
             .summary = if (obj.get("summary")) |val| try allocator.dupe(u8, val.string) else null,
             .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
             .externalDocs = if (obj.get("externalDocs")) |val| try ExternalDocumentation.parseFromJson(allocator, val) else null,
             .operationId = if (obj.get("operationId")) |val| try allocator.dupe(u8, val.string) else null,
-            .parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice() else null,
+            .parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice(allocator) else null,
             .requestBody = if (obj.get("requestBody")) |val| try RequestBodyOrReference.parseFromJson(allocator, val) else null,
             .callbacks = if (callbacks_map.count() > 0) callbacks_map else null,
             .deprecated = if (obj.get("deprecated")) |val| val.bool else null,
-            .security = if (security_list.items.len > 0) try security_list.toOwnedSlice() else null,
-            .servers = if (servers_list.items.len > 0) try servers_list.toOwnedSlice() else null,
+            .security = if (security_list.items.len > 0) try security_list.toOwnedSlice(allocator) else null,
+            .servers = if (servers_list.items.len > 0) try servers_list.toOwnedSlice(allocator) else null,
         };
     }
 

--- a/src/models/v3.0/paths.zig
+++ b/src/models/v3.0/paths.zig
@@ -21,18 +21,18 @@ pub const PathItem = struct {
 
     pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!PathItem {
         const obj = value.object;
-        var parameters_list = std.ArrayList(ParameterOrReference).init(allocator);
-        errdefer parameters_list.deinit();
+        var parameters_list = std.ArrayList(ParameterOrReference){};
+        errdefer parameters_list.deinit(allocator);
         if (obj.get("parameters")) |params_val| {
             for (params_val.array.items) |item| {
-                try parameters_list.append(try ParameterOrReference.parseFromJson(allocator, item));
+                try parameters_list.append(allocator, try ParameterOrReference.parseFromJson(allocator, item));
             }
         }
-        var servers_list = std.ArrayList(Server).init(allocator);
-        errdefer servers_list.deinit();
+        var servers_list = std.ArrayList(Server){};
+        errdefer servers_list.deinit(allocator);
         if (obj.get("servers")) |servers_val| {
             for (servers_val.array.items) |item| {
-                try servers_list.append(try Server.parseFromJson(allocator, item));
+                try servers_list.append(allocator, try Server.parseFromJson(allocator, item));
             }
         }
         return PathItem{
@@ -47,8 +47,8 @@ pub const PathItem = struct {
             .head = if (obj.get("head")) |val| try Operation.parseFromJson(allocator, val) else null,
             .patch = if (obj.get("patch")) |val| try Operation.parseFromJson(allocator, val) else null,
             .trace = if (obj.get("trace")) |val| try Operation.parseFromJson(allocator, val) else null,
-            .servers = if (servers_list.items.len > 0) try servers_list.toOwnedSlice() else null,
-            .parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice() else null,
+            .servers = if (servers_list.items.len > 0) try servers_list.toOwnedSlice(allocator) else null,
+            .parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice(allocator) else null,
         };
     }
 

--- a/src/models/v3.0/schema.zig
+++ b/src/models/v3.0/schema.zig
@@ -138,39 +138,39 @@ pub const Schema = struct {
 
     pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Schema {
         const obj = value.object;
-        var required_list = std.ArrayList([]const u8).init(allocator);
-        errdefer required_list.deinit();
+        var required_list = std.ArrayList([]const u8){};
+        errdefer required_list.deinit(allocator);
         if (obj.get("required")) |req_val| {
             for (req_val.array.items) |item| {
-                try required_list.append(try allocator.dupe(u8, item.string));
+                try required_list.append(allocator, try allocator.dupe(u8, item.string));
             }
         }
-        var enum_list = std.ArrayList(json.Value).init(allocator);
-        errdefer enum_list.deinit();
+        var enum_list = std.ArrayList(json.Value){};
+        errdefer enum_list.deinit(allocator);
         if (obj.get("enum")) |enum_val| {
             for (enum_val.array.items) |item| {
-                try enum_list.append(item);
+                try enum_list.append(allocator, item);
             }
         }
-        var all_of_list = std.ArrayList(SchemaOrReference).init(allocator);
-        errdefer all_of_list.deinit();
+        var all_of_list = std.ArrayList(SchemaOrReference){};
+        errdefer all_of_list.deinit(allocator);
         if (obj.get("allOf")) |all_of_val| {
             for (all_of_val.array.items) |item| {
-                try all_of_list.append(try SchemaOrReference.parseFromJson(allocator, item));
+                try all_of_list.append(allocator, try SchemaOrReference.parseFromJson(allocator, item));
             }
         }
-        var one_of_list = std.ArrayList(SchemaOrReference).init(allocator);
-        errdefer one_of_list.deinit();
+        var one_of_list = std.ArrayList(SchemaOrReference){};
+        errdefer one_of_list.deinit(allocator);
         if (obj.get("oneOf")) |one_of_val| {
             for (one_of_val.array.items) |item| {
-                try one_of_list.append(try SchemaOrReference.parseFromJson(allocator, item));
+                try one_of_list.append(allocator, try SchemaOrReference.parseFromJson(allocator, item));
             }
         }
-        var any_of_list = std.ArrayList(SchemaOrReference).init(allocator);
-        errdefer any_of_list.deinit();
+        var any_of_list = std.ArrayList(SchemaOrReference){};
+        errdefer any_of_list.deinit(allocator);
         if (obj.get("anyOf")) |any_of_val| {
             for (any_of_val.array.items) |item| {
-                try any_of_list.append(try SchemaOrReference.parseFromJson(allocator, item));
+                try any_of_list.append(allocator, try SchemaOrReference.parseFromJson(allocator, item));
             }
         }
         var properties_map = std.StringHashMap(SchemaOrReference).init(allocator);
@@ -195,13 +195,13 @@ pub const Schema = struct {
             .uniqueItems = if (obj.get("uniqueItems")) |val| val.bool else null,
             .maxProperties = if (obj.get("maxProperties")) |val| val.integer else null,
             .minProperties = if (obj.get("minProperties")) |val| val.integer else null,
-            .required = if (required_list.items.len > 0) try required_list.toOwnedSlice() else null,
-            .enum_values = if (enum_list.items.len > 0) try enum_list.toOwnedSlice() else null,
+            .required = if (required_list.items.len > 0) try required_list.toOwnedSlice(allocator) else null,
+            .enum_values = if (enum_list.items.len > 0) try enum_list.toOwnedSlice(allocator) else null,
             .type = if (obj.get("type")) |val| try allocator.dupe(u8, val.string) else null,
             .not = if (obj.get("not")) |val| try SchemaOrReference.parseFromJson(allocator, val) else null,
-            .allOf = if (all_of_list.items.len > 0) try all_of_list.toOwnedSlice() else null,
-            .oneOf = if (one_of_list.items.len > 0) try one_of_list.toOwnedSlice() else null,
-            .anyOf = if (any_of_list.items.len > 0) try any_of_list.toOwnedSlice() else null,
+            .allOf = if (all_of_list.items.len > 0) try all_of_list.toOwnedSlice(allocator) else null,
+            .oneOf = if (one_of_list.items.len > 0) try one_of_list.toOwnedSlice(allocator) else null,
+            .anyOf = if (any_of_list.items.len > 0) try any_of_list.toOwnedSlice(allocator) else null,
             .items = if (obj.get("items")) |val| try SchemaOrReference.parseFromJson(allocator, val) else null,
             .properties = if (properties_map.count() > 0) properties_map else null,
             .additionalProperties = if (obj.get("additionalProperties")) |val| try AdditionalProperties.parseFromJson(allocator, val) else null,

--- a/src/models/v3.0/security.zig
+++ b/src/models/v3.0/security.zig
@@ -9,12 +9,12 @@ pub const SecurityRequirement = struct {
         errdefer schemes_map.deinit();
         const obj = value.object;
         for (obj.keys()) |key| {
-            var scopes_list = std.ArrayList([]const u8).init(allocator);
-            errdefer scopes_list.deinit();
+            var scopes_list = std.ArrayList([]const u8){};
+            errdefer scopes_list.deinit(allocator);
             for (obj.get(key).?.array.items) |item| {
-                try scopes_list.append(try allocator.dupe(u8, item.string));
+                try scopes_list.append(allocator, try allocator.dupe(u8, item.string));
             }
-            try schemes_map.put(try allocator.dupe(u8, key), try scopes_list.toOwnedSlice());
+            try schemes_map.put(try allocator.dupe(u8, key), try scopes_list.toOwnedSlice(allocator));
         }
         return SecurityRequirement{ .schemes = schemes_map };
     }

--- a/src/models/v3.0/server.zig
+++ b/src/models/v3.0/server.zig
@@ -8,18 +8,18 @@ pub const ServerVariable = struct {
 
     pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!ServerVariable {
         const obj = value.object;
-        var enum_list = std.ArrayList([]const u8).init(allocator);
-        errdefer enum_list.deinit();
+        var enum_list = std.ArrayList([]const u8){};
+        errdefer enum_list.deinit(allocator);
 
         if (obj.get("enum")) |enum_val| {
             for (enum_val.array.items) |item| {
-                try enum_list.append(try allocator.dupe(u8, item.string));
+                try enum_list.append(allocator, try allocator.dupe(u8, item.string));
             }
         }
 
         return ServerVariable{
             .default = try allocator.dupe(u8, obj.get("default").?.string),
-            .enum_values = if (enum_list.items.len > 0) try enum_list.toOwnedSlice() else null,
+            .enum_values = if (enum_list.items.len > 0) try enum_list.toOwnedSlice(allocator) else null,
             .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
         };
     }


### PR DESCRIPTION
Address build errors following the Zig 0.15.1 update and update all relevant API usages, documentation, and workflows to reflect the new version. Ensure compatibility with the updated allocator requirements in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Zig toolchain to 0.15.1 across CI, devcontainer, release workflows, and project manifest.

* **Documentation**
  * Updated README, docs, site content, and setup/troubleshooting instructions to reference Zig 0.15.1.

* **Refactor**
  * Internal memory handling migrated to allocator-aware patterns for consistent allocation/deallocation.
  * Build configuration updated to newer Zig build APIs.
  * Public model exports flattened to explicit named types (may require updating imports).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->