### PR TITLE
Add smoke tests for OpenAPI examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,6 @@ jobs:
       - name: Verify Zig installation
         run: zig version
 
-      - name: Generate Code using OpenAPI v3.0 Petstore example
-        run: |
-          zig build run-generate
-          zig run generated/main.zig
+      - name: Run smoke tests
+        shell: pwsh
+        run: ./test/smoke-tests.ps1 -Optimize ReleaseFast

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ generated/swagger-petstore-expanded.zig
 generated/swagger-petstore.zig
 generated/petstore_v2_unified.zig
 generated/petstore_v3_unified.zig
+generated/smoke/
 # Squad: ignore runtime state (logs, inbox, sessions)
 .squad/orchestration-log/
 .squad/log/

--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ zig fmt --check src/
 zig fmt --check build.zig
 ```
 
+### Smoke tests
+
+Run the full smoke suite against every supported JSON OpenAPI/Swagger example under `openapi/`:
+
+```powershell
+pwsh -File test/smoke-tests.ps1
+```
+
+The smoke tests:
+
+- build `openapi2zig` once
+- generate one Zig client per example specification
+- compile each generated client individually through a tiny Zig test harness
+- exclude YAML examples and `openapi/json-schema/**`, which are not currently supported smoke-test inputs
+
+The script defaults to `ReleaseFast` optimization. Pass `-Optimize Debug` if you want a debug build locally. The pull request workflow runs the same script in `ReleaseFast`.
+
 ### Cross-compilation
 
 Build for different targets:

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -104,6 +104,39 @@ fn isPathParam(segment: []const u8) bool {
     return segment.len >= 2 and segment[0] == '{' and segment[segment.len - 1] == '}';
 }
 
+fn escapeFormatStringPath(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < path.len) {
+        if (std.mem.startsWith(u8, path[i..], "{s}")) {
+            try out.appendSlice(allocator, "{s}");
+            i += 3;
+            continue;
+        }
+        if (std.mem.startsWith(u8, path[i..], "{d}")) {
+            try out.appendSlice(allocator, "{d}");
+            i += 3;
+            continue;
+        }
+        if (std.mem.startsWith(u8, path[i..], "{any}")) {
+            try out.appendSlice(allocator, "{any}");
+            i += 5;
+            continue;
+        }
+
+        switch (path[i]) {
+            '{' => try out.appendSlice(allocator, "{{"),
+            '}' => try out.appendSlice(allocator, "}}"),
+            else => try out.append(allocator, path[i]),
+        }
+        i += 1;
+    }
+
+    return try out.toOwnedSlice(allocator);
+}
+
 pub const UnifiedApiGenerator = struct {
     allocator: std.mem.Allocator,
     buffer: std.ArrayList(u8),
@@ -704,10 +737,13 @@ pub const UnifiedApiGenerator = struct {
             }
         }
 
+        const escaped_path = try escapeFormatStringPath(self.allocator, new_path);
+        defer self.allocator.free(escaped_path);
+
         try self.buffer.appendSlice(self.allocator, "    var uri_buf: std.Io.Writer.Allocating = .init(allocator);\n");
         try self.buffer.appendSlice(self.allocator, "    defer uri_buf.deinit();\n");
         try self.buffer.appendSlice(self.allocator, "    try uri_buf.writer.print(\"{s}");
-        try self.buffer.appendSlice(self.allocator, new_path);
+        try self.buffer.appendSlice(self.allocator, escaped_path);
         try self.buffer.appendSlice(self.allocator, "\", .{client.base_url");
         if (operation.parameters) |parameters| {
             for (parameters) |parameter| {
@@ -1380,10 +1416,13 @@ pub const UnifiedApiGenerator = struct {
             }
         }
 
+        const escaped_path = try escapeFormatStringPath(self.allocator, new_path);
+        defer self.allocator.free(escaped_path);
+
         try self.buffer.appendSlice(self.allocator, "    var uri_buf: std.Io.Writer.Allocating = .init(allocator);\n");
         try self.buffer.appendSlice(self.allocator, "    defer uri_buf.deinit();\n");
         try self.buffer.appendSlice(self.allocator, "    try uri_buf.writer.print(\"{s}");
-        try self.buffer.appendSlice(self.allocator, new_path);
+        try self.buffer.appendSlice(self.allocator, escaped_path);
         try self.buffer.appendSlice(self.allocator, "\", .{client.base_url");
         if (operation.parameters) |parameters| {
             for (parameters) |parameter| {

--- a/src/generators/unified/model_generator.zig
+++ b/src/generators/unified/model_generator.zig
@@ -69,6 +69,10 @@ pub const UnifiedModelGenerator = struct {
     }
 
     fn appendIdentifier(self: *UnifiedModelGenerator, name: []const u8) !void {
+        if (name.len == 0) {
+            try self.buffer.appendSlice(self.allocator, "__empty");
+            return;
+        }
         if (isBareIdentifier(name)) {
             try self.buffer.appendSlice(self.allocator, name);
             return;
@@ -271,14 +275,16 @@ pub const UnifiedModelGenerator = struct {
         return try std.fmt.allocPrint(self.allocator, "{s}Variant{d}", .{ union_name, index });
     }
 
-    fn appendTitleIdentPart(self: *UnifiedModelGenerator, out: *std.ArrayList(u8), value: []const u8) !void {
+    fn appendTitleIdentPart(self: *UnifiedModelGenerator, out: *std.ArrayList(u8), value: []const u8, capitalize_first: bool) !void {
+        if (value.len == 0) {
+            try out.appendSlice(self.allocator, if (capitalize_first or out.items.len > 0) "Empty" else "empty");
+            return;
+        }
         var capitalize_next = true;
-        for (value, 0..) |c, i| {
+        for (value) |c| {
             if (std.ascii.isAlphanumeric(c)) {
-                const prev = if (i > 0) value[i - 1] else 0;
-                const camel_boundary = std.ascii.isUpper(c) and i > 0 and (std.ascii.isLower(prev) or std.ascii.isDigit(prev));
-                const lower = std.ascii.toLower(c);
-                try out.append(self.allocator, if (capitalize_next or camel_boundary) std.ascii.toUpper(lower) else lower);
+                const should_capitalize = capitalize_next and (capitalize_first or out.items.len > 0);
+                try out.append(self.allocator, if (should_capitalize) std.ascii.toUpper(c) else c);
                 capitalize_next = false;
             } else {
                 capitalize_next = true;
@@ -289,8 +295,8 @@ pub const UnifiedModelGenerator = struct {
     fn fieldTypeNameAlloc(self: *UnifiedModelGenerator, owner_name: []const u8, field_name: []const u8) ![]const u8 {
         var out = std.ArrayList(u8).empty;
         errdefer out.deinit(self.allocator);
-        try self.appendTitleIdentPart(&out, owner_name);
-        try self.appendTitleIdentPart(&out, field_name);
+        try self.appendTitleIdentPart(&out, owner_name, false);
+        try self.appendTitleIdentPart(&out, field_name, true);
         if (out.items.len == 0 or !isIdentStart(out.items[0])) try out.insert(self.allocator, 0, '_');
         return try out.toOwnedSlice(self.allocator);
     }

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -1,0 +1,206 @@
+param (
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("Debug", "ReleaseFast", "ReleaseSafe", "ReleaseSmall")]
+    [string]
+    $Optimize = "ReleaseFast"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Format-CommandLine {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Command,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $Arguments = @()
+    )
+
+    $parts = @($Command)
+    foreach ($argument in $Arguments) {
+        if ($argument -match '[\s"]') {
+            $parts += '"' + $argument.Replace('"', '\"') + '"'
+        } else {
+            $parts += $argument
+        }
+    }
+
+    return ($parts -join " ")
+}
+
+function Invoke-NativeCommand {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Command,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $Arguments = @(),
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $FailureMessage
+    )
+
+    Write-Host (Format-CommandLine -Command $Command -Arguments $Arguments)
+    & $Command @Arguments
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "$FailureMessage (exit code $exitCode)"
+    }
+}
+
+function Resolve-ZigCommand {
+    $zig = Get-Command "zig" -ErrorAction SilentlyContinue
+    if ($zig) {
+        return $zig.Source
+    }
+
+    if ($IsWindows) {
+        $candidates = @(
+            "$env:USERPROFILE\scoop\shims\zig.exe",
+            "$env:USERPROFILE\scoop\apps\zig\current\zig.exe",
+            "C:\Program Files\Zig\zig.exe",
+            "C:\tools\zig\zig.exe"
+        )
+
+        $wingetRoot = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Packages\zig.zig_Microsoft.Winget.Source_8wekyb3d8bbwe"
+        if (Test-Path -LiteralPath $wingetRoot) {
+            $wingetZig = Get-ChildItem -Path $wingetRoot -Recurse -File -Filter "zig.exe" |
+                Sort-Object -Property FullName -Descending |
+                Select-Object -First 1
+            if ($wingetZig) {
+                $candidates += $wingetZig.FullName
+            }
+        }
+
+        foreach ($candidate in $candidates) {
+            if ($candidate -and (Test-Path -LiteralPath $candidate)) {
+                return $candidate
+            }
+        }
+    }
+
+    throw "Could not locate the Zig executable. Install Zig 0.16.0+ or ensure 'zig' is available on PATH."
+}
+
+function Get-SmokeSpecFiles {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $OpenApiRoot
+    )
+
+    return Get-ChildItem -Path $OpenApiRoot -Recurse -File -Filter "*.json" |
+        Where-Object { $_.FullName -notmatch '[\\/]+json-schema[\\/]+' } |
+        Sort-Object -Property FullName
+}
+
+function New-CompileHarness {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $HarnessPath
+    )
+
+    $content = @'
+const std = @import("std");
+const generated = @import("generated.zig");
+
+test "generated code compiles" {
+    std.testing.refAllDecls(generated);
+}
+'@
+
+    Set-Content -LiteralPath $HarnessPath -Value $content -Encoding utf8NoBOM
+}
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $scriptRoot ".."))
+$openApiRoot = Join-Path $repoRoot "openapi"
+$generatedRoot = Join-Path (Join-Path $repoRoot "generated") "smoke"
+$zig = Resolve-ZigCommand
+$binaryName = if ($IsWindows) { "openapi2zig.exe" } else { "openapi2zig" }
+$openApi2Zig = Join-Path (Join-Path (Join-Path $repoRoot "zig-out") "bin") $binaryName
+
+$specFiles = @(Get-SmokeSpecFiles -OpenApiRoot $openApiRoot)
+if ($specFiles.Count -eq 0) {
+    throw "No supported JSON OpenAPI/Swagger smoke-test inputs were found under '$openApiRoot'."
+}
+
+Push-Location $repoRoot
+try {
+    Write-Host "Discovered $($specFiles.Count) JSON OpenAPI/Swagger smoke-test inputs."
+    Write-Host "Excluded: YAML examples and openapi/json-schema fixtures."
+    Write-Host ""
+
+    Invoke-NativeCommand -Command $zig -Arguments @("version") -FailureMessage "Unable to query Zig version"
+    Invoke-NativeCommand -Command $zig -Arguments @("build", "-Doptimize=$Optimize") -FailureMessage "Failed to build openapi2zig"
+
+    if (-not (Test-Path -LiteralPath $openApi2Zig)) {
+        throw "Expected generated CLI at '$openApi2Zig' after build, but it was not found."
+    }
+
+    if (Test-Path -LiteralPath $generatedRoot) {
+        Remove-Item -LiteralPath $generatedRoot -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $generatedRoot -Force | Out-Null
+
+    $passedCount = 0
+    $failures = [System.Collections.Generic.List[object]]::new()
+
+    for ($index = 0; $index -lt $specFiles.Count; $index++) {
+        $spec = $specFiles[$index]
+        $relativeSpecPath = [System.IO.Path]::GetRelativePath($repoRoot, $spec.FullName)
+        $relativeOutputPath = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetRelativePath($openApiRoot, $spec.FullName), $null)
+        $outputDirectory = Join-Path $generatedRoot $relativeOutputPath
+        $generatedFile = Join-Path $outputDirectory "generated.zig"
+        $compileHarness = Join-Path $outputDirectory "compile.zig"
+
+        New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+
+        Write-Host "[$($index + 1)/$($specFiles.Count)] $relativeSpecPath" -ForegroundColor Cyan
+
+        try {
+            Invoke-NativeCommand `
+                -Command $openApi2Zig `
+                -Arguments @("generate", "-i", $spec.FullName, "-o", $generatedFile) `
+                -FailureMessage "Generation failed for '$relativeSpecPath'"
+
+            New-CompileHarness -HarnessPath $compileHarness
+
+            Invoke-NativeCommand `
+                -Command $zig `
+                -Arguments @("test", $compileHarness) `
+                -FailureMessage "Compilation failed for '$relativeSpecPath'"
+
+            Write-Host "PASS  $relativeSpecPath" -ForegroundColor Green
+            $passedCount += 1
+        } catch {
+            Write-Host "FAIL  $relativeSpecPath" -ForegroundColor Red
+            $failures.Add([pscustomobject]@{
+                Spec = $relativeSpecPath
+                Message = $_.Exception.Message
+            })
+        }
+
+        Write-Host ""
+    }
+
+    Write-Host "Smoke tests completed: $passedCount passed, $($failures.Count) failed."
+    if ($failures.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Failing specifications:" -ForegroundColor Red
+        foreach ($failure in $failures) {
+            Write-Host "- $($failure.Spec): $($failure.Message)" -ForegroundColor Red
+        }
+
+        throw "Smoke tests failed for $($failures.Count) specification(s)."
+    }
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Why

The repo only smoke-tested a small canned generation path, which made it easy for spec-specific generation bugs to slip through. This adds a broader smoke test flow that exercises the real example specs under `openapi/` and verifies the generated Zig actually compiles.

## What changed

- Added `test/smoke-tests.ps1` to discover supported JSON OpenAPI and Swagger examples, generate code one spec at a time, and compile each generated client through a tiny Zig test harness with clear per-spec logging.
- Updated CI to run that smoke script in the smoke-tests job, so pull requests validate the full JSON example matrix instead of only the petstore path.
- Documented local smoke test usage in the README and ignored `generated/smoke/` so local runs do not leave noisy artifacts behind.
- Hardened code generation based on failures found by the sweep:
  - preserve enough casing in nested helper type names to avoid collisions
  - map empty property names to a valid Zig identifier
  - escape unresolved path placeholders before emitting `writer.print(...)` format strings

## Notes for reviewers

The smoke suite intentionally covers only supported JSON OpenAPI and Swagger inputs. YAML examples and `openapi/json-schema/**` are excluded because YAML generation is still unsupported and the JSON Schema fixtures are not OpenAPI smoke targets.

The generator fixes are tightly coupled to the smoke work because the new sweep immediately exposed real compile failures in `ingram-micro.json`. Those fixes are included here so the new CI coverage is green instead of introducing a permanently failing workflow.

## Validation

- `zig build test -Doptimize=ReleaseFast`
- generated and compiled all 22 supported JSON example specs through the smoke harness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Smoke test infrastructure for validating OpenAPI/Swagger example generation across the codebase

* **Bug Fixes**
  * Enhanced URL path handling in generated code with proper format placeholder escaping
  * Improved identifier naming for empty inputs and field type generation

* **Documentation**
  * Added comprehensive smoke testing guide with setup commands and optimization options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->