### PR TITLE
Add OpenAPI 3.2 specification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A CLI tool and Zig library that generates type-safe API client code from OpenAPI
 
 ## Features
 
-- Parse OpenAPI v2.0 and v3.0 specifications (JSON format)
+- Parse OpenAPI v2.0, v3.0, and v3.2 specifications (JSON format)
 - Generate type-safe Zig client code
 - Support for complex OpenAPI schemas and operations
 - Cross-platform support (Linux, macOS, Windows)
@@ -272,12 +272,13 @@ pub fn main() !void {
 #### Version Detection
 
 - `detectVersion(allocator, json_content)` - Detect OpenAPI/Swagger version
-- `ApiVersion` - Enum representing supported API versions (.v2_0, .v3_0, .v3_1, .Unsupported)
+- `ApiVersion` - Enum representing supported API versions (.v2_0, .v3_0, .v3_1, .v3_2, .Unsupported)
 
 #### Parsing Functions
 
 - `parseToUnified(allocator, json_content)` - Parse any supported version to unified representation
 - `parseOpenApi(allocator, json_content)` - Parse OpenAPI v3.0 specifically
+- `parseOpenApi32(allocator, json_content)` - Parse OpenAPI v3.2 specifically
 - `parseSwagger(allocator, json_content)` - Parse Swagger v2.0 specifically
 
 #### Code Generation
@@ -289,12 +290,14 @@ pub fn main() !void {
 #### Conversion Functions
 
 - `convertOpenApiToUnified(allocator, openapi_doc)` - Convert OpenAPI v3.0 to unified format
+- `convertOpenApi32ToUnified(allocator, openapi_doc)` - Convert OpenAPI v3.2 to unified format
 - `convertSwaggerToUnified(allocator, swagger_doc)` - Convert Swagger v2.0 to unified format
 
 #### Data Types
 
 - `UnifiedDocument` - Common document representation for both OpenAPI and Swagger
 - `OpenApiDocument` - OpenAPI v3.0 specific document structure
+- `OpenApi32Document` - OpenAPI v3.2 specific document structure
 - `SwaggerDocument` - Swagger v2.0 specific document structure
 - `DocumentInfo`, `Schema`, `Operation`, etc. - Various OpenAPI components
 
@@ -435,7 +438,7 @@ This project follows standard Zig formatting. Use `zig fmt` to format your code 
 
 This project is in early development. Current capabilities include:
 
-- OpenAPI v2.0 and v3.0 specification parsing
+- OpenAPI v2.0, v3.0, and v3.2 specification parsing
 - Basic data model structures for OpenAPI components
 - Generate API client code using `std.http.Client`
 - Comprehensive test suite for parsing functionality

--- a/build.zig
+++ b/build.zig
@@ -76,9 +76,23 @@ pub fn build(b: *std.Build) void {
     const run_generate_v2_step = b.step("run-generate-v2", "Run the app with generate command");
     run_generate_v2_step.dependOn(&run_generate_v2_cmd.step);
 
+    const run_generate_v32_cmd = b.addRunArtifact(exe);
+    run_generate_v32_cmd.addArgs(&.{
+        "generate",
+        "-i",
+        "openapi/v3.2/petstore.json",
+        "-o",
+        "generated/generated_v32.zig",
+        "--base-url",
+        "https://petstore3.swagger.io/api/v3",
+    });
+    const run_generate_v32_step = b.step("run-generate-v32", "Run the app with generate command for OpenAPI v3.2");
+    run_generate_v32_step.dependOn(&run_generate_v32_cmd.step);
+
     const run_generate = b.step("run-generate", "Run the app with generate commands");
     run_generate.dependOn(&run_generate_v3_cmd.step);
     run_generate.dependOn(&run_generate_v2_cmd.step);
+    run_generate.dependOn(&run_generate_v32_cmd.step);
 
     const tests_mod = b.createModule(.{
         .root_source_file = b.path("src/tests.zig"),

--- a/generated/generated_v32.zig
+++ b/generated/generated_v32.zig
@@ -1,0 +1,373 @@
+const std = @import("std");
+
+///////////////////////////////////////////
+// Generated Zig structures from OpenAPI
+///////////////////////////////////////////
+
+pub const Category = struct {
+    id: ?i64 = null,
+    name: ?[]const u8 = null,
+};
+
+pub const Pet = struct {
+    status: ?[]const u8 = null,
+    tags: ?[]const std.json.Value = null,
+    category: ?Category = null,
+    id: ?i64 = null,
+    name: []const u8,
+    photoUrls: []const []const u8,
+};
+
+pub const User = struct {
+    password: ?[]const u8 = null,
+    userStatus: ?i64 = null,
+    username: ?[]const u8 = null,
+    email: ?[]const u8 = null,
+    firstName: ?[]const u8 = null,
+    id: ?i64 = null,
+    lastName: ?[]const u8 = null,
+    phone: ?[]const u8 = null,
+};
+
+pub const Tag = struct {
+    id: ?i64 = null,
+    name: ?[]const u8 = null,
+};
+
+pub const Order = struct {
+    status: ?[]const u8 = null,
+    petId: ?i64 = null,
+    complete: ?bool = null,
+    id: ?i64 = null,
+    quantity: ?i64 = null,
+    shipDate: ?[]const u8 = null,
+};
+
+pub const ApiResponse = struct {
+    type: ?[]const u8 = null,
+    message: ?[]const u8 = null,
+    code: ?i64 = null,
+};
+
+
+///////////////////////////////////////////
+// Generated Zig API client from OpenAPI
+///////////////////////////////////////////
+
+/////////////////
+// Summary:
+// Returns pet inventories by status
+//
+// Description:
+// Returns a map of status codes to quantities
+//
+pub fn getInventory(allocator: std.mem.Allocator) !std.json.Value {
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri = try std.Uri.parse("https://petstore3.swagger.io/api/v3/store/inventory");
+    var req = try client.request(std.http.Method.GET, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    try req.sendBodiless();
+
+    var response = try req.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        return error.ResponseError;
+    }
+
+    var reader_buffer: [100]u8 = undefined;
+    const body_reader = response.reader(&reader_buffer);
+    const body = try body_reader.readAlloc(allocator, response.head.content_length orelse 1024 * 1024 * 4);
+    defer allocator.free(body);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+
+    return parsed.value;
+}
+
+/////////////////
+// Summary:
+// Get user by user name
+//
+// Description:
+// 
+//
+pub fn getUserByName(allocator: std.mem.Allocator, username: []const u8) !User {
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri_str = try std.fmt.allocPrint(allocator, "https://petstore3.swagger.io/api/v3/user/{s}", .{username});
+    defer allocator.free(uri_str);
+    const uri = try std.Uri.parse(uri_str);
+    var req = try client.request(std.http.Method.GET, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    try req.sendBodiless();
+
+    var response = try req.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        return error.ResponseError;
+    }
+
+    var reader_buffer: [100]u8 = undefined;
+    const body_reader = response.reader(&reader_buffer);
+    const body = try body_reader.readAlloc(allocator, response.head.content_length orelse 1024 * 1024 * 4);
+    defer allocator.free(body);
+
+    const parsed = try std.json.parseFromSlice(User, allocator, body, .{});
+    defer parsed.deinit();
+
+    return parsed.value;
+}
+
+/////////////////
+// Summary:
+// Place an order for a pet
+//
+// Description:
+// Place a new order in the store
+//
+pub fn placeOrder(allocator: std.mem.Allocator, requestBody: Order) !void {
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri_str = try std.fmt.allocPrint(allocator, "https://petstore3.swagger.io/api/v3/store/order", .{});
+    defer allocator.free(uri_str);
+    const uri = try std.Uri.parse(uri_str);
+    var req = try client.request(std.http.Method.POST, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    var str = std.ArrayList(u8){};
+    defer str.deinit(allocator);
+
+    try std.json.stringify(requestBody, .{}, str.writer());
+    const payload = str.items;
+
+    req.transfer_encoding = .{ .content_length = payload.len };
+    try req.sendBodyComplete(payload);
+
+}
+
+/////////////////
+// Summary:
+// Create user
+//
+// Description:
+// This can only be done by the logged in user.
+//
+pub fn createUser(allocator: std.mem.Allocator, requestBody: User) !void {
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri_str = try std.fmt.allocPrint(allocator, "https://petstore3.swagger.io/api/v3/user", .{});
+    defer allocator.free(uri_str);
+    const uri = try std.Uri.parse(uri_str);
+    var req = try client.request(std.http.Method.POST, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    var str = std.ArrayList(u8){};
+    defer str.deinit(allocator);
+
+    try std.json.stringify(requestBody, .{}, str.writer());
+    const payload = str.items;
+
+    req.transfer_encoding = .{ .content_length = payload.len };
+    try req.sendBodyComplete(payload);
+
+}
+
+/////////////////
+// Summary:
+// Find pet by ID
+//
+// Description:
+// Returns a single pet
+//
+pub fn getPetById(allocator: std.mem.Allocator, petId: []const u8) !Pet {
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri_str = try std.fmt.allocPrint(allocator, "https://petstore3.swagger.io/api/v3/pet/{s}", .{petId});
+    defer allocator.free(uri_str);
+    const uri = try std.Uri.parse(uri_str);
+    var req = try client.request(std.http.Method.GET, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    try req.sendBodiless();
+
+    var response = try req.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        return error.ResponseError;
+    }
+
+    var reader_buffer: [100]u8 = undefined;
+    const body_reader = response.reader(&reader_buffer);
+    const body = try body_reader.readAlloc(allocator, response.head.content_length orelse 1024 * 1024 * 4);
+    defer allocator.free(body);
+
+    const parsed = try std.json.parseFromSlice(Pet, allocator, body, .{});
+    defer parsed.deinit();
+
+    return parsed.value;
+}
+
+/////////////////
+// Summary:
+// Deletes a pet
+//
+// Description:
+// 
+//
+pub fn deletePet(allocator: std.mem.Allocator, api_key: []const u8, petId: []const u8) !void {
+    _ = api_key;
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri_str = try std.fmt.allocPrint(allocator, "https://petstore3.swagger.io/api/v3/pet/{s}", .{petId, });
+    defer allocator.free(uri_str);
+    const uri = try std.Uri.parse(uri_str);
+    var req = try client.request(std.http.Method.DELETE, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    try req.sendBodiless();
+}
+
+/////////////////
+// Summary:
+// Add a new pet to the store
+//
+// Description:
+// Add a new pet to the store
+//
+pub fn addPet(allocator: std.mem.Allocator, requestBody: Pet) !void {
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri_str = try std.fmt.allocPrint(allocator, "https://petstore3.swagger.io/api/v3/pet", .{});
+    defer allocator.free(uri_str);
+    const uri = try std.Uri.parse(uri_str);
+    var req = try client.request(std.http.Method.POST, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    var str = std.ArrayList(u8){};
+    defer str.deinit(allocator);
+
+    try std.json.stringify(requestBody, .{}, str.writer());
+    const payload = str.items;
+
+    req.transfer_encoding = .{ .content_length = payload.len };
+    try req.sendBodyComplete(payload);
+
+}
+
+/////////////////
+// Summary:
+// Update an existing pet
+//
+// Description:
+// Update an existing pet by Id
+//
+pub fn updatePet(allocator: std.mem.Allocator, requestBody: Pet) !void {
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri_str = try std.fmt.allocPrint(allocator, "https://petstore3.swagger.io/api/v3/pet", .{});
+    defer allocator.free(uri_str);
+    const uri = try std.Uri.parse(uri_str);
+    var req = try client.request(std.http.Method.PUT, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    var str = std.ArrayList(u8){};
+    defer str.deinit(allocator);
+
+    try std.json.stringify(requestBody, .{}, str.writer());
+    const payload = str.items;
+
+    req.transfer_encoding = .{ .content_length = payload.len };
+    try req.sendBodyComplete(payload);
+
+}
+
+/////////////////
+// Summary:
+// Finds Pets by status
+//
+// Description:
+// Multiple status values can be provided with comma separated strings
+//
+pub fn findPetsByStatus(allocator: std.mem.Allocator, status: []const u8) ![]const u8 {
+    _ = status;
+    var client = std.http.Client { .allocator = allocator };
+    defer client.deinit();
+
+    const headers = &[_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Accept", .value = "application/json" },
+    };
+
+    const uri_str = try std.fmt.allocPrint(allocator, "https://petstore3.swagger.io/api/v3/pet/findByStatus", .{});
+    defer allocator.free(uri_str);
+    const uri = try std.Uri.parse(uri_str);
+    var req = try client.request(std.http.Method.GET, uri, .{ .extra_headers = headers });
+    defer req.deinit();
+
+    try req.sendBodiless();
+
+    var response = try req.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        return error.ResponseError;
+    }
+
+    var reader_buffer: [100]u8 = undefined;
+    const body_reader = response.reader(&reader_buffer);
+    const body = try body_reader.readAlloc(allocator, response.head.content_length orelse 1024 * 1024 * 4);
+    defer allocator.free(body);
+
+    const parsed = try std.json.parseFromSlice([]const u8, allocator, body, .{});
+    defer parsed.deinit();
+
+    return parsed.value;
+}
+

--- a/openapi/v3.2/petstore-expanded.json
+++ b/openapi/v3.2/petstore-expanded.json
@@ -1,0 +1,294 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Petstore - Expanded",
+    "summary": "An expanded petstore API with webhooks and type arrays",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.2 specification, including webhooks, type arrays for nullable, and SPDX license identifiers.",
+    "version": "2.0.0",
+    "contact": {
+      "name": "Swagger API Team",
+      "url": "http://swagger.io",
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "identifier": "Apache-2.0"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v2",
+      "description": "Production server"
+    },
+    {
+      "url": "https://petstore-staging.swagger.io/v2",
+      "description": "Staging server"
+    }
+  ],
+  "webhooks": {
+    "newPet": {
+      "post": {
+        "summary": "New pet available",
+        "description": "A webhook that is called when a new pet is added to the store",
+        "operationId": "newPetWebhook",
+        "requestBody": {
+          "description": "Information about a new pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Return a 200 status to indicate that the data was received successfully"
+          }
+        }
+      }
+    },
+    "petUpdated": {
+      "post": {
+        "summary": "Pet updated",
+        "description": "A webhook that is called when an existing pet is updated",
+        "operationId": "petUpdatedWebhook",
+        "requestBody": {
+          "description": "Information about the updated pet",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Return a 200 status to indicate that the data was received successfully"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "description": "Returns all pets from the system that the user has access to",
+        "operationId": "listPets",
+        "tags": ["pets"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["available", "pending", "sold"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of pets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "description": "Creates a new pet in the store",
+        "operationId": "createPet",
+        "tags": ["pets"],
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "description": "Returns a pet based on a single ID",
+        "operationId": "showPetById",
+        "tags": ["pets"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a specific pet",
+        "description": "Deletes a pet based on a single ID",
+        "operationId": "deletePet",
+        "tags": ["pets"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to delete",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": ["string", "null"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["available", "pending", "sold"]
+          }
+        }
+      },
+      "NewPet": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/v3.2/petstore.json
+++ b/openapi/v3.2/petstore.json
@@ -1,0 +1,549 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Swagger Petstore",
+    "summary": "A sample API that uses a petstore as an example",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.2 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+      "identifier": "Apache-2.0"
+    },
+    "version": "1.0.0"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "https://petstore3.swagger.io/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "put": {
+        "tags": ["pet"],
+        "summary": "Update an existing pet",
+        "description": "Update an existing pet by Id",
+        "operationId": "updatePet",
+        "requestBody": {
+          "description": "Update an existent pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "422": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "422": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "default": "available",
+              "enum": ["available", "pending", "sold"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "description": "Place a new order in the store",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "422": {
+            "description": "Validation exception"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "description": "Created user object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "petId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "enum": ["placed", "approved", "delivered"]
+          },
+          "complete": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "username": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "userStatus": {
+            "type": "integer",
+            "description": "User Status",
+            "format": "int32"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Pet": {
+        "required": ["name", "photoUrls"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "photoUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": ["available", "pending", "sold"]
+          }
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/src/detector.zig
+++ b/src/detector.zig
@@ -10,6 +10,7 @@ pub const OpenApiVersion = enum {
     v2_0,
     v3_0,
     v3_1,
+    v3_2,
 };
 
 pub fn getOpenApiVersionString(version: OpenApiVersion) []const u8 {
@@ -18,6 +19,7 @@ pub fn getOpenApiVersionString(version: OpenApiVersion) []const u8 {
         .v2_0 => "v2.0",
         .v3_0 => "v3.0",
         .v3_1 => "v3.1",
+        .v3_2 => "v3.2",
     };
 }
 
@@ -27,7 +29,9 @@ pub fn getOpenApiVersion(allocator: std.mem.Allocator, json: []const u8) !OpenAp
     const root = parsed.value;
 
     if (root.openapi) |version| {
-        if (std.mem.startsWith(u8, version, "3.1")) {
+        if (std.mem.startsWith(u8, version, "3.2")) {
+            return OpenApiVersion.v3_2;
+        } else if (std.mem.startsWith(u8, version, "3.1")) {
             return OpenApiVersion.v3_1;
         } else if (std.mem.startsWith(u8, version, "3.0")) {
             return OpenApiVersion.v3_0;

--- a/src/generators/converters/openapi32_converter.zig
+++ b/src/generators/converters/openapi32_converter.zig
@@ -1,0 +1,441 @@
+const std = @import("std");
+const UnifiedDocument = @import("../../models/common/document.zig").UnifiedDocument;
+const DocumentInfo = @import("../../models/common/document.zig").DocumentInfo;
+const ContactInfo = @import("../../models/common/document.zig").ContactInfo;
+const LicenseInfo = @import("../../models/common/document.zig").LicenseInfo;
+const ExternalDocumentation = @import("../../models/common/document.zig").ExternalDocumentation;
+const Tag = @import("../../models/common/document.zig").Tag;
+const Server = @import("../../models/common/document.zig").Server;
+const SecurityRequirement = @import("../../models/common/document.zig").SecurityRequirement;
+const Schema = @import("../../models/common/document.zig").Schema;
+const SchemaType = @import("../../models/common/document.zig").SchemaType;
+const Parameter = @import("../../models/common/document.zig").Parameter;
+const ParameterLocation = @import("../../models/common/document.zig").ParameterLocation;
+const Response = @import("../../models/common/document.zig").Response;
+const Operation = @import("../../models/common/document.zig").Operation;
+const PathItem = @import("../../models/common/document.zig").PathItem;
+const OpenApi32Document = @import("../../models/v3.2/openapi.zig").OpenApi32Document;
+const Info32 = @import("../../models/v3.2/info.zig").Info;
+const Contact32 = @import("../../models/v3.2/info.zig").Contact;
+const License32 = @import("../../models/v3.2/info.zig").License;
+const ExternalDocs32 = @import("../../models/v3.2/externaldocs.zig").ExternalDocumentation;
+const Tag32 = @import("../../models/v3.2/tag.zig").Tag;
+const Server32 = @import("../../models/v3.2/server.zig").Server;
+const SecurityRequirement32 = @import("../../models/v3.2/security.zig").SecurityRequirement;
+const Components32 = @import("../../models/v3.2/components.zig").Components;
+const SchemaOrReference32 = @import("../../models/v3.2/schema.zig").SchemaOrReference;
+const Schema32 = @import("../../models/v3.2/schema.zig").Schema;
+const ParameterOrReference32 = @import("../../models/v3.2/parameter.zig").ParameterOrReference;
+const Parameter32 = @import("../../models/v3.2/parameter.zig").Parameter;
+const ResponseOrReference32 = @import("../../models/v3.2/response.zig").ResponseOrReference;
+const Response32 = @import("../../models/v3.2/response.zig").Response;
+const RequestBodyOrReference32 = @import("../../models/v3.2/requestbody.zig").RequestBodyOrReference;
+const RequestBody32 = @import("../../models/v3.2/requestbody.zig").RequestBody;
+const Operation32 = @import("../../models/v3.2/operation.zig").Operation;
+const PathItem32 = @import("../../models/v3.2/paths.zig").PathItem;
+const Paths32 = @import("../../models/v3.2/paths.zig").Paths;
+
+pub const OpenApi32Converter = struct {
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator) OpenApi32Converter {
+        return OpenApi32Converter{ .allocator = allocator };
+    }
+
+    pub fn convert(self: *OpenApi32Converter, openapi: OpenApi32Document) !UnifiedDocument {
+        const version = openapi.openapi;
+        const info = self.convertInfo(openapi.info);
+        const paths = if (openapi.paths) |p| try self.convertPaths(p) else std.StringHashMap(PathItem).init(self.allocator);
+        const servers = if (openapi.servers) |servers_list| try self.convertServers(servers_list) else null;
+        const security = if (openapi.security) |security_list| try self.convertSecurityRequirements(security_list) else null;
+        const tags = if (openapi.tags) |tags_list| try self.convertTags(tags_list) else null;
+        const externalDocs = if (openapi.externalDocs) |ext_docs| try self.convertExternalDocs(ext_docs) else null;
+        const schemas = if (openapi.components) |components| try self.convertSchemas(components) else null;
+        return UnifiedDocument{
+            .version = version,
+            .info = info,
+            .paths = paths,
+            .servers = servers,
+            .security = security,
+            .tags = tags,
+            .externalDocs = externalDocs,
+            .schemas = schemas,
+            .parameters = null,
+            .responses = null,
+        };
+    }
+
+    fn convertInfo(self: *OpenApi32Converter, info: Info32) DocumentInfo {
+        _ = self;
+        const title = info.title;
+        const description = info.description;
+        const version = info.version;
+        const termsOfService = info.termsOfService;
+        const contact = if (info.contact) |contact_info| blk: {
+            const name = contact_info.name;
+            const url = contact_info.url;
+            const email = contact_info.email;
+            break :blk ContactInfo{ .name = name, .url = url, .email = email };
+        } else null;
+        const license = if (info.license) |license_info| blk: {
+            const name = license_info.name;
+            const url = license_info.url;
+            break :blk LicenseInfo{ .name = name, .url = url };
+        } else null;
+        return DocumentInfo{
+            .title = title,
+            .description = description,
+            .version = version,
+            .termsOfService = termsOfService,
+            .contact = contact,
+            .license = license,
+        };
+    }
+
+    fn convertServers(self: *OpenApi32Converter, servers: []Server32) ![]Server {
+        var converted_servers = try self.allocator.alloc(Server, servers.len);
+        for (servers, 0..) |server, i| {
+            const url = try self.allocator.dupe(u8, server.url);
+            const description = if (server.description) |desc| try self.allocator.dupe(u8, desc) else null;
+            converted_servers[i] = Server{
+                .url = url,
+                .description = description,
+                ._url_allocated = true,
+                ._description_allocated = description != null,
+            };
+        }
+        return converted_servers;
+    }
+
+    fn convertSecurityRequirements(self: *OpenApi32Converter, security: []const SecurityRequirement32) ![]SecurityRequirement {
+        var converted_security = try self.allocator.alloc(SecurityRequirement, security.len);
+        for (security, 0..) |sec_req, i| {
+            var schemes = std.StringHashMap([][]const u8).init(self.allocator);
+            var sec_iterator = sec_req.schemes.iterator();
+            while (sec_iterator.next()) |entry| {
+                const key = try self.allocator.dupe(u8, entry.key_ptr.*);
+                const scopes = try self.allocator.alloc([]const u8, entry.value_ptr.*.len);
+                for (entry.value_ptr.*, 0..) |scope, j| {
+                    scopes[j] = scope;
+                }
+                try schemes.put(key, scopes);
+            }
+            converted_security[i] = SecurityRequirement{ .schemes = schemes };
+        }
+        return converted_security;
+    }
+
+    fn convertTags(self: *OpenApi32Converter, tags: []const Tag32) ![]Tag {
+        var converted_tags = try self.allocator.alloc(Tag, tags.len);
+        for (tags, 0..) |tag, i| {
+            const name = tag.name;
+            const description = tag.description;
+            const externalDocs = if (tag.externalDocs) |ext_docs| try self.convertExternalDocs(ext_docs) else null;
+            converted_tags[i] = Tag{ .name = name, .description = description, .externalDocs = externalDocs };
+        }
+        return converted_tags;
+    }
+
+    fn convertExternalDocs(self: *OpenApi32Converter, externalDocs: ExternalDocs32) !ExternalDocumentation {
+        _ = self;
+        const url = externalDocs.url;
+        const description = externalDocs.description;
+        return ExternalDocumentation{ .url = url, .description = description };
+    }
+
+    fn convertSchemas(self: *OpenApi32Converter, components: Components32) !std.StringHashMap(Schema) {
+        var schemas = std.StringHashMap(Schema).init(self.allocator);
+        if (components.schemas) |schemas_map| {
+            var schema_iterator = schemas_map.iterator();
+            while (schema_iterator.next()) |entry| {
+                const key = try self.allocator.dupe(u8, entry.key_ptr.*);
+                const schema = try self.convertSchemaOrReference(entry.value_ptr.*);
+                try schemas.put(key, schema);
+            }
+        }
+        return schemas;
+    }
+
+    fn convertSchemaOrReference(self: *OpenApi32Converter, schemaOrRef: SchemaOrReference32) anyerror!Schema {
+        switch (schemaOrRef) {
+            .reference => |ref| {
+                const ref_str = ref.ref;
+                return Schema{ .type = .reference, .ref = ref_str };
+            },
+            .schema => |schema| {
+                return self.convertSchema(schema.*);
+            },
+        }
+    }
+
+    fn convertSchema(self: *OpenApi32Converter, schema: Schema32) anyerror!Schema {
+        // Handle type_array (e.g. ["string", "null"]) by using the first non-null type
+        const schema_type = blk: {
+            if (schema.type) |type_str| {
+                break :blk self.convertSchemaType(type_str);
+            }
+            if (schema.type_array) |type_arr| {
+                for (type_arr) |t| {
+                    if (!std.mem.eql(u8, t, "null")) {
+                        break :blk self.convertSchemaType(t);
+                    }
+                }
+            }
+            break :blk null;
+        };
+        const title = schema.title;
+        const description = schema.description;
+        const format = schema.format;
+        const required = if (schema.required) |req_list| blk: {
+            const req_array = try self.allocator.alloc([]const u8, req_list.len);
+            for (req_list, 0..) |req, i| {
+                req_array[i] = req;
+            }
+            break :blk req_array;
+        } else null;
+        const properties = if (schema.properties) |props| blk: {
+            var props_map = std.StringHashMap(Schema).init(self.allocator);
+            var prop_iterator = props.iterator();
+            while (prop_iterator.next()) |entry| {
+                const key = try self.allocator.dupe(u8, entry.key_ptr.*);
+                const prop_schema = try self.convertSchemaOrReference(entry.value_ptr.*);
+                try props_map.put(key, prop_schema);
+            }
+            break :blk props_map;
+        } else null;
+        const items = if (schema.items) |items_ref| blk: {
+            const items_schema = try self.convertSchemaOrReference(items_ref);
+            const items_ptr = try self.allocator.create(Schema);
+            items_ptr.* = items_schema;
+            break :blk items_ptr;
+        } else null;
+        return Schema{
+            .type = schema_type,
+            .ref = null,
+            .title = title,
+            .description = description,
+            .format = format,
+            .required = required,
+            .properties = properties,
+            .items = items,
+            .enum_values = null,
+            .default = schema.default,
+            .example = schema.example,
+        };
+    }
+
+    fn convertSchemaType(self: *OpenApi32Converter, type_str: []const u8) SchemaType {
+        _ = self;
+        if (std.mem.eql(u8, type_str, "string")) return .string;
+        if (std.mem.eql(u8, type_str, "number")) return .number;
+        if (std.mem.eql(u8, type_str, "integer")) return .integer;
+        if (std.mem.eql(u8, type_str, "boolean")) return .boolean;
+        if (std.mem.eql(u8, type_str, "array")) return .array;
+        if (std.mem.eql(u8, type_str, "object")) return .object;
+        return .string;
+    }
+
+    fn convertPaths(self: *OpenApi32Converter, paths: Paths32) !std.StringHashMap(PathItem) {
+        var converted_paths = std.StringHashMap(PathItem).init(self.allocator);
+        var path_iterator = paths.path_items.iterator();
+        while (path_iterator.next()) |entry| {
+            const path = try self.allocator.dupe(u8, entry.key_ptr.*);
+            const path_item = try self.convertPathItem(entry.value_ptr.*);
+            try converted_paths.put(path, path_item);
+        }
+        return converted_paths;
+    }
+
+    fn convertPathItem(self: *OpenApi32Converter, pathItem: PathItem32) !PathItem {
+        const get = if (pathItem.get) |op| try self.convertOperation(op) else null;
+        const put = if (pathItem.put) |op| try self.convertOperation(op) else null;
+        const post = if (pathItem.post) |op| try self.convertOperation(op) else null;
+        const delete = if (pathItem.delete) |op| try self.convertOperation(op) else null;
+        const options = if (pathItem.options) |op| try self.convertOperation(op) else null;
+        const head = if (pathItem.head) |op| try self.convertOperation(op) else null;
+        const patch = if (pathItem.patch) |op| try self.convertOperation(op) else null;
+        const parameters = if (pathItem.parameters) |params| try self.convertParameters(params) else null;
+        return PathItem{
+            .get = get,
+            .put = put,
+            .post = post,
+            .delete = delete,
+            .options = options,
+            .head = head,
+            .patch = patch,
+            .parameters = parameters,
+        };
+    }
+
+    fn convertOperation(self: *OpenApi32Converter, operation: Operation32) !Operation {
+        const tags = if (operation.tags) |tags_list| blk: {
+            const tags_array = try self.allocator.alloc([]const u8, tags_list.len);
+            for (tags_list, 0..) |tag, i| {
+                tags_array[i] = tag;
+            }
+            break :blk tags_array;
+        } else null;
+        const summary = operation.summary;
+        const description = operation.description;
+        const operationId = operation.operationId;
+
+        var parameters_list = std.ArrayList(Parameter){};
+        defer parameters_list.deinit(self.allocator);
+
+        if (operation.parameters) |params| {
+            for (params) |*param_ref| {
+                try parameters_list.append(self.allocator, try self.convertParameterOrReference(param_ref));
+            }
+        }
+
+        if (operation.requestBody) |*request_body_or_ref| {
+            const request_body_param = try self.convertRequestBodyOrReference(request_body_or_ref);
+            try parameters_list.append(self.allocator, request_body_param);
+        }
+
+        const parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice(self.allocator) else null;
+
+        var responses = std.StringHashMap(Response).init(self.allocator);
+        if (operation.responses.default) |default_response| {
+            const response = try self.convertResponseOrReference(default_response);
+            const default_key = try self.allocator.dupe(u8, "default");
+            try responses.put(default_key, response);
+        }
+        var resp_iterator = operation.responses.status_codes.iterator();
+        while (resp_iterator.next()) |entry| {
+            const key = try self.allocator.dupe(u8, entry.key_ptr.*);
+            const response = try self.convertResponseOrReference(entry.value_ptr.*);
+            try responses.put(key, response);
+        }
+        const security = if (operation.security) |sec_list| try self.convertSecurityRequirements(sec_list) else null;
+        return Operation{
+            .tags = tags,
+            .summary = summary,
+            .description = description,
+            .operationId = operationId,
+            .parameters = parameters,
+            .responses = responses,
+            .deprecated = operation.deprecated orelse false,
+            .security = security,
+        };
+    }
+
+    fn convertRequestBodyOrReference(self: *OpenApi32Converter, requestBodyOrRef: *const RequestBodyOrReference32) !Parameter {
+        switch (requestBodyOrRef.*) {
+            .reference => |ref| {
+                const name = try self.allocator.dupe(u8, ref.ref);
+                return Parameter{
+                    .name = name,
+                    .location = .body,
+                    .required = false,
+                };
+            },
+            .request_body => |*body| {
+                return self.convertRequestBody(body);
+            },
+        }
+    }
+
+    fn convertRequestBody(self: *OpenApi32Converter, requestBody: *const RequestBody32) !Parameter {
+        var mut_request_body = requestBody.*;
+        var schema: ?Schema = null;
+        if (mut_request_body.content.count() > 0) {
+            var it = mut_request_body.content.iterator();
+            if (it.next()) |entry| {
+                if (entry.value_ptr.schema) |schema_or_ref| {
+                    schema = try self.convertSchemaOrReference(schema_or_ref);
+                }
+            }
+        }
+        return Parameter{
+            .name = "body",
+            .location = .body,
+            .description = requestBody.description,
+            .required = requestBody.required orelse false,
+            .schema = schema,
+            .type = null,
+            .format = null,
+        };
+    }
+
+    fn convertParameters(self: *OpenApi32Converter, parameters: []const ParameterOrReference32) ![]Parameter {
+        var converted_params = try self.allocator.alloc(Parameter, parameters.len);
+        for (parameters, 0..) |param_ref, i| {
+            converted_params[i] = try self.convertParameterOrReference(&param_ref);
+        }
+        return converted_params;
+    }
+
+    fn convertParameterOrReference(self: *OpenApi32Converter, paramOrRef: *const ParameterOrReference32) !Parameter {
+        switch (paramOrRef.*) {
+            .reference => |ref| {
+                const name = try self.allocator.dupe(u8, ref.ref);
+                return Parameter{
+                    .name = name,
+                    .location = .query,
+                    .required = false,
+                };
+            },
+            .parameter => |param| {
+                return self.convertParameter(param);
+            },
+        }
+    }
+
+    fn convertParameter(self: *OpenApi32Converter, parameter: Parameter32) !Parameter {
+        const name = parameter.name;
+        const location = self.convertParameterLocation(parameter.in_field);
+        const description = parameter.description;
+        const required = parameter.required orelse false;
+        const schema = if (parameter.schema) |schema_ref| try self.convertSchemaOrReference(schema_ref) else null;
+        return Parameter{
+            .name = name,
+            .location = location,
+            .description = description,
+            .required = required,
+            .schema = schema,
+            .type = null,
+            .format = null,
+        };
+    }
+
+    fn convertParameterLocation(self: *OpenApi32Converter, location: []const u8) ParameterLocation {
+        _ = self;
+        if (std.mem.eql(u8, location, "query")) return .query;
+        if (std.mem.eql(u8, location, "header")) return .header;
+        if (std.mem.eql(u8, location, "path")) return .path;
+        if (std.mem.eql(u8, location, "cookie")) return .query;
+        return .query;
+    }
+
+    fn convertResponseOrReference(self: *OpenApi32Converter, respOrRef: ResponseOrReference32) !Response {
+        switch (respOrRef) {
+            .reference => |ref| {
+                const description = try self.allocator.dupe(u8, ref.ref);
+                return Response{ .description = description };
+            },
+            .response => |resp| {
+                return self.convertResponse(resp);
+            },
+        }
+    }
+
+    fn convertResponse(self: *OpenApi32Converter, response: Response32) !Response {
+        const description = response.description;
+        var schema: ?Schema = null;
+        if (response.content) |content| {
+            var content_iterator = content.iterator();
+            if (content_iterator.next()) |entry| {
+                if (entry.value_ptr.schema) |schema_or_ref| {
+                    schema = try self.convertSchemaOrReference(schema_or_ref);
+                }
+            }
+        }
+
+        return Response{
+            .description = description,
+            .schema = schema,
+            .headers = null,
+        };
+    }
+};

--- a/src/models.zig
+++ b/src/models.zig
@@ -1,4 +1,6 @@
 pub const OpenApiDocument = @import("models/v3.0/openapi.zig").OpenApiDocument;
+pub const OpenApi32Document = @import("models/v3.2/openapi.zig").OpenApi32Document;
 pub const SwaggerDocument = @import("models/v2.0/swagger.zig").SwaggerDocument;
 pub const v2 = @import("models/v2.0/models.zig");
 pub const v3 = @import("models/v3.0/models.zig");
+pub const v32 = @import("models/v3.2/models.zig");

--- a/src/models/v3.2/callback.zig
+++ b/src/models/v3.2/callback.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const json = std.json;
+const PathItem = @import("paths.zig").PathItem;
+const Reference = @import("reference.zig").Reference;
+
+pub const Callback = struct {
+    path_items: std.StringHashMap(PathItem),
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Callback {
+        var path_items_map = std.StringHashMap(PathItem).init(allocator);
+        const obj = value.object;
+        for (obj.keys()) |key| {
+            try path_items_map.put(try allocator.dupe(u8, key), try PathItem.parseFromJson(allocator, obj.get(key).?));
+        }
+        return Callback{ .path_items = path_items_map };
+    }
+
+    pub fn deinit(self: *Callback, allocator: std.mem.Allocator) void {
+        var iterator = self.path_items.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(allocator);
+        }
+        self.path_items.deinit();
+    }
+};
+
+pub const CallbackOrReference = union(enum) {
+    callback: Callback,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!CallbackOrReference {
+        if (value.object.get("$ref") != null) {
+            return CallbackOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            return CallbackOrReference{ .callback = try Callback.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *CallbackOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .callback => |*callback| callback.deinit(allocator),
+            .reference => |*reference| reference.deinit(allocator),
+        }
+    }
+};

--- a/src/models/v3.2/components.zig
+++ b/src/models/v3.2/components.zig
@@ -1,0 +1,234 @@
+const std = @import("std");
+const json = std.json;
+const SchemaOrReference = @import("schema.zig").SchemaOrReference;
+const ResponseOrReference = @import("response.zig").ResponseOrReference;
+const ParameterOrReference = @import("parameter.zig").ParameterOrReference;
+const ExampleOrReference = @import("media.zig").ExampleOrReference;
+const RequestBodyOrReference = @import("requestbody.zig").RequestBodyOrReference;
+const HeaderOrReference = @import("media.zig").HeaderOrReference;
+const SecuritySchemeOrReference = @import("security.zig").SecuritySchemeOrReference;
+const LinkOrReference = @import("link.zig").LinkOrReference;
+const CallbackOrReference = @import("callback.zig").CallbackOrReference;
+const PathItem = @import("paths.zig").PathItem;
+const Reference = @import("reference.zig").Reference;
+
+/// PathItemOrReference supports both inline PathItem and $ref references in webhooks/pathItems
+pub const PathItemOrReference = union(enum) {
+    path_item: PathItem,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!PathItemOrReference {
+        if (value.object.get("$ref") != null) {
+            return PathItemOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            return PathItemOrReference{ .path_item = try PathItem.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *PathItemOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .path_item => |*path_item| path_item.deinit(allocator),
+            .reference => |*reference| reference.deinit(allocator),
+        }
+    }
+};
+
+pub const Components = struct {
+    schemas: ?std.StringHashMap(SchemaOrReference) = null,
+    responses: ?std.StringHashMap(ResponseOrReference) = null,
+    parameters: ?std.StringHashMap(ParameterOrReference) = null,
+    examples: ?std.StringHashMap(ExampleOrReference) = null,
+    requestBodies: ?std.StringHashMap(RequestBodyOrReference) = null,
+    headers: ?std.StringHashMap(HeaderOrReference) = null,
+    securitySchemes: ?std.StringHashMap(SecuritySchemeOrReference) = null,
+    links: ?std.StringHashMap(LinkOrReference) = null,
+    callbacks: ?std.StringHashMap(CallbackOrReference) = null,
+    pathItems: ?std.StringHashMap(PathItemOrReference) = null,
+    _allocated_strings: std.ArrayList([]const u8),
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Components {
+        var _allocated_strings = std.ArrayList([]const u8){};
+        errdefer _allocated_strings.deinit(allocator);
+        const obj = value.object;
+        var schemas_map = std.StringHashMap(SchemaOrReference).init(allocator);
+        errdefer schemas_map.deinit();
+        if (obj.get("schemas")) |schemas_val| {
+            for (schemas_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try schemas_map.put(k, try SchemaOrReference.parseFromJson(allocator, schemas_val.object.get(key).?));
+            }
+        }
+        var responses_map = std.StringHashMap(ResponseOrReference).init(allocator);
+        errdefer responses_map.deinit();
+        if (obj.get("responses")) |responses_val| {
+            for (responses_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try responses_map.put(k, try ResponseOrReference.parseFromJson(allocator, responses_val.object.get(key).?));
+            }
+        }
+        var parameters_map = std.StringHashMap(ParameterOrReference).init(allocator);
+        errdefer parameters_map.deinit();
+        if (obj.get("parameters")) |parameters_val| {
+            for (parameters_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try parameters_map.put(k, try ParameterOrReference.parseFromJson(allocator, parameters_val.object.get(key).?));
+            }
+        }
+        var examples_map = std.StringHashMap(ExampleOrReference).init(allocator);
+        errdefer examples_map.deinit();
+        if (obj.get("examples")) |examples_val| {
+            for (examples_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try examples_map.put(k, try ExampleOrReference.parseFromJson(allocator, examples_val.object.get(key).?));
+            }
+        }
+        var request_bodies_map = std.StringHashMap(RequestBodyOrReference).init(allocator);
+        errdefer request_bodies_map.deinit();
+        if (obj.get("requestBodies")) |request_bodies_val| {
+            for (request_bodies_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try request_bodies_map.put(k, try RequestBodyOrReference.parseFromJson(allocator, request_bodies_val.object.get(key).?));
+            }
+        }
+        var headers_map = std.StringHashMap(HeaderOrReference).init(allocator);
+        errdefer headers_map.deinit();
+        if (obj.get("headers")) |headers_val| {
+            for (headers_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try headers_map.put(k, try HeaderOrReference.parseFromJson(allocator, headers_val.object.get(key).?));
+            }
+        }
+        var security_schemes_map = std.StringHashMap(SecuritySchemeOrReference).init(allocator);
+        errdefer security_schemes_map.deinit();
+        if (obj.get("securitySchemes")) |security_schemes_val| {
+            for (security_schemes_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try security_schemes_map.put(k, try SecuritySchemeOrReference.parseFromJson(allocator, security_schemes_val.object.get(key).?));
+            }
+        }
+        var links_map = std.StringHashMap(LinkOrReference).init(allocator);
+        errdefer links_map.deinit();
+        if (obj.get("links")) |links_val| {
+            for (links_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try links_map.put(k, try LinkOrReference.parseFromJson(allocator, links_val.object.get(key).?));
+            }
+        }
+        var callbacks_map = std.StringHashMap(CallbackOrReference).init(allocator);
+        errdefer callbacks_map.deinit();
+        if (obj.get("callbacks")) |callbacks_val| {
+            for (callbacks_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try callbacks_map.put(k, try CallbackOrReference.parseFromJson(allocator, callbacks_val.object.get(key).?));
+            }
+        }
+        var path_items_map = std.StringHashMap(PathItemOrReference).init(allocator);
+        errdefer path_items_map.deinit();
+        if (obj.get("pathItems")) |path_items_val| {
+            for (path_items_val.object.keys()) |key| {
+                const k = try allocator.dupe(u8, key);
+                try _allocated_strings.append(allocator, k);
+                try path_items_map.put(k, try PathItemOrReference.parseFromJson(allocator, path_items_val.object.get(key).?));
+            }
+        }
+        return Components{
+            .schemas = if (schemas_map.count() > 0) schemas_map else null,
+            .responses = if (responses_map.count() > 0) responses_map else null,
+            .parameters = if (parameters_map.count() > 0) parameters_map else null,
+            .examples = if (examples_map.count() > 0) examples_map else null,
+            .requestBodies = if (request_bodies_map.count() > 0) request_bodies_map else null,
+            .headers = if (headers_map.count() > 0) headers_map else null,
+            .securitySchemes = if (security_schemes_map.count() > 0) security_schemes_map else null,
+            .links = if (links_map.count() > 0) links_map else null,
+            .callbacks = if (callbacks_map.count() > 0) callbacks_map else null,
+            .pathItems = if (path_items_map.count() > 0) path_items_map else null,
+            ._allocated_strings = _allocated_strings,
+        };
+    }
+
+    pub fn deinit(self: *Components, allocator: std.mem.Allocator) void {
+        for (self._allocated_strings.items) |str| {
+            allocator.free(str);
+        }
+        defer self._allocated_strings.deinit(allocator);
+        if (self.schemas) |*schemas| {
+            var iterator = schemas.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            schemas.deinit();
+        }
+        if (self.responses) |*responses| {
+            var iterator = responses.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            responses.deinit();
+        }
+        if (self.parameters) |*parameters| {
+            var iterator = parameters.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            parameters.deinit();
+        }
+        if (self.examples) |*examples| {
+            var iterator = examples.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            examples.deinit();
+        }
+        if (self.requestBodies) |*requestBodies| {
+            var iterator = requestBodies.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            requestBodies.deinit();
+        }
+        if (self.headers) |*headers| {
+            var iterator = headers.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            headers.deinit();
+        }
+        if (self.securitySchemes) |*securitySchemes| {
+            var iterator = securitySchemes.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            securitySchemes.deinit();
+        }
+        if (self.links) |*links| {
+            var iterator = links.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            links.deinit();
+        }
+        if (self.callbacks) |*callbacks| {
+            var iterator = callbacks.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            callbacks.deinit();
+        }
+        if (self.pathItems) |*pathItems| {
+            var iterator = pathItems.iterator();
+            while (iterator.next()) |entry| {
+                entry.value_ptr.deinit(allocator);
+            }
+            pathItems.deinit();
+        }
+    }
+};

--- a/src/models/v3.2/externaldocs.zig
+++ b/src/models/v3.2/externaldocs.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+const json = std.json;
+
+pub const ExternalDocumentation = struct {
+    url: []const u8,
+    description: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!ExternalDocumentation {
+        const obj = value.object;
+        return ExternalDocumentation{
+            .url = try allocator.dupe(u8, obj.get("url").?.string),
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: ExternalDocumentation, allocator: std.mem.Allocator) void {
+        allocator.free(self.url);
+        if (self.description) |desc| allocator.free(desc);
+    }
+};

--- a/src/models/v3.2/info.zig
+++ b/src/models/v3.2/info.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const json = std.json;
+
+pub const Contact = struct {
+    name: ?[]const u8 = null,
+    url: ?[]const u8 = null,
+    email: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Contact {
+        const obj = value.object;
+        return Contact{
+            .name = if (obj.get("name")) |val| try allocator.dupe(u8, val.string) else null,
+            .url = if (obj.get("url")) |val| try allocator.dupe(u8, val.string) else null,
+            .email = if (obj.get("email")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: Contact, allocator: std.mem.Allocator) void {
+        if (self.name) |name| allocator.free(name);
+        if (self.url) |url| allocator.free(url);
+        if (self.email) |email| allocator.free(email);
+    }
+};
+
+pub const License = struct {
+    name: []const u8,
+    url: ?[]const u8 = null,
+    identifier: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!License {
+        const obj = value.object;
+        return License{
+            .name = try allocator.dupe(u8, obj.get("name").?.string),
+            .url = if (obj.get("url")) |val| try allocator.dupe(u8, val.string) else null,
+            .identifier = if (obj.get("identifier")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: License, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        if (self.url) |url| allocator.free(url);
+        if (self.identifier) |identifier| allocator.free(identifier);
+    }
+};
+
+pub const Info = struct {
+    title: []const u8,
+    version: []const u8,
+    summary: ?[]const u8 = null,
+    description: ?[]const u8 = null,
+    termsOfService: ?[]const u8 = null,
+    contact: ?Contact = null,
+    license: ?License = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Info {
+        const obj = value.object;
+        return Info{
+            .title = try allocator.dupe(u8, obj.get("title").?.string),
+            .version = try allocator.dupe(u8, obj.get("version").?.string),
+            .summary = if (obj.get("summary")) |val| try allocator.dupe(u8, val.string) else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .termsOfService = if (obj.get("termsOfService")) |val| try allocator.dupe(u8, val.string) else null,
+            .contact = if (obj.get("contact")) |val| try Contact.parseFromJson(allocator, val) else null,
+            .license = if (obj.get("license")) |val| try License.parseFromJson(allocator, val) else null,
+        };
+    }
+
+    pub fn deinit(self: Info, allocator: std.mem.Allocator) void {
+        allocator.free(self.title);
+        allocator.free(self.version);
+        if (self.summary) |summary| allocator.free(summary);
+        if (self.description) |desc| allocator.free(desc);
+        if (self.termsOfService) |terms| allocator.free(terms);
+        if (self.contact) |contact| contact.deinit(allocator);
+        if (self.license) |license| license.deinit(allocator);
+    }
+};

--- a/src/models/v3.2/link.zig
+++ b/src/models/v3.2/link.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const json = std.json;
+const Server = @import("server.zig").Server;
+const Reference = @import("reference.zig").Reference;
+
+pub const Link = struct {
+    operationId: ?[]const u8 = null,
+    operationRef: ?[]const u8 = null,
+    parameters: ?std.StringHashMap(json.Value) = null,
+    requestBody: ?json.Value = null,
+    description: ?[]const u8 = null,
+    server: ?Server = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Link {
+        const obj = value.object;
+        var parameters_map = std.StringHashMap(json.Value).init(allocator);
+        if (obj.get("parameters")) |params_val| {
+            for (params_val.object.keys()) |key| {
+                try parameters_map.put(try allocator.dupe(u8, key), params_val.object.get(key).?);
+            }
+        }
+        return Link{
+            .operationId = if (obj.get("operationId")) |val| try allocator.dupe(u8, val.string) else null,
+            .operationRef = if (obj.get("operationRef")) |val| try allocator.dupe(u8, val.string) else null,
+            .parameters = if (parameters_map.count() > 0) parameters_map else null,
+            .requestBody = if (obj.get("requestBody")) |val| val else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .server = if (obj.get("server")) |val| try Server.parseFromJson(allocator, val) else null,
+        };
+    }
+
+    pub fn deinit(self: *Link, allocator: std.mem.Allocator) void {
+        if (self.operationId) |operationId| allocator.free(operationId);
+        if (self.operationRef) |operationRef| allocator.free(operationRef);
+        if (self.description) |description| allocator.free(description);
+        if (self.parameters) |*parameters| {
+            var iterator = parameters.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+            }
+            parameters.deinit();
+        }
+        if (self.server) |*server| {
+            server.deinit(allocator);
+        }
+    }
+};
+
+pub const LinkOrReference = union(enum) {
+    link: Link,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!LinkOrReference {
+        if (value.object.get("$ref") != null) {
+            return LinkOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            return LinkOrReference{ .link = try Link.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *LinkOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .link => |*link| link.deinit(allocator),
+            .reference => |*reference| reference.deinit(allocator),
+        }
+    }
+};

--- a/src/models/v3.2/media.zig
+++ b/src/models/v3.2/media.zig
@@ -1,0 +1,223 @@
+const std = @import("std");
+const json = std.json;
+const SchemaOrReference = @import("schema.zig").SchemaOrReference;
+const Reference = @import("reference.zig").Reference;
+
+pub const Example = struct {
+    summary: ?[]const u8 = null,
+    description: ?[]const u8 = null,
+    value: ?json.Value = null,
+    externalValue: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Example {
+        const obj = value.object;
+        return Example{
+            .summary = if (obj.get("summary")) |val| try allocator.dupe(u8, val.string) else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .value = if (obj.get("value")) |val| val else null,
+            .externalValue = if (obj.get("externalValue")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *Example, allocator: std.mem.Allocator) void {
+        if (self.summary) |summary| allocator.free(summary);
+        if (self.description) |description| allocator.free(description);
+        if (self.externalValue) |externalValue| allocator.free(externalValue);
+    }
+};
+
+pub const ExampleOrReference = union(enum) {
+    example: Example,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!ExampleOrReference {
+        if (value.object.get("$ref") != null) {
+            return ExampleOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            return ExampleOrReference{ .example = try Example.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *ExampleOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .example => |*example| example.deinit(allocator),
+            .reference => |*reference| reference.deinit(allocator),
+        }
+    }
+};
+
+pub const HeaderOrReference = union(enum) {
+    header: Header,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!HeaderOrReference {
+        if (value.object.get("$ref") != null) {
+            return HeaderOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            return HeaderOrReference{ .header = try Header.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *HeaderOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .header => |*header| header.deinit(allocator),
+            .reference => |*reference| reference.deinit(allocator),
+        }
+    }
+};
+
+pub const Encoding = struct {
+    contentType: ?[]const u8 = null,
+    headers: ?std.StringHashMap(HeaderOrReference) = null,
+    style: ?[]const u8 = null,
+    explode: ?bool = null,
+    allowReserved: ?bool = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Encoding {
+        const obj = value.object;
+        var headers_map = std.StringHashMap(HeaderOrReference).init(allocator);
+        if (obj.get("headers")) |headers_val| {
+            for (headers_val.object.keys()) |key| {
+                try headers_map.put(try allocator.dupe(u8, key), try HeaderOrReference.parseFromJson(allocator, headers_val.object.get(key).?));
+            }
+        }
+        return Encoding{
+            .contentType = if (obj.get("contentType")) |val| try allocator.dupe(u8, val.string) else null,
+            .headers = if (headers_map.count() > 0) headers_map else null,
+            .style = if (obj.get("style")) |val| try allocator.dupe(u8, val.string) else null,
+            .explode = if (obj.get("explode")) |val| val.bool else null,
+            .allowReserved = if (obj.get("allowReserved")) |val| val.bool else null,
+        };
+    }
+
+    pub fn deinit(self: *Encoding, allocator: std.mem.Allocator) void {
+        if (self.contentType) |contentType| allocator.free(contentType);
+        if (self.style) |style| allocator.free(style);
+        if (self.headers) |*headers| {
+            var iterator = headers.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            headers.deinit();
+        }
+    }
+};
+
+pub const MediaType = struct {
+    schema: ?SchemaOrReference = null,
+    example: ?json.Value = null,
+    examples: ?std.StringHashMap(ExampleOrReference) = null,
+    encoding: ?std.StringHashMap(Encoding) = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!MediaType {
+        const obj = value.object;
+        var examples_map = std.StringHashMap(ExampleOrReference).init(allocator);
+        if (obj.get("examples")) |examples_val| {
+            for (examples_val.object.keys()) |key| {
+                try examples_map.put(try allocator.dupe(u8, key), try ExampleOrReference.parseFromJson(allocator, examples_val.object.get(key).?));
+            }
+        }
+        var encoding_map = std.StringHashMap(Encoding).init(allocator);
+        if (obj.get("encoding")) |encoding_val| {
+            for (encoding_val.object.keys()) |key| {
+                try encoding_map.put(try allocator.dupe(u8, key), try Encoding.parseFromJson(allocator, encoding_val.object.get(key).?));
+            }
+        }
+        return MediaType{
+            .schema = if (obj.get("schema")) |val| try SchemaOrReference.parseFromJson(allocator, val) else null,
+            .example = if (obj.get("example")) |val| val else null,
+            .examples = if (examples_map.count() > 0) examples_map else null,
+            .encoding = if (encoding_map.count() > 0) encoding_map else null,
+        };
+    }
+
+    pub fn deinit(self: *MediaType, allocator: std.mem.Allocator) void {
+        if (self.schema) |*schema| {
+            schema.deinit(allocator);
+        }
+        if (self.examples) |*examples| {
+            var iterator = examples.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            examples.deinit();
+        }
+        if (self.encoding) |*encoding| {
+            var iterator = encoding.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            encoding.deinit();
+        }
+    }
+};
+
+pub const Header = struct {
+    description: ?[]const u8 = null,
+    required: ?bool = null,
+    deprecated: ?bool = null,
+    allowEmptyValue: ?bool = null,
+    style: ?[]const u8 = null,
+    explode: ?bool = null,
+    allowReserved: ?bool = null,
+    schema: ?SchemaOrReference = null,
+    content: ?std.StringHashMap(MediaType) = null,
+    example: ?json.Value = null,
+    examples: ?std.StringHashMap(ExampleOrReference) = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Header {
+        const obj = value.object;
+        var content_map = std.StringHashMap(MediaType).init(allocator);
+        if (obj.get("content")) |content_val| {
+            for (content_val.object.keys()) |key| {
+                try content_map.put(try allocator.dupe(u8, key), try MediaType.parseFromJson(allocator, content_val.object.get(key).?));
+            }
+        }
+        var examples_map = std.StringHashMap(ExampleOrReference).init(allocator);
+        if (obj.get("examples")) |examples_val| {
+            for (examples_val.object.keys()) |key| {
+                try examples_map.put(try allocator.dupe(u8, key), try ExampleOrReference.parseFromJson(allocator, examples_val.object.get(key).?));
+            }
+        }
+        return Header{
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .required = if (obj.get("required")) |val| val.bool else null,
+            .deprecated = if (obj.get("deprecated")) |val| val.bool else null,
+            .allowEmptyValue = if (obj.get("allowEmptyValue")) |val| val.bool else null,
+            .style = if (obj.get("style")) |val| try allocator.dupe(u8, val.string) else null,
+            .explode = if (obj.get("explode")) |val| val.bool else null,
+            .allowReserved = if (obj.get("allowReserved")) |val| val.bool else null,
+            .schema = if (obj.get("schema")) |val| try SchemaOrReference.parseFromJson(allocator, val) else null,
+            .content = if (content_map.count() > 0) content_map else null,
+            .example = if (obj.get("example")) |val| val else null,
+            .examples = if (examples_map.count() > 0) examples_map else null,
+        };
+    }
+
+    pub fn deinit(self: *Header, allocator: std.mem.Allocator) void {
+        if (self.description) |description| allocator.free(description);
+        if (self.style) |style| allocator.free(style);
+        if (self.schema) |*schema| {
+            schema.deinit(allocator);
+        }
+        if (self.content) |*content| {
+            var iterator = content.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            content.deinit();
+        }
+        if (self.examples) |*examples| {
+            var iterator = examples.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            examples.deinit();
+        }
+    }
+};

--- a/src/models/v3.2/models.zig
+++ b/src/models/v3.2/models.zig
@@ -1,0 +1,64 @@
+pub const OpenApi32Document = @import("openapi.zig").OpenApi32Document;
+
+pub const Info = @import("info.zig").Info;
+pub const Contact = @import("info.zig").Contact;
+pub const License = @import("info.zig").License;
+
+pub const Server = @import("server.zig").Server;
+pub const ServerVariable = @import("server.zig").ServerVariable;
+
+pub const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
+
+pub const Tag = @import("tag.zig").Tag;
+
+pub const Reference = @import("reference.zig").Reference;
+
+pub const Schema = @import("schema.zig").Schema;
+pub const SchemaOrReference = @import("schema.zig").SchemaOrReference;
+pub const XML = @import("schema.zig").XML;
+pub const Discriminator = @import("schema.zig").Discriminator;
+pub const AdditionalProperties = @import("schema.zig").AdditionalProperties;
+
+pub const Example = @import("media.zig").Example;
+pub const ExampleOrReference = @import("media.zig").ExampleOrReference;
+pub const Header = @import("media.zig").Header;
+pub const HeaderOrReference = @import("media.zig").HeaderOrReference;
+pub const Encoding = @import("media.zig").Encoding;
+pub const MediaType = @import("media.zig").MediaType;
+
+pub const Parameter = @import("parameter.zig").Parameter;
+pub const ParameterOrReference = @import("parameter.zig").ParameterOrReference;
+
+pub const RequestBody = @import("requestbody.zig").RequestBody;
+pub const RequestBodyOrReference = @import("requestbody.zig").RequestBodyOrReference;
+
+pub const Response = @import("response.zig").Response;
+pub const ResponseOrReference = @import("response.zig").ResponseOrReference;
+pub const Responses = @import("response.zig").Responses;
+
+pub const PathItem = @import("paths.zig").PathItem;
+pub const Paths = @import("paths.zig").Paths;
+
+pub const Operation = @import("operation.zig").Operation;
+
+pub const Link = @import("link.zig").Link;
+pub const LinkOrReference = @import("link.zig").LinkOrReference;
+
+pub const Callback = @import("callback.zig").Callback;
+pub const CallbackOrReference = @import("callback.zig").CallbackOrReference;
+
+pub const SecurityRequirement = @import("security.zig").SecurityRequirement;
+pub const SecurityScheme = @import("security.zig").SecurityScheme;
+pub const SecuritySchemeOrReference = @import("security.zig").SecuritySchemeOrReference;
+pub const OAuthFlows = @import("security.zig").OAuthFlows;
+pub const ImplicitOAuthFlow = @import("security.zig").ImplicitOAuthFlow;
+pub const PasswordOAuthFlow = @import("security.zig").PasswordOAuthFlow;
+pub const ClientCredentialsFlow = @import("security.zig").ClientCredentialsFlow;
+pub const AuthorizationCodeOAuthFlow = @import("security.zig").AuthorizationCodeOAuthFlow;
+pub const APIKeySecurityScheme = @import("security.zig").APIKeySecurityScheme;
+pub const HTTPSecurityScheme = @import("security.zig").HTTPSecurityScheme;
+pub const OAuth2SecurityScheme = @import("security.zig").OAuth2SecurityScheme;
+pub const OpenIdConnectSecurityScheme = @import("security.zig").OpenIdConnectSecurityScheme;
+
+pub const Components = @import("components.zig").Components;
+pub const PathItemOrReference = @import("components.zig").PathItemOrReference;

--- a/src/models/v3.2/openapi.zig
+++ b/src/models/v3.2/openapi.zig
@@ -1,0 +1,131 @@
+const std = @import("std");
+const json = std.json;
+const Info = @import("info.zig").Info;
+const Paths = @import("paths.zig").Paths;
+const PathItem = @import("paths.zig").PathItem;
+const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
+const Server = @import("server.zig").Server;
+const SecurityRequirement = @import("security.zig").SecurityRequirement;
+const Tag = @import("tag.zig").Tag;
+const Components = @import("components.zig").Components;
+const PathItemOrReference = @import("components.zig").PathItemOrReference;
+
+pub const OpenApi32Document = struct {
+    openapi: []const u8,
+    info: Info,
+    paths: ?Paths = null,
+    externalDocs: ?ExternalDocumentation = null,
+    servers: ?[]Server = null,
+    security: ?[]SecurityRequirement = null,
+    tags: ?[]const Tag = null,
+    components: ?Components = null,
+    jsonSchemaDialect: ?[]const u8 = null,
+    webhooks: ?std.StringHashMap(PathItemOrReference) = null,
+
+    pub fn deinit(self: *OpenApi32Document, allocator: std.mem.Allocator) void {
+        allocator.free(self.openapi);
+        self.info.deinit(allocator);
+        if (self.paths) |*paths| {
+            paths.deinit(allocator);
+        }
+        if (self.externalDocs) |external_docs| {
+            external_docs.deinit(allocator);
+        }
+        if (self.servers) |servers| {
+            for (servers) |*server| {
+                server.deinit(allocator);
+            }
+            allocator.free(servers);
+        }
+        if (self.security) |security| {
+            for (security) |*security_req| {
+                security_req.deinit(allocator);
+            }
+            allocator.free(security);
+        }
+        if (self.tags) |tags| {
+            for (tags) |tag| {
+                tag.deinit(allocator);
+            }
+            allocator.free(tags);
+        }
+        if (self.components) |*components| {
+            components.deinit(allocator);
+        }
+        if (self.jsonSchemaDialect) |dialect| {
+            allocator.free(dialect);
+        }
+        if (self.webhooks) |*webhooks| {
+            var iterator = webhooks.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            webhooks.deinit();
+        }
+    }
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, json_string: []const u8) anyerror!OpenApi32Document {
+        var parsed = try json.parseFromSlice(json.Value, allocator, json_string, .{ .ignore_unknown_fields = true });
+        defer parsed.deinit();
+        const root = parsed.value;
+        const openapi_str = try allocator.dupe(u8, root.object.get("openapi").?.string);
+        const info = try Info.parseFromJson(allocator, root.object.get("info").?);
+        const paths = if (root.object.get("paths")) |val| try Paths.parseFromJson(allocator, val) else null;
+        const externalDocs = if (root.object.get("externalDocs")) |val| try ExternalDocumentation.parseFromJson(allocator, val) else null;
+        const servers = if (root.object.get("servers")) |val| try parseServers(allocator, val) else null;
+        const security = if (root.object.get("security")) |val| try parseSecurityRequirements(allocator, val) else null;
+        const tags = if (root.object.get("tags")) |val| try parseTags(allocator, val) else null;
+        const components = if (root.object.get("components")) |val| try Components.parseFromJson(allocator, val) else null;
+        const jsonSchemaDialect = if (root.object.get("jsonSchemaDialect")) |val| try allocator.dupe(u8, val.string) else null;
+        const webhooks = if (root.object.get("webhooks")) |val| try parseWebhooks(allocator, val) else null;
+        return OpenApi32Document{
+            .openapi = openapi_str,
+            .info = info,
+            .paths = paths,
+            .externalDocs = externalDocs,
+            .servers = servers,
+            .security = security,
+            .tags = tags,
+            .components = components,
+            .jsonSchemaDialect = jsonSchemaDialect,
+            .webhooks = webhooks,
+        };
+    }
+
+    fn parseServers(allocator: std.mem.Allocator, value: json.Value) anyerror![]Server {
+        var array_list = std.ArrayList(Server){};
+        errdefer array_list.deinit(allocator);
+        for (value.array.items) |item| {
+            try array_list.append(allocator, try Server.parseFromJson(allocator, item));
+        }
+        return array_list.toOwnedSlice(allocator);
+    }
+
+    fn parseSecurityRequirements(allocator: std.mem.Allocator, value: json.Value) anyerror![]SecurityRequirement {
+        var array_list = std.ArrayList(SecurityRequirement){};
+        errdefer array_list.deinit(allocator);
+        for (value.array.items) |item| {
+            try array_list.append(allocator, try SecurityRequirement.parseFromJson(allocator, item));
+        }
+        return array_list.toOwnedSlice(allocator);
+    }
+
+    fn parseTags(allocator: std.mem.Allocator, value: json.Value) anyerror![]const Tag {
+        var array_list = std.ArrayList(Tag){};
+        errdefer array_list.deinit(allocator);
+        for (value.array.items) |item| {
+            try array_list.append(allocator, try Tag.parseFromJson(allocator, item));
+        }
+        return array_list.toOwnedSlice(allocator);
+    }
+
+    fn parseWebhooks(allocator: std.mem.Allocator, value: json.Value) anyerror!std.StringHashMap(PathItemOrReference) {
+        var webhooks_map = std.StringHashMap(PathItemOrReference).init(allocator);
+        errdefer webhooks_map.deinit();
+        for (value.object.keys()) |key| {
+            try webhooks_map.put(try allocator.dupe(u8, key), try PathItemOrReference.parseFromJson(allocator, value.object.get(key).?));
+        }
+        return webhooks_map;
+    }
+};

--- a/src/models/v3.2/operation.zig
+++ b/src/models/v3.2/operation.zig
@@ -1,0 +1,125 @@
+const std = @import("std");
+const json = std.json;
+const Server = @import("server.zig").Server;
+const ParameterOrReference = @import("parameter.zig").ParameterOrReference;
+const Responses = @import("response.zig").Responses;
+const RequestBodyOrReference = @import("requestbody.zig").RequestBodyOrReference;
+const CallbackOrReference = @import("callback.zig").CallbackOrReference;
+const SecurityRequirement = @import("security.zig").SecurityRequirement;
+const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
+
+pub const Operation = struct {
+    responses: Responses,
+    tags: ?[]const []const u8 = null,
+    summary: ?[]const u8 = null,
+    description: ?[]const u8 = null,
+    externalDocs: ?ExternalDocumentation = null,
+    operationId: ?[]const u8 = null,
+    parameters: ?[]const ParameterOrReference = null,
+    requestBody: ?RequestBodyOrReference = null,
+    callbacks: ?std.StringHashMap(CallbackOrReference) = null,
+    deprecated: ?bool = null,
+    security: ?[]const SecurityRequirement = null,
+    servers: ?[]const Server = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Operation {
+        const obj = value.object;
+        var tags_list = std.ArrayList([]const u8){};
+        errdefer tags_list.deinit(allocator);
+        if (obj.get("tags")) |tags_val| {
+            for (tags_val.array.items) |item| {
+                try tags_list.append(allocator, try allocator.dupe(u8, item.string));
+            }
+        }
+        var parameters_list = std.ArrayList(ParameterOrReference){};
+        errdefer parameters_list.deinit(allocator);
+        if (obj.get("parameters")) |params_val| {
+            for (params_val.array.items) |item| {
+                try parameters_list.append(allocator, try ParameterOrReference.parseFromJson(allocator, item));
+            }
+        }
+        var callbacks_map = std.StringHashMap(CallbackOrReference).init(allocator);
+        errdefer callbacks_map.deinit();
+        if (obj.get("callbacks")) |callbacks_val| {
+            for (callbacks_val.object.keys()) |key| {
+                try callbacks_map.put(try allocator.dupe(u8, key), try CallbackOrReference.parseFromJson(allocator, callbacks_val.object.get(key).?));
+            }
+        }
+        var security_list = std.ArrayList(SecurityRequirement){};
+        errdefer security_list.deinit(allocator);
+        if (obj.get("security")) |security_val| {
+            for (security_val.array.items) |item| {
+                try security_list.append(allocator, try SecurityRequirement.parseFromJson(allocator, item));
+            }
+        }
+        var servers_list = std.ArrayList(Server){};
+        errdefer servers_list.deinit(allocator);
+        if (obj.get("servers")) |servers_val| {
+            for (servers_val.array.items) |item| {
+                try servers_list.append(allocator, try Server.parseFromJson(allocator, item));
+            }
+        }
+        return Operation{
+            .responses = try Responses.parseFromJson(allocator, obj.get("responses").?),
+            .tags = if (tags_list.items.len > 0) try tags_list.toOwnedSlice(allocator) else null,
+            .summary = if (obj.get("summary")) |val| try allocator.dupe(u8, val.string) else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .externalDocs = if (obj.get("externalDocs")) |val| try ExternalDocumentation.parseFromJson(allocator, val) else null,
+            .operationId = if (obj.get("operationId")) |val| try allocator.dupe(u8, val.string) else null,
+            .parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice(allocator) else null,
+            .requestBody = if (obj.get("requestBody")) |val| try RequestBodyOrReference.parseFromJson(allocator, val) else null,
+            .callbacks = if (callbacks_map.count() > 0) callbacks_map else null,
+            .deprecated = if (obj.get("deprecated")) |val| val.bool else null,
+            .security = if (security_list.items.len > 0) try security_list.toOwnedSlice(allocator) else null,
+            .servers = if (servers_list.items.len > 0) try servers_list.toOwnedSlice(allocator) else null,
+        };
+    }
+
+    pub fn deinit(self: *Operation, allocator: std.mem.Allocator) void {
+        self.responses.deinit(allocator);
+        if (self.tags) |tags| {
+            for (tags) |tag| {
+                allocator.free(tag);
+            }
+            allocator.free(tags);
+        }
+        if (self.summary) |summary| allocator.free(summary);
+        if (self.description) |description| allocator.free(description);
+        if (self.operationId) |operationId| allocator.free(operationId);
+        if (self.externalDocs) |*externalDocs| {
+            externalDocs.deinit(allocator);
+        }
+        if (self.parameters) |params| {
+            for (params) |*param| {
+                var mutable_param = @constCast(param);
+                mutable_param.deinit(allocator);
+            }
+            allocator.free(params);
+        }
+        if (self.requestBody) |*requestBody| {
+            requestBody.deinit(allocator);
+        }
+        if (self.callbacks) |*callbacks| {
+            var iterator = callbacks.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            callbacks.deinit();
+        }
+        if (self.security) |security| {
+            for (security) |*sec| {
+                var mutable_sec = @constCast(sec);
+                mutable_sec.deinit(allocator);
+            }
+            allocator.free(security);
+        }
+        if (self.servers) |servers| {
+            for (servers) |*server| {
+                var mutable_server = @constCast(server);
+                mutable_server.deinit(allocator);
+            }
+            allocator.free(servers);
+        }
+    }
+};

--- a/src/models/v3.2/parameter.zig
+++ b/src/models/v3.2/parameter.zig
@@ -1,0 +1,99 @@
+const std = @import("std");
+const json = std.json;
+const SchemaOrReference = @import("schema.zig").SchemaOrReference;
+const Reference = @import("reference.zig").Reference;
+const MediaType = @import("media.zig").MediaType;
+const ExampleOrReference = @import("media.zig").ExampleOrReference;
+
+pub const Parameter = struct {
+    name: []const u8,
+    in_field: []const u8,
+    description: ?[]const u8 = null,
+    required: ?bool = null,
+    deprecated: ?bool = null,
+    allowEmptyValue: ?bool = null,
+    style: ?[]const u8 = null,
+    explode: ?bool = null,
+    allowReserved: ?bool = null,
+    schema: ?SchemaOrReference = null,
+    content: ?std.StringHashMap(MediaType) = null,
+    example: ?json.Value = null,
+    examples: ?std.StringHashMap(ExampleOrReference) = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Parameter {
+        const obj = value.object;
+        var content_map = std.StringHashMap(MediaType).init(allocator);
+        if (obj.get("content")) |content_val| {
+            for (content_val.object.keys()) |key| {
+                try content_map.put(try allocator.dupe(u8, key), try MediaType.parseFromJson(allocator, content_val.object.get(key).?));
+            }
+        }
+        var examples_map = std.StringHashMap(ExampleOrReference).init(allocator);
+        if (obj.get("examples")) |examples_val| {
+            for (examples_val.object.keys()) |key| {
+                try examples_map.put(try allocator.dupe(u8, key), try ExampleOrReference.parseFromJson(allocator, examples_val.object.get(key).?));
+            }
+        }
+        return Parameter{
+            .name = try allocator.dupe(u8, obj.get("name").?.string),
+            .in_field = try allocator.dupe(u8, obj.get("in").?.string),
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .required = if (obj.get("required")) |val| val.bool else null,
+            .deprecated = if (obj.get("deprecated")) |val| val.bool else null,
+            .allowEmptyValue = if (obj.get("allowEmptyValue")) |val| val.bool else null,
+            .style = if (obj.get("style")) |val| try allocator.dupe(u8, val.string) else null,
+            .explode = if (obj.get("explode")) |val| val.bool else null,
+            .allowReserved = if (obj.get("allowReserved")) |val| val.bool else null,
+            .schema = if (obj.get("schema")) |val| try SchemaOrReference.parseFromJson(allocator, val) else null,
+            .content = if (content_map.count() > 0) content_map else null,
+            .example = if (obj.get("example")) |val| val else null,
+            .examples = if (examples_map.count() > 0) examples_map else null,
+        };
+    }
+
+    pub fn deinit(self: *Parameter, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.in_field);
+        if (self.description) |description| allocator.free(description);
+        if (self.style) |style| allocator.free(style);
+        if (self.schema) |*schema| {
+            schema.deinit(allocator);
+        }
+        if (self.content) |*content| {
+            var iterator = content.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            content.deinit();
+        }
+        if (self.examples) |*examples| {
+            var iterator = examples.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            examples.deinit();
+        }
+    }
+};
+
+pub const ParameterOrReference = union(enum) {
+    parameter: Parameter,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!ParameterOrReference {
+        if (value.object.get("$ref") != null) {
+            return ParameterOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            return ParameterOrReference{ .parameter = try Parameter.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *ParameterOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .parameter => |*param| param.deinit(allocator),
+            .reference => |*ref| ref.deinit(allocator),
+        }
+    }
+};

--- a/src/models/v3.2/paths.zig
+++ b/src/models/v3.2/paths.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+const json = std.json;
+const Operation = @import("operation.zig").Operation;
+const Server = @import("server.zig").Server;
+const ParameterOrReference = @import("parameter.zig").ParameterOrReference;
+
+pub const PathItem = struct {
+    ref: ?[]const u8 = null,
+    summary: ?[]const u8 = null,
+    description: ?[]const u8 = null,
+    get: ?Operation = null,
+    put: ?Operation = null,
+    post: ?Operation = null,
+    delete: ?Operation = null,
+    options: ?Operation = null,
+    head: ?Operation = null,
+    patch: ?Operation = null,
+    trace: ?Operation = null,
+    servers: ?[]const Server = null,
+    parameters: ?[]const ParameterOrReference = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!PathItem {
+        const obj = value.object;
+        var parameters_list = std.ArrayList(ParameterOrReference){};
+        errdefer parameters_list.deinit(allocator);
+        if (obj.get("parameters")) |params_val| {
+            for (params_val.array.items) |item| {
+                try parameters_list.append(allocator, try ParameterOrReference.parseFromJson(allocator, item));
+            }
+        }
+        var servers_list = std.ArrayList(Server){};
+        errdefer servers_list.deinit(allocator);
+        if (obj.get("servers")) |servers_val| {
+            for (servers_val.array.items) |item| {
+                try servers_list.append(allocator, try Server.parseFromJson(allocator, item));
+            }
+        }
+        return PathItem{
+            .ref = if (obj.get("$ref")) |val| try allocator.dupe(u8, val.string) else null,
+            .summary = if (obj.get("summary")) |val| try allocator.dupe(u8, val.string) else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .get = if (obj.get("get")) |val| try Operation.parseFromJson(allocator, val) else null,
+            .put = if (obj.get("put")) |val| try Operation.parseFromJson(allocator, val) else null,
+            .post = if (obj.get("post")) |val| try Operation.parseFromJson(allocator, val) else null,
+            .delete = if (obj.get("delete")) |val| try Operation.parseFromJson(allocator, val) else null,
+            .options = if (obj.get("options")) |val| try Operation.parseFromJson(allocator, val) else null,
+            .head = if (obj.get("head")) |val| try Operation.parseFromJson(allocator, val) else null,
+            .patch = if (obj.get("patch")) |val| try Operation.parseFromJson(allocator, val) else null,
+            .trace = if (obj.get("trace")) |val| try Operation.parseFromJson(allocator, val) else null,
+            .servers = if (servers_list.items.len > 0) try servers_list.toOwnedSlice(allocator) else null,
+            .parameters = if (parameters_list.items.len > 0) try parameters_list.toOwnedSlice(allocator) else null,
+        };
+    }
+
+    pub fn deinit(self: *PathItem, allocator: std.mem.Allocator) void {
+        if (self.ref) |ref| allocator.free(ref);
+        if (self.summary) |summary| allocator.free(summary);
+        if (self.description) |description| allocator.free(description);
+        if (self.get) |*get| get.deinit(allocator);
+        if (self.put) |*put| put.deinit(allocator);
+        if (self.post) |*post| post.deinit(allocator);
+        if (self.delete) |*delete| delete.deinit(allocator);
+        if (self.options) |*options| options.deinit(allocator);
+        if (self.head) |*head| head.deinit(allocator);
+        if (self.patch) |*patch| patch.deinit(allocator);
+        if (self.trace) |*trace| trace.deinit(allocator);
+        if (self.servers) |servers| {
+            for (servers) |*server| {
+                var mutable_server = @constCast(server);
+                mutable_server.deinit(allocator);
+            }
+            allocator.free(servers);
+        }
+        if (self.parameters) |parameters| {
+            for (parameters) |*param| {
+                var mutable_param = @constCast(param);
+                mutable_param.deinit(allocator);
+            }
+            allocator.free(parameters);
+        }
+    }
+};
+
+pub const Paths = struct {
+    path_items: std.StringHashMap(PathItem),
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Paths {
+        var path_items_map = std.StringHashMap(PathItem).init(allocator);
+        errdefer path_items_map.deinit();
+        const obj = value.object;
+        for (obj.keys()) |key| {
+            if (key[0] == '/') {
+                try path_items_map.put(try allocator.dupe(u8, key), try PathItem.parseFromJson(allocator, obj.get(key).?));
+            }
+        }
+        return Paths{ .path_items = path_items_map };
+    }
+
+    pub fn deinit(self: *Paths, allocator: std.mem.Allocator) void {
+        var iterator = self.path_items.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(allocator);
+        }
+        self.path_items.deinit();
+    }
+};

--- a/src/models/v3.2/reference.zig
+++ b/src/models/v3.2/reference.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const json = std.json;
+
+pub const Reference = struct {
+    ref: []const u8,
+    summary: ?[]const u8 = null,
+    description: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Reference {
+        const obj = value.object;
+        return Reference{
+            .ref = try allocator.dupe(u8, obj.get("$ref").?.string),
+            .summary = if (obj.get("summary")) |val| try allocator.dupe(u8, val.string) else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *Reference, allocator: std.mem.Allocator) void {
+        allocator.free(self.ref);
+        if (self.summary) |summary| allocator.free(summary);
+        if (self.description) |description| allocator.free(description);
+    }
+};

--- a/src/models/v3.2/requestbody.zig
+++ b/src/models/v3.2/requestbody.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const json = std.json;
+const MediaType = @import("media.zig").MediaType;
+const Reference = @import("reference.zig").Reference;
+
+pub const RequestBody = struct {
+    content: std.StringHashMap(MediaType),
+    description: ?[]const u8 = null,
+    required: ?bool = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!RequestBody {
+        const obj = value.object;
+        var content_map = std.StringHashMap(MediaType).init(allocator);
+        if (obj.get("content")) |content_val| {
+            for (content_val.object.keys()) |key| {
+                try content_map.put(try allocator.dupe(u8, key), try MediaType.parseFromJson(allocator, content_val.object.get(key).?));
+            }
+        }
+        return RequestBody{
+            .content = content_map,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .required = if (obj.get("required")) |val| val.bool else null,
+        };
+    }
+
+    pub fn deinit(self: *RequestBody, allocator: std.mem.Allocator) void {
+        if (self.description) |description| allocator.free(description);
+        var iterator = self.content.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(allocator);
+        }
+        self.content.deinit();
+    }
+};
+
+pub const RequestBodyOrReference = union(enum) {
+    request_body: RequestBody,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!RequestBodyOrReference {
+        if (value.object.get("$ref") != null) {
+            return RequestBodyOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            return RequestBodyOrReference{ .request_body = try RequestBody.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *RequestBodyOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .request_body => |*request_body| request_body.deinit(allocator),
+            .reference => |*reference| reference.deinit(allocator),
+        }
+    }
+};

--- a/src/models/v3.2/response.zig
+++ b/src/models/v3.2/response.zig
@@ -1,0 +1,120 @@
+const std = @import("std");
+const json = std.json;
+const MediaType = @import("media.zig").MediaType;
+const HeaderOrReference = @import("media.zig").HeaderOrReference;
+const LinkOrReference = @import("link.zig").LinkOrReference;
+const Reference = @import("reference.zig").Reference;
+
+pub const Response = struct {
+    description: []const u8,
+    headers: ?std.StringHashMap(HeaderOrReference) = null,
+    content: ?std.StringHashMap(MediaType) = null,
+    links: ?std.StringHashMap(LinkOrReference) = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Response {
+        const obj = value.object;
+        var headers_map = std.StringHashMap(HeaderOrReference).init(allocator);
+        if (obj.get("headers")) |headers_val| {
+            for (headers_val.object.keys()) |key| {
+                try headers_map.put(try allocator.dupe(u8, key), try HeaderOrReference.parseFromJson(allocator, headers_val.object.get(key).?));
+            }
+        }
+        var content_map = std.StringHashMap(MediaType).init(allocator);
+        if (obj.get("content")) |content_val| {
+            for (content_val.object.keys()) |key| {
+                try content_map.put(try allocator.dupe(u8, key), try MediaType.parseFromJson(allocator, content_val.object.get(key).?));
+            }
+        }
+        var links_map = std.StringHashMap(LinkOrReference).init(allocator);
+        if (obj.get("links")) |links_val| {
+            for (links_val.object.keys()) |key| {
+                try links_map.put(try allocator.dupe(u8, key), try LinkOrReference.parseFromJson(allocator, links_val.object.get(key).?));
+            }
+        }
+        return Response{
+            .description = try allocator.dupe(u8, obj.get("description").?.string),
+            .headers = if (headers_map.count() > 0) headers_map else null,
+            .content = if (content_map.count() > 0) content_map else null,
+            .links = if (links_map.count() > 0) links_map else null,
+        };
+    }
+
+    pub fn deinit(self: *Response, allocator: std.mem.Allocator) void {
+        allocator.free(self.description);
+        if (self.headers) |*headers| {
+            var iterator = headers.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            headers.deinit();
+        }
+        if (self.content) |*content| {
+            var iterator = content.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            content.deinit();
+        }
+        if (self.links) |*links| {
+            var iterator = links.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            links.deinit();
+        }
+    }
+};
+
+pub const ResponseOrReference = union(enum) {
+    response: Response,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!ResponseOrReference {
+        if (value.object.get("$ref") != null) {
+            return ResponseOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            return ResponseOrReference{ .response = try Response.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *ResponseOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .response => |*response| response.deinit(allocator),
+            .reference => |*reference| reference.deinit(allocator),
+        }
+    }
+};
+
+pub const Responses = struct {
+    default: ?ResponseOrReference = null,
+    status_codes: std.StringHashMap(ResponseOrReference),
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Responses {
+        var status_codes_map = std.StringHashMap(ResponseOrReference).init(allocator);
+        const obj = value.object;
+        for (obj.keys()) |key| {
+            if (std.ascii.isDigit(key[0])) {
+                try status_codes_map.put(try allocator.dupe(u8, key), try ResponseOrReference.parseFromJson(allocator, obj.get(key).?));
+            }
+        }
+        return Responses{
+            .default = if (obj.get("default")) |val| try ResponseOrReference.parseFromJson(allocator, val) else null,
+            .status_codes = status_codes_map,
+        };
+    }
+
+    pub fn deinit(self: *Responses, allocator: std.mem.Allocator) void {
+        if (self.default) |*default| {
+            default.deinit(allocator);
+        }
+        var iterator = self.status_codes.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(allocator);
+        }
+        self.status_codes.deinit();
+    }
+};

--- a/src/models/v3.2/schema.zig
+++ b/src/models/v3.2/schema.zig
@@ -1,0 +1,320 @@
+const std = @import("std");
+const json = std.json;
+const Reference = @import("reference.zig").Reference;
+const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
+
+pub const XML = struct {
+    name: ?[]const u8 = null,
+    namespace: ?[]const u8 = null,
+    prefix: ?[]const u8 = null,
+    attribute: ?bool = null,
+    wrapped: ?bool = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!XML {
+        const obj = value.object;
+        return XML{
+            .name = if (obj.get("name")) |val| try allocator.dupe(u8, val.string) else null,
+            .namespace = if (obj.get("namespace")) |val| try allocator.dupe(u8, val.string) else null,
+            .prefix = if (obj.get("prefix")) |val| try allocator.dupe(u8, val.string) else null,
+            .attribute = if (obj.get("attribute")) |val| val.bool else null,
+            .wrapped = if (obj.get("wrapped")) |val| val.bool else null,
+        };
+    }
+
+    pub fn deinit(self: *XML, allocator: std.mem.Allocator) void {
+        if (self.name) |name| allocator.free(name);
+        if (self.namespace) |namespace| allocator.free(namespace);
+        if (self.prefix) |prefix| allocator.free(prefix);
+    }
+};
+
+pub const Discriminator = struct {
+    propertyName: []const u8,
+    mapping: ?std.StringHashMap([]const u8) = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Discriminator {
+        const obj = value.object;
+        var mapping_map = std.StringHashMap([]const u8).init(allocator);
+        errdefer mapping_map.deinit();
+        if (obj.get("mapping")) |map_val| {
+            for (map_val.object.keys()) |key| {
+                try mapping_map.put(try allocator.dupe(u8, key), try allocator.dupe(u8, map_val.object.get(key).?.string));
+            }
+        }
+        return Discriminator{
+            .propertyName = try allocator.dupe(u8, obj.get("propertyName").?.string),
+            .mapping = if (mapping_map.count() > 0) mapping_map else null,
+        };
+    }
+
+    pub fn deinit(self: *Discriminator, allocator: std.mem.Allocator) void {
+        allocator.free(self.propertyName);
+        if (self.mapping) |*map| {
+            var iterator = map.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                allocator.free(entry.value_ptr.*);
+            }
+            map.deinit();
+        }
+    }
+};
+
+pub const AdditionalProperties = union(enum) {
+    boolean: bool,
+    schema_or_reference: SchemaOrReference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!AdditionalProperties {
+        switch (value) {
+            .bool => |bool_val| return AdditionalProperties{ .boolean = bool_val },
+            .object => return AdditionalProperties{ .schema_or_reference = try SchemaOrReference.parseFromJson(allocator, value) },
+            else => return error.InvalidAdditionalPropertiesType,
+        }
+    }
+};
+
+pub const SchemaOrReference = union(enum) {
+    schema: *Schema,
+    reference: Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!SchemaOrReference {
+        if (value.object.get("$ref") != null) {
+            return SchemaOrReference{ .reference = try Reference.parseFromJson(allocator, value) };
+        } else {
+            const schema = try allocator.create(Schema);
+            errdefer allocator.destroy(schema);
+            schema.* = try Schema.parseFromJson(allocator, value);
+            return SchemaOrReference{ .schema = schema };
+        }
+    }
+
+    pub fn deinit(self: *SchemaOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .schema => |schema| {
+                schema.deinit(allocator);
+                allocator.destroy(schema);
+            },
+            .reference => |*ref| ref.deinit(allocator),
+        }
+    }
+};
+
+/// OpenAPI 3.2 Schema supports `type` as either a single string or an array of strings
+/// (e.g. `["string", "null"]` for nullable types instead of the `nullable` boolean).
+pub const Schema = struct {
+    title: ?[]const u8 = null,
+    multipleOf: ?f64 = null,
+    maximum: ?f64 = null,
+    exclusiveMaximum: ?bool = null,
+    minimum: ?f64 = null,
+    exclusiveMinimum: ?bool = null,
+    maxLength: ?i64 = null,
+    minLength: ?i64 = null,
+    pattern: ?[]const u8 = null,
+    maxItems: ?i64 = null,
+    minItems: ?i64 = null,
+    uniqueItems: ?bool = null,
+    maxProperties: ?i64 = null,
+    minProperties: ?i64 = null,
+    required: ?[]const []const u8 = null,
+    enum_values: ?[]const json.Value = null,
+    type: ?[]const u8 = null,
+    type_array: ?[]const []const u8 = null,
+    not: ?SchemaOrReference = null,
+    allOf: ?[]const SchemaOrReference = null,
+    oneOf: ?[]const SchemaOrReference = null,
+    anyOf: ?[]const SchemaOrReference = null,
+    items: ?SchemaOrReference = null,
+    properties: ?std.StringHashMap(SchemaOrReference) = null,
+    additionalProperties: ?AdditionalProperties = null,
+    description: ?[]const u8 = null,
+    format: ?[]const u8 = null,
+    default: ?json.Value = null,
+    nullable: ?bool = null,
+    discriminator: ?Discriminator = null,
+    readOnly: ?bool = null,
+    writeOnly: ?bool = null,
+    example: ?json.Value = null,
+    externalDocs: ?ExternalDocumentation = null,
+    deprecated: ?bool = null,
+    xml: ?XML = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Schema {
+        const obj = value.object;
+        var required_list = std.ArrayList([]const u8){};
+        errdefer required_list.deinit(allocator);
+        if (obj.get("required")) |req_val| {
+            for (req_val.array.items) |item| {
+                try required_list.append(allocator, try allocator.dupe(u8, item.string));
+            }
+        }
+        var enum_list = std.ArrayList(json.Value){};
+        errdefer enum_list.deinit(allocator);
+        if (obj.get("enum")) |enum_val| {
+            for (enum_val.array.items) |item| {
+                try enum_list.append(allocator, item);
+            }
+        }
+        var all_of_list = std.ArrayList(SchemaOrReference){};
+        errdefer all_of_list.deinit(allocator);
+        if (obj.get("allOf")) |all_of_val| {
+            for (all_of_val.array.items) |item| {
+                try all_of_list.append(allocator, try SchemaOrReference.parseFromJson(allocator, item));
+            }
+        }
+        var one_of_list = std.ArrayList(SchemaOrReference){};
+        errdefer one_of_list.deinit(allocator);
+        if (obj.get("oneOf")) |one_of_val| {
+            for (one_of_val.array.items) |item| {
+                try one_of_list.append(allocator, try SchemaOrReference.parseFromJson(allocator, item));
+            }
+        }
+        var any_of_list = std.ArrayList(SchemaOrReference){};
+        errdefer any_of_list.deinit(allocator);
+        if (obj.get("anyOf")) |any_of_val| {
+            for (any_of_val.array.items) |item| {
+                try any_of_list.append(allocator, try SchemaOrReference.parseFromJson(allocator, item));
+            }
+        }
+        var properties_map = std.StringHashMap(SchemaOrReference).init(allocator);
+        errdefer properties_map.deinit();
+        if (obj.get("properties")) |props_val| {
+            for (props_val.object.keys()) |key| {
+                try properties_map.put(try allocator.dupe(u8, key), try SchemaOrReference.parseFromJson(allocator, props_val.object.get(key).?));
+            }
+        }
+
+        // In OpenAPI 3.2, "type" can be a string or an array of strings
+        var type_str: ?[]const u8 = null;
+        var type_array: ?[]const []const u8 = null;
+        if (obj.get("type")) |type_val| {
+            switch (type_val) {
+                .string => |s| {
+                    type_str = try allocator.dupe(u8, s);
+                },
+                .array => |arr| {
+                    var type_list = std.ArrayList([]const u8){};
+                    errdefer type_list.deinit(allocator);
+                    for (arr.items) |item| {
+                        try type_list.append(allocator, try allocator.dupe(u8, item.string));
+                    }
+                    type_array = try type_list.toOwnedSlice(allocator);
+                },
+                else => {},
+            }
+        }
+
+        return Schema{
+            .title = if (obj.get("title")) |val| try allocator.dupe(u8, val.string) else null,
+            .multipleOf = if (obj.get("multipleOf")) |val| val.float else null,
+            .maximum = if (obj.get("maximum")) |val| val.float else null,
+            .exclusiveMaximum = if (obj.get("exclusiveMaximum")) |val| val.bool else null,
+            .minimum = if (obj.get("minimum")) |val| val.float else null,
+            .exclusiveMinimum = if (obj.get("exclusiveMinimum")) |val| val.bool else null,
+            .maxLength = if (obj.get("maxLength")) |val| val.integer else null,
+            .minLength = if (obj.get("minLength")) |val| val.integer else null,
+            .pattern = if (obj.get("pattern")) |val| try allocator.dupe(u8, val.string) else null,
+            .maxItems = if (obj.get("maxItems")) |val| val.integer else null,
+            .minItems = if (obj.get("minItems")) |val| val.integer else null,
+            .uniqueItems = if (obj.get("uniqueItems")) |val| val.bool else null,
+            .maxProperties = if (obj.get("maxProperties")) |val| val.integer else null,
+            .minProperties = if (obj.get("minProperties")) |val| val.integer else null,
+            .required = if (required_list.items.len > 0) try required_list.toOwnedSlice(allocator) else null,
+            .enum_values = if (enum_list.items.len > 0) try enum_list.toOwnedSlice(allocator) else null,
+            .type = type_str,
+            .type_array = type_array,
+            .not = if (obj.get("not")) |val| try SchemaOrReference.parseFromJson(allocator, val) else null,
+            .allOf = if (all_of_list.items.len > 0) try all_of_list.toOwnedSlice(allocator) else null,
+            .oneOf = if (one_of_list.items.len > 0) try one_of_list.toOwnedSlice(allocator) else null,
+            .anyOf = if (any_of_list.items.len > 0) try any_of_list.toOwnedSlice(allocator) else null,
+            .items = if (obj.get("items")) |val| try SchemaOrReference.parseFromJson(allocator, val) else null,
+            .properties = if (properties_map.count() > 0) properties_map else null,
+            .additionalProperties = if (obj.get("additionalProperties")) |val| try AdditionalProperties.parseFromJson(allocator, val) else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .format = if (obj.get("format")) |val| try allocator.dupe(u8, val.string) else null,
+            .default = if (obj.get("default")) |val| val else null,
+            .nullable = if (obj.get("nullable")) |val| val.bool else null,
+            .discriminator = if (obj.get("discriminator")) |val| try Discriminator.parseFromJson(allocator, val) else null,
+            .readOnly = if (obj.get("readOnly")) |val| val.bool else null,
+            .writeOnly = if (obj.get("writeOnly")) |val| val.bool else null,
+            .example = if (obj.get("example")) |val| val else null,
+            .externalDocs = if (obj.get("externalDocs")) |val| try ExternalDocumentation.parseFromJson(allocator, val) else null,
+            .deprecated = if (obj.get("deprecated")) |val| val.bool else null,
+            .xml = if (obj.get("xml")) |val| try XML.parseFromJson(allocator, val) else null,
+        };
+    }
+
+    pub fn deinit(self: *Schema, allocator: std.mem.Allocator) void {
+        if (self.title) |title| allocator.free(title);
+        if (self.pattern) |pattern| allocator.free(pattern);
+        if (self.type) |type_val| allocator.free(type_val);
+        if (self.type_array) |type_arr| {
+            for (type_arr) |t| {
+                allocator.free(t);
+            }
+            allocator.free(type_arr);
+        }
+        if (self.description) |description| allocator.free(description);
+        if (self.format) |format| allocator.free(format);
+        if (self.properties) |props| {
+            var iterator = props.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            var mutable_props = @constCast(&props);
+            mutable_props.deinit();
+        }
+        if (self.items) |*items| {
+            items.deinit(allocator);
+        }
+        if (self.required) |req| {
+            for (req) |item| {
+                allocator.free(item);
+            }
+            allocator.free(req);
+        }
+        if (self.allOf) |allOf| {
+            for (allOf) |*item| {
+                var mutable_item = @constCast(item);
+                mutable_item.deinit(allocator);
+            }
+            allocator.free(allOf);
+        }
+        if (self.oneOf) |oneOf| {
+            for (oneOf) |*item| {
+                var mutable_item = @constCast(item);
+                mutable_item.deinit(allocator);
+            }
+            allocator.free(oneOf);
+        }
+        if (self.anyOf) |anyOf| {
+            for (anyOf) |*item| {
+                var mutable_item = @constCast(item);
+                mutable_item.deinit(allocator);
+            }
+            allocator.free(anyOf);
+        }
+        if (self.not) |*not| {
+            not.deinit(allocator);
+        }
+        if (self.additionalProperties) |*additionalProperties| {
+            switch (additionalProperties.*) {
+                .schema_or_reference => |*schema_ref| schema_ref.deinit(allocator),
+                .boolean => {},
+            }
+        }
+        if (self.discriminator) |*discriminator| {
+            discriminator.deinit(allocator);
+        }
+        if (self.externalDocs) |*externalDocs| {
+            externalDocs.deinit(allocator);
+        }
+        if (self.enum_values) |enum_values| {
+            allocator.free(enum_values);
+        }
+        if (self.xml) |*xml| {
+            xml.deinit(allocator);
+        }
+    }
+};

--- a/src/models/v3.2/security.zig
+++ b/src/models/v3.2/security.zig
@@ -1,0 +1,356 @@
+const std = @import("std");
+const json = std.json;
+
+pub const SecurityRequirement = struct {
+    schemes: std.StringHashMap([]const []const u8),
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!SecurityRequirement {
+        var schemes_map = std.StringHashMap([]const []const u8).init(allocator);
+        errdefer schemes_map.deinit();
+        const obj = value.object;
+        for (obj.keys()) |key| {
+            var scopes_list = std.ArrayList([]const u8){};
+            errdefer scopes_list.deinit(allocator);
+            for (obj.get(key).?.array.items) |item| {
+                try scopes_list.append(allocator, try allocator.dupe(u8, item.string));
+            }
+            try schemes_map.put(try allocator.dupe(u8, key), try scopes_list.toOwnedSlice(allocator));
+        }
+        return SecurityRequirement{ .schemes = schemes_map };
+    }
+
+    pub fn deinit(self: *SecurityRequirement, allocator: std.mem.Allocator) void {
+        var iterator = self.schemes.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            for (entry.value_ptr.*) |scope| {
+                allocator.free(scope);
+            }
+            allocator.free(entry.value_ptr.*);
+        }
+        self.schemes.deinit();
+    }
+};
+
+pub const OAuthFlows = struct {
+    implicit: ?ImplicitOAuthFlow = null,
+    password: ?PasswordOAuthFlow = null,
+    clientCredentials: ?ClientCredentialsFlow = null,
+    authorizationCode: ?AuthorizationCodeOAuthFlow = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!OAuthFlows {
+        const obj = value.object;
+        return OAuthFlows{
+            .implicit = if (obj.get("implicit")) |val| try ImplicitOAuthFlow.parseFromJson(allocator, val) else null,
+            .password = if (obj.get("password")) |val| try PasswordOAuthFlow.parseFromJson(allocator, val) else null,
+            .clientCredentials = if (obj.get("clientCredentials")) |val| try ClientCredentialsFlow.parseFromJson(allocator, val) else null,
+            .authorizationCode = if (obj.get("authorizationCode")) |val| try AuthorizationCodeOAuthFlow.parseFromJson(allocator, val) else null,
+        };
+    }
+
+    pub fn deinit(self: *OAuthFlows, allocator: std.mem.Allocator) void {
+        if (self.implicit) |*flow| {
+            flow.deinit(allocator);
+        }
+        if (self.password) |*flow| {
+            flow.deinit(allocator);
+        }
+        if (self.clientCredentials) |*flow| {
+            flow.deinit(allocator);
+        }
+        if (self.authorizationCode) |*flow| {
+            flow.deinit(allocator);
+        }
+    }
+};
+
+pub const ImplicitOAuthFlow = struct {
+    authorizationUrl: []const u8,
+    scopes: std.StringHashMap([]const u8),
+    refreshUrl: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!ImplicitOAuthFlow {
+        const obj = value.object;
+        var scopes_map = std.StringHashMap([]const u8).init(allocator);
+        if (obj.get("scopes")) |scopes_val| {
+            for (scopes_val.object.keys()) |key| {
+                try scopes_map.put(try allocator.dupe(u8, key), try allocator.dupe(u8, scopes_val.object.get(key).?.string));
+            }
+        }
+        return ImplicitOAuthFlow{
+            .authorizationUrl = try allocator.dupe(u8, obj.get("authorizationUrl").?.string),
+            .scopes = scopes_map,
+            .refreshUrl = if (obj.get("refreshUrl")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *ImplicitOAuthFlow, allocator: std.mem.Allocator) void {
+        allocator.free(self.authorizationUrl);
+        var iterator = self.scopes.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            allocator.free(entry.value_ptr.*);
+        }
+        self.scopes.deinit();
+        if (self.refreshUrl) |url| {
+            allocator.free(url);
+        }
+    }
+};
+
+pub const PasswordOAuthFlow = struct {
+    tokenUrl: []const u8,
+    scopes: std.StringHashMap([]const u8),
+    refreshUrl: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!PasswordOAuthFlow {
+        const obj = value.object;
+        var scopes_map = std.StringHashMap([]const u8).init(allocator);
+        if (obj.get("scopes")) |scopes_val| {
+            for (scopes_val.object.keys()) |key| {
+                try scopes_map.put(try allocator.dupe(u8, key), try allocator.dupe(u8, scopes_val.object.get(key).?.string));
+            }
+        }
+        return PasswordOAuthFlow{
+            .tokenUrl = try allocator.dupe(u8, obj.get("tokenUrl").?.string),
+            .scopes = scopes_map,
+            .refreshUrl = if (obj.get("refreshUrl")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *PasswordOAuthFlow, allocator: std.mem.Allocator) void {
+        allocator.free(self.tokenUrl);
+        var iterator = self.scopes.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            allocator.free(entry.value_ptr.*);
+        }
+        self.scopes.deinit();
+        if (self.refreshUrl) |url| {
+            allocator.free(url);
+        }
+    }
+};
+
+pub const ClientCredentialsFlow = struct {
+    tokenUrl: []const u8,
+    scopes: std.StringHashMap([]const u8),
+    refreshUrl: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!ClientCredentialsFlow {
+        const obj = value.object;
+        var scopes_map = std.StringHashMap([]const u8).init(allocator);
+        if (obj.get("scopes")) |scopes_val| {
+            for (scopes_val.object.keys()) |key| {
+                try scopes_map.put(try allocator.dupe(u8, key), try allocator.dupe(u8, scopes_val.object.get(key).?.string));
+            }
+        }
+        return ClientCredentialsFlow{
+            .tokenUrl = try allocator.dupe(u8, obj.get("tokenUrl").?.string),
+            .scopes = scopes_map,
+            .refreshUrl = if (obj.get("refreshUrl")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *ClientCredentialsFlow, allocator: std.mem.Allocator) void {
+        allocator.free(self.tokenUrl);
+        var iterator = self.scopes.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            allocator.free(entry.value_ptr.*);
+        }
+        self.scopes.deinit();
+        if (self.refreshUrl) |url| {
+            allocator.free(url);
+        }
+    }
+};
+
+pub const AuthorizationCodeOAuthFlow = struct {
+    authorizationUrl: []const u8,
+    tokenUrl: []const u8,
+    scopes: std.StringHashMap([]const u8),
+    refreshUrl: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!AuthorizationCodeOAuthFlow {
+        const obj = value.object;
+        var scopes_map = std.StringHashMap([]const u8).init(allocator);
+        if (obj.get("scopes")) |scopes_val| {
+            for (scopes_val.object.keys()) |key| {
+                try scopes_map.put(try allocator.dupe(u8, key), try allocator.dupe(u8, scopes_val.object.get(key).?.string));
+            }
+        }
+        return AuthorizationCodeOAuthFlow{
+            .authorizationUrl = try allocator.dupe(u8, obj.get("authorizationUrl").?.string),
+            .tokenUrl = try allocator.dupe(u8, obj.get("tokenUrl").?.string),
+            .scopes = scopes_map,
+            .refreshUrl = if (obj.get("refreshUrl")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *AuthorizationCodeOAuthFlow, allocator: std.mem.Allocator) void {
+        allocator.free(self.authorizationUrl);
+        allocator.free(self.tokenUrl);
+        var iterator = self.scopes.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            allocator.free(entry.value_ptr.*);
+        }
+        self.scopes.deinit();
+        if (self.refreshUrl) |url| {
+            allocator.free(url);
+        }
+    }
+};
+
+pub const APIKeySecurityScheme = struct {
+    type: []const u8,
+    name: []const u8,
+    in_field: []const u8,
+    description: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!APIKeySecurityScheme {
+        const obj = value.object;
+        return APIKeySecurityScheme{
+            .type = try allocator.dupe(u8, obj.get("type").?.string),
+            .name = try allocator.dupe(u8, obj.get("name").?.string),
+            .in_field = try allocator.dupe(u8, obj.get("in").?.string),
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *APIKeySecurityScheme, allocator: std.mem.Allocator) void {
+        allocator.free(self.type);
+        allocator.free(self.name);
+        allocator.free(self.in_field);
+        if (self.description) |desc| {
+            allocator.free(desc);
+        }
+    }
+};
+
+pub const HTTPSecurityScheme = struct {
+    scheme: []const u8,
+    type: []const u8,
+    bearerFormat: ?[]const u8 = null,
+    description: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!HTTPSecurityScheme {
+        const obj = value.object;
+        return HTTPSecurityScheme{
+            .scheme = try allocator.dupe(u8, obj.get("scheme").?.string),
+            .type = try allocator.dupe(u8, obj.get("type").?.string),
+            .bearerFormat = if (obj.get("bearerFormat")) |val| try allocator.dupe(u8, val.string) else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *HTTPSecurityScheme, allocator: std.mem.Allocator) void {
+        allocator.free(self.scheme);
+        allocator.free(self.type);
+        if (self.bearerFormat) |bf| {
+            allocator.free(bf);
+        }
+        if (self.description) |desc| {
+            allocator.free(desc);
+        }
+    }
+};
+
+pub const OAuth2SecurityScheme = struct {
+    type: []const u8,
+    flows: OAuthFlows,
+    description: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!OAuth2SecurityScheme {
+        const obj = value.object;
+        return OAuth2SecurityScheme{
+            .type = try allocator.dupe(u8, obj.get("type").?.string),
+            .flows = try OAuthFlows.parseFromJson(allocator, obj.get("flows").?),
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *OAuth2SecurityScheme, allocator: std.mem.Allocator) void {
+        allocator.free(self.type);
+        self.flows.deinit(allocator);
+        if (self.description) |desc| {
+            allocator.free(desc);
+        }
+    }
+};
+
+pub const OpenIdConnectSecurityScheme = struct {
+    type: []const u8,
+    openIdConnectUrl: []const u8,
+    description: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!OpenIdConnectSecurityScheme {
+        const obj = value.object;
+        return OpenIdConnectSecurityScheme{
+            .type = try allocator.dupe(u8, obj.get("type").?.string),
+            .openIdConnectUrl = try allocator.dupe(u8, obj.get("openIdConnectUrl").?.string),
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: *OpenIdConnectSecurityScheme, allocator: std.mem.Allocator) void {
+        allocator.free(self.type);
+        allocator.free(self.openIdConnectUrl);
+        if (self.description) |desc| {
+            allocator.free(desc);
+        }
+    }
+};
+
+pub const SecurityScheme = union(enum) {
+    api_key: APIKeySecurityScheme,
+    http: HTTPSecurityScheme,
+    oauth2: OAuth2SecurityScheme,
+    openIdConnect: OpenIdConnectSecurityScheme,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!SecurityScheme {
+        const obj = value.object;
+        const type_str = obj.get("type").?.string;
+        if (std.mem.eql(u8, type_str, "apiKey")) {
+            return SecurityScheme{ .api_key = try APIKeySecurityScheme.parseFromJson(allocator, value) };
+        } else if (std.mem.eql(u8, type_str, "http")) {
+            return SecurityScheme{ .http = try HTTPSecurityScheme.parseFromJson(allocator, value) };
+        } else if (std.mem.eql(u8, type_str, "oauth2")) {
+            return SecurityScheme{ .oauth2 = try OAuth2SecurityScheme.parseFromJson(allocator, value) };
+        } else if (std.mem.eql(u8, type_str, "openIdConnect")) {
+            return SecurityScheme{ .openIdConnect = try OpenIdConnectSecurityScheme.parseFromJson(allocator, value) };
+        } else {
+            return error.UnknownSecuritySchemeType;
+        }
+    }
+
+    pub fn deinit(self: *SecurityScheme, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .api_key => |*api_key| api_key.deinit(allocator),
+            .http => |*http| http.deinit(allocator),
+            .oauth2 => |*oauth2| oauth2.deinit(allocator),
+            .openIdConnect => |*openIdConnect| openIdConnect.deinit(allocator),
+        }
+    }
+};
+
+pub const SecuritySchemeOrReference = union(enum) {
+    security_scheme: SecurityScheme,
+    reference: @import("reference.zig").Reference,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!SecuritySchemeOrReference {
+        if (value.object.get("$ref") != null) {
+            return SecuritySchemeOrReference{ .reference = try @import("reference.zig").Reference.parseFromJson(allocator, value) };
+        } else {
+            return SecuritySchemeOrReference{ .security_scheme = try SecurityScheme.parseFromJson(allocator, value) };
+        }
+    }
+
+    pub fn deinit(self: *SecuritySchemeOrReference, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .security_scheme => |*security_scheme| security_scheme.deinit(allocator),
+            .reference => |*reference| reference.deinit(allocator),
+        }
+    }
+};

--- a/src/models/v3.2/server.zig
+++ b/src/models/v3.2/server.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const json = std.json;
+
+pub const ServerVariable = struct {
+    default: []const u8,
+    enum_values: ?[]const []const u8 = null,
+    description: ?[]const u8 = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!ServerVariable {
+        const obj = value.object;
+        var enum_list = std.ArrayList([]const u8){};
+        errdefer enum_list.deinit(allocator);
+
+        if (obj.get("enum")) |enum_val| {
+            for (enum_val.array.items) |item| {
+                try enum_list.append(allocator, try allocator.dupe(u8, item.string));
+            }
+        }
+
+        return ServerVariable{
+            .default = try allocator.dupe(u8, obj.get("default").?.string),
+            .enum_values = if (enum_list.items.len > 0) try enum_list.toOwnedSlice(allocator) else null,
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+        };
+    }
+
+    pub fn deinit(self: ServerVariable, allocator: std.mem.Allocator) void {
+        allocator.free(self.default);
+        if (self.description) |desc| allocator.free(desc);
+        if (self.enum_values) |enum_vals| {
+            for (enum_vals) |val| {
+                allocator.free(val);
+            }
+            allocator.free(enum_vals);
+        }
+    }
+};
+
+pub const Server = struct {
+    url: []const u8,
+    description: ?[]const u8 = null,
+    variables: ?std.StringHashMap(ServerVariable) = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Server {
+        const obj = value.object;
+        var variables_map = std.StringHashMap(ServerVariable).init(allocator);
+        errdefer variables_map.deinit();
+
+        if (obj.get("variables")) |vars_val| {
+            for (vars_val.object.keys()) |key| {
+                try variables_map.put(try allocator.dupe(u8, key), try ServerVariable.parseFromJson(allocator, vars_val.object.get(key).?));
+            }
+        }
+
+        return Server{
+            .url = try allocator.dupe(u8, obj.get("url").?.string),
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .variables = if (variables_map.count() > 0) variables_map else null,
+        };
+    }
+
+    pub fn deinit(self: *Server, allocator: std.mem.Allocator) void {
+        allocator.free(self.url);
+        if (self.description) |desc| allocator.free(desc);
+        if (self.variables) |*vars| {
+            var iterator = vars.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            vars.deinit();
+        }
+    }
+};

--- a/src/models/v3.2/tag.zig
+++ b/src/models/v3.2/tag.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const json = std.json;
+const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
+
+pub const Tag = struct {
+    name: []const u8,
+    description: ?[]const u8 = null,
+    externalDocs: ?ExternalDocumentation = null,
+
+    pub fn parseFromJson(allocator: std.mem.Allocator, value: json.Value) anyerror!Tag {
+        const obj = value.object;
+        return Tag{
+            .name = try allocator.dupe(u8, obj.get("name").?.string),
+            .description = if (obj.get("description")) |val| try allocator.dupe(u8, val.string) else null,
+            .externalDocs = if (obj.get("externalDocs")) |val| try ExternalDocumentation.parseFromJson(allocator, val) else null,
+        };
+    }
+
+    pub fn deinit(self: Tag, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        if (self.description) |desc| allocator.free(desc);
+        if (self.externalDocs) |docs| docs.deinit(allocator);
+    }
+};

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,9 +1,11 @@
 const openapi_v3_tests = @import("tests/openapi_v3_tests.zig");
+const openapi_v32_tests = @import("tests/openapi_v32_tests.zig");
 const swagger_v2_tests = @import("tests/swagger_v2_tests.zig");
 const unified_converter_tests = @import("tests/unified_converter_tests.zig");
 const comprehensive_converter_tests = @import("tests/comprehensive_converter_tests.zig");
 comptime {
     _ = openapi_v3_tests;
+    _ = openapi_v32_tests;
     _ = swagger_v2_tests;
     _ = unified_converter_tests;
     _ = comprehensive_converter_tests;

--- a/src/tests/openapi_v32_tests.zig
+++ b/src/tests/openapi_v32_tests.zig
@@ -1,0 +1,347 @@
+const OpenApi32Converter = @import("../generators/converters/openapi32_converter.zig").OpenApi32Converter;
+const models = @import("../models.zig");
+const std = @import("std");
+const test_utils = @import("test_utils.zig");
+
+fn loadOpenApi32Document(allocator: std.mem.Allocator, file_path: []const u8) !models.OpenApi32Document {
+    const file = try std.fs.cwd().openFile(file_path, .{});
+    defer file.close();
+    try file.seekBy(0);
+    const file_contents = try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+    defer allocator.free(file_contents);
+    return try models.OpenApi32Document.parseFromJson(allocator, file_contents);
+}
+
+fn testOpenApi32DocumentParsing(allocator: std.mem.Allocator, file_path: []const u8) !void {
+    var parsed = try loadOpenApi32Document(allocator, file_path);
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.openapi.len > 0);
+    try std.testing.expect(parsed.info.title.len > 0);
+    std.debug.print("Successfully parsed OpenAPI 3.2 document from {s}: {s} (version: {s})\n", .{ file_path, parsed.info.title, parsed.openapi });
+}
+
+test "can deserialize petstore into OpenApi32Document" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expectEqualStrings("3.2.0", parsed.openapi);
+    try std.testing.expectEqualStrings("Swagger Petstore", parsed.info.title);
+}
+
+test "can parse petstore info summary field" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.info.summary != null);
+    try std.testing.expectEqualStrings("A sample API that uses a petstore as an example", parsed.info.summary.?);
+}
+
+test "can parse petstore license identifier" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.info.license != null);
+    try std.testing.expectEqualStrings("Apache-2.0", parsed.info.license.?.identifier.?);
+}
+
+test "can parse petstore paths" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.paths != null);
+    try std.testing.expect(parsed.paths.?.path_items.count() > 0);
+}
+
+test "can parse petstore components schemas" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.components != null);
+    try std.testing.expect(parsed.components.?.schemas != null);
+    try std.testing.expect(parsed.components.?.schemas.?.count() > 0);
+}
+
+test "can parse petstore tags" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.tags != null);
+    try std.testing.expect(parsed.tags.?.len == 3);
+}
+
+test "can parse petstore servers" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.servers != null);
+    try std.testing.expect(parsed.servers.?.len == 1);
+    try std.testing.expectEqualStrings("https://petstore3.swagger.io/api/v3", parsed.servers.?[0].url);
+}
+
+test "can parse petstore security schemes" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.components != null);
+    try std.testing.expect(parsed.components.?.securitySchemes != null);
+    try std.testing.expect(parsed.components.?.securitySchemes.?.count() == 2);
+}
+
+test "can parse petstore-expanded.json" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    try testOpenApi32DocumentParsing(allocator, "openapi/v3.2/petstore-expanded.json");
+}
+
+test "can parse petstore-expanded webhooks" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore-expanded.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.webhooks != null);
+    try std.testing.expect(parsed.webhooks.?.count() == 2);
+}
+
+test "can parse petstore-expanded type arrays for nullable" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore-expanded.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.components != null);
+    try std.testing.expect(parsed.components.?.schemas != null);
+    const schemas = parsed.components.?.schemas.?;
+    const pet_schema_or_ref = schemas.get("Pet").?;
+    switch (pet_schema_or_ref) {
+        .schema => |schema| {
+            try std.testing.expect(schema.properties != null);
+            const tag_prop = schema.properties.?.get("tag").?;
+            switch (tag_prop) {
+                .schema => |tag_schema| {
+                    // "type": ["string", "null"] should populate type_array
+                    try std.testing.expect(tag_schema.type_array != null);
+                    try std.testing.expect(tag_schema.type_array.?.len == 2);
+                },
+                .reference => {
+                    return error.UnexpectedReference;
+                },
+            }
+        },
+        .reference => {
+            return error.UnexpectedReference;
+        },
+    }
+}
+
+test "can parse petstore-expanded multiple servers" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore-expanded.json");
+    defer parsed.deinit(allocator);
+    try std.testing.expect(parsed.servers != null);
+    try std.testing.expect(parsed.servers.?.len == 2);
+}
+
+test "can parse all v3.2 JSON OpenAPI specifications" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const json_files = [_][]const u8{
+        "openapi/v3.2/petstore.json",
+        "openapi/v3.2/petstore-expanded.json",
+    };
+    var successful_parses: u32 = 0;
+    for (json_files) |file_path| {
+        testOpenApi32DocumentParsing(allocator, file_path) catch |err| {
+            std.debug.print("Failed to parse {s}: {}\n", .{ file_path, err });
+            continue;
+        };
+        successful_parses += 1;
+    }
+    std.debug.print("Successfully parsed {d}/{d} JSON OpenAPI 3.2 specifications\n", .{ successful_parses, json_files.len });
+    try std.testing.expect(successful_parses == json_files.len);
+}
+
+fn testOpenApi32ToUnifiedDocumentConversion(allocator: std.mem.Allocator, file_path: []const u8) !void {
+    var parsed = try loadOpenApi32Document(allocator, file_path);
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expect(unified.version.len > 0);
+    try std.testing.expect(unified.info.title.len > 0);
+    try std.testing.expect(std.mem.startsWith(u8, unified.version, "3.2"));
+    std.debug.print("Successfully converted OpenAPI 3.2 document from {s}: {s} (version: {s})\n", .{ file_path, unified.info.title, unified.version });
+}
+
+test "can convert petstore.json to UnifiedDocument" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    try testOpenApi32ToUnifiedDocumentConversion(allocator, "openapi/v3.2/petstore.json");
+}
+
+test "can convert petstore-expanded.json to UnifiedDocument" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    try testOpenApi32ToUnifiedDocumentConversion(allocator, "openapi/v3.2/petstore-expanded.json");
+}
+
+test "converted petstore has correct version" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expectEqualStrings("3.2.0", unified.version);
+}
+
+test "converted petstore has correct title" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expectEqualStrings("Swagger Petstore", unified.info.title);
+}
+
+test "converted petstore has paths" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expect(unified.paths.count() > 0);
+}
+
+test "converted petstore has schemas" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expect(unified.schemas != null);
+    try std.testing.expect(unified.schemas.?.count() > 0);
+}
+
+test "converted petstore has servers" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expect(unified.servers != null);
+    try std.testing.expect(unified.servers.?.len == 1);
+}
+
+test "converted petstore has tags" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expect(unified.tags != null);
+    try std.testing.expect(unified.tags.?.len == 3);
+}
+
+test "converted petstore has external docs" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expect(unified.externalDocs != null);
+}
+
+test "converted petstore-expanded has correct paths" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    var parsed = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore-expanded.json");
+    defer parsed.deinit(allocator);
+    var converter = OpenApi32Converter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+    try std.testing.expect(unified.paths.count() == 2);
+}
+
+test "can convert all v3.2 JSON OpenAPI specifications to UnifiedDocument" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const json_files = [_][]const u8{
+        "openapi/v3.2/petstore.json",
+        "openapi/v3.2/petstore-expanded.json",
+    };
+    var successful_conversions: u32 = 0;
+    for (json_files) |file_path| {
+        testOpenApi32ToUnifiedDocumentConversion(allocator, file_path) catch |err| {
+            std.debug.print("Failed to convert {s}: {}\n", .{ file_path, err });
+            continue;
+        };
+        successful_conversions += 1;
+    }
+    std.debug.print("Successfully converted {d}/{d} JSON OpenAPI v3.2 specifications to UnifiedDocument\n", .{ successful_conversions, json_files.len });
+    try std.testing.expect(successful_conversions == json_files.len);
+}
+
+test "dynamically convert all OpenAPI v3.2 JSON files to UnifiedDocument" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const openapi_dir = try std.fs.cwd().openDir("openapi/v3.2", .{ .iterate = true });
+    var iterator = openapi_dir.iterate();
+    var successful_conversions: u32 = 0;
+    var total_files: u32 = 0;
+    while (try iterator.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".json")) continue;
+        total_files += 1;
+        var path_buffer: [256]u8 = undefined;
+        const full_path = try std.fmt.bufPrint(path_buffer[0..], "openapi/v3.2/{s}", .{entry.name});
+        testOpenApi32ToUnifiedDocumentConversion(allocator, full_path) catch |err| {
+            std.debug.print("✗ Failed to convert OpenAPI v3.2 {s}: {}\n", .{ full_path, err });
+            continue;
+        };
+        successful_conversions += 1;
+    }
+    std.debug.print("Dynamic OpenAPI v3.2 test: {d}/{d} files converted successfully\n", .{ successful_conversions, total_files });
+    try std.testing.expect(successful_conversions == total_files);
+    try std.testing.expect(total_files > 0);
+}
+
+test "memory leak stress test for v3.2 converter" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const iterations = 50;
+    for (0..iterations) |i| {
+        {
+            var openapi_doc = try loadOpenApi32Document(allocator, "openapi/v3.2/petstore.json");
+            defer openapi_doc.deinit(allocator);
+            var converter = OpenApi32Converter.init(allocator);
+            var unified = try converter.convert(openapi_doc);
+            defer unified.deinit(allocator);
+            try std.testing.expect(unified.info.title.len > 0);
+        }
+        if ((i + 1) % 10 == 0) {
+            std.debug.print("Completed {d}/{d} v3.2 stress test iterations\n", .{ i + 1, iterations });
+        }
+    }
+    std.debug.print("✓ v3.2 memory leak stress test passed: {d} iterations completed successfully\n", .{iterations});
+}


### PR DESCRIPTION
Implement full support for parsing, converting, and generating code from OpenAPI 3.2 specifications. This follows the existing unified converter architecture pattern.

New v3.2-specific features:
- Info.summary field for API summary
- License.identifier field for SPDX license identifiers
- Reference.summary and Reference.description fields
- Schema type arrays (e.g. ["string", "null"]) for nullable types
- Components.pathItems field
- Top-level webhooks field (map of PathItemOrReference)
- Top-level jsonSchemaDialect field
- Optional paths (document can have only webhooks)

Changes:
- Add 14 model files in src/models/v3.2/ matching v3.0 patterns
- Add OpenApi32Converter in src/generators/converters/
- Update detector.zig to detect v3.2 version strings
- Update generator.zig to route v3.2 documents through converter
- Update models.zig to export v3.2 types
- Add 2 sample specs in openapi/v3.2/ (petstore, petstore-expanded)
- Add comprehensive test suite with 27 tests covering parsing, conversion, v3.2-specific features, and memory leak stress testing
- Add run-generate-v32 build step
- Update README.md to document v3.2 support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI v3.2 specification support, enabling parsing and processing of v3.2 documents.
  * New API entry points for parsing OpenAPI v3.2 files and converting them to the library's unified representation.
  * Extended version detection to recognize and handle OpenAPI v3.2 documents alongside existing versions.

* **Tests**
  * Added comprehensive test suite validating v3.2 document parsing, conversion, and memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->