### PR TITLE
Add YAML OpenAPI parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool supports the following OpenAPI and Swagger specifications:
 - **OpenAPI v3.1** - Full support
 - **OpenAPI v3.2** - Full support
 
-All specifications are supported in JSON format. YAML support may be added in future releases.
+All specifications are supported in JSON and YAML format.
 
 ## Features
 
@@ -201,7 +201,7 @@ The `generate` command reads a JSON OpenAPI/Swagger document from a local file o
 
 | Flag | Description |
 | :--- | :--- |
-| `-i`, `--input <PATH_OR_URL>` | OpenAPI/Swagger JSON spec from a file path or `http`/`https` URL. Required. |
+| `-i`, `--input <PATH_OR_URL>` | OpenAPI/Swagger JSON or YAML spec from a file path or `http`/`https` URL. Required. |
 | `-o`, `--output <path>` | Output file for the generated Zig code. Defaults to `generated.zig`. Parent directories are created when needed. |
 | `--base-url <url>` | Base URL baked into the generated `Client`. Defaults to the server URL from the OpenAPI/Swagger document. |
 | `--resource-wrappers <mode>` | Generate resource wrapper namespaces. Modes: `none`, `tags`, `paths`, `hybrid`. Defaults to `paths`. |
@@ -211,6 +211,11 @@ The `generate` command reads a JSON OpenAPI/Swagger document from a local file o
 **From a local file:**
 ```bash
 openapi2zig generate -i openapi/v3.0/petstore.json -o api.zig
+```
+
+**From a local YAML file:**
+```bash
+openapi2zig generate -i openapi/v3.0/petstore.yaml -o api.zig
 ```
 
 **From a remote URL:**
@@ -327,16 +332,21 @@ pub fn main(init: std.process.Init) !void {
 
 #### Version Detection
 
-- `detectVersion(allocator, json_content)` - Detect OpenAPI/Swagger version
+- `detectVersion(allocator, json_content)` - Detect OpenAPI/Swagger version from JSON
+- `detectVersionFromYaml(allocator, yaml_content)` - Detect OpenAPI/Swagger version from YAML
 - `ApiVersion` - Enum representing supported API versions (.v2_0, .v3_0, .v3_1, .v3_2, .Unsupported)
 
 #### Parsing Functions
 
-- `parseToUnified(allocator, json_content)` - Parse any supported version (v2.0, v3.0, v3.1, v3.2) to unified representation
+- `parseToUnified(allocator, json_content)` - Parse any supported JSON version (v2.0, v3.0, v3.1, v3.2) to unified representation
 - `parseOpenApi(allocator, json_content)` - Parse OpenAPI v3.0 specifically
+- `parseOpenApiYaml(allocator, yaml_content)` - Parse OpenAPI v3.0 YAML specifically
 - `parseOpenApi31(allocator, json_content)` - Parse OpenAPI v3.1 specifically
+- `parseOpenApi31Yaml(allocator, yaml_content)` - Parse OpenAPI v3.1 YAML specifically
 - `parseOpenApi32(allocator, json_content)` - Parse OpenAPI v3.2 specifically
+- `parseOpenApi32Yaml(allocator, yaml_content)` - Parse OpenAPI v3.2 YAML specifically
 - `parseSwagger(allocator, json_content)` - Parse Swagger v2.0 specifically
+- `parseSwaggerYaml(allocator, yaml_content)` - Parse Swagger v2.0 YAML specifically
 
 #### Code Generation
 

--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,10 @@ pub fn build(b: *std.Build) void {
     const run_integration_tests = b.option(bool, "run-integration", "Run network integration tests") orelse false;
     const build_info = createBuildInfoOptions(b, run_integration_tests);
     const package_snapshot_step = createPackageSnapshotStep(b);
+    const yaml_dep = b.dependency("yaml", .{
+        .target = target,
+        .optimize = optimize,
+    });
 
     // Library module for external packages
     const openapi2zig_mod = b.addModule("openapi2zig", .{
@@ -15,6 +19,7 @@ pub fn build(b: *std.Build) void {
     });
     openapi2zig_mod.addIncludePath(b.path("src"));
     openapi2zig_mod.addOptions("build_info", build_info);
+    openapi2zig_mod.addImport("yaml", yaml_dep.module("yaml"));
 
     // CLI executable
     const exe_root_module = b.createModule(.{
@@ -23,6 +28,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     exe_root_module.addOptions("build_info", build_info);
+    exe_root_module.addImport("yaml", yaml_dep.module("yaml"));
     const exe = b.addExecutable(.{
         .name = "openapi2zig",
         .root_module = exe_root_module,
@@ -37,6 +43,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     lib_root_module.addOptions("build_info", build_info);
+    lib_root_module.addImport("yaml", yaml_dep.module("yaml"));
     const lib = b.addLibrary(.{
         .name = "openapi2zig",
         .root_module = lib_root_module,
@@ -115,6 +122,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     tests_mod.addOptions("build_info", build_info);
+    tests_mod.addImport("yaml", yaml_dep.module("yaml"));
 
     const exe_unit_tests = b.addTest(.{
         .root_module = tests_mod,
@@ -246,7 +254,9 @@ fn getPackageSnapshotFiles(allocator: std.mem.Allocator, io: std.Io) ?[]const u8
         "build.zig",
         "build.zig.zon",
         "src",
+        "openapi",
         "generated",
+        "vendor/zig-yaml",
         "LICENSE",
         "README.md",
         "examples/package_consumer",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -37,6 +37,9 @@
     // internet connectivity.
     .dependencies = .{
         // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        .yaml = .{
+            .path = "vendor/zig-yaml",
+        },
         //.example = .{
         //    // When updating this field to a new URL, be sure to delete the corresponding
         //    // `hash`, otherwise you are communicating that you expect to find the old hash at
@@ -66,20 +69,13 @@
         //    .lazy = false,
         //},
     },
-
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package. Only files listed here will remain on disk
-    // when using the zig package manager. As a rule of thumb, one should list
-    // files required for compilation plus any license(s).
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
     .paths = .{
         "build.zig",
         "build.zig.zon",
         "src",
+        "openapi",
         "generated",
+        "vendor/zig-yaml",
         "LICENSE",
         "README.md",
     },

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -3,6 +3,7 @@ const cli = @import("cli.zig");
 const detector = @import("detector.zig");
 const models = @import("models.zig");
 const input_loader = @import("input_loader.zig");
+const yaml_loader = @import("yaml_loader.zig");
 const OpenApiConverter = @import("generators/converters/openapi_converter.zig").OpenApiConverter;
 const OpenApi31Converter = @import("generators/converters/openapi31_converter.zig").OpenApi31Converter;
 const OpenApi32Converter = @import("generators/converters/openapi32_converter.zig").OpenApi32Converter;
@@ -47,49 +48,59 @@ pub fn generateCode(allocator: std.mem.Allocator, io: std.Io, args: cli.CliArgs)
     const file_contents = try input_loader.loadInput(allocator, io, source);
     defer allocator.free(file_contents);
 
-    switch (extension) {
-        .YAML => {
-            std.debug.print("YAML support is not yet implemented\n", .{});
-            return GeneratorErrors.UnsupportedExtension;
-        },
-        .JSON => {
-            const version = detector.getOpenApiVersion(allocator, file_contents) catch |err| {
-                std.debug.print("Failed to parse OpenAPI version: {}\n", .{err});
+    var normalized_yaml_json: ?[]const u8 = null;
+    defer if (normalized_yaml_json) |json_contents| allocator.free(json_contents);
+
+    const json_contents = switch (extension) {
+        .YAML => blk: {
+            normalized_yaml_json = yaml_loader.yamlToJson(allocator, file_contents) catch |err| {
+                std.debug.print("Failed to parse YAML OpenAPI document: {}\n", .{err});
                 return err;
             };
+            break :blk normalized_yaml_json.?;
+        },
+        .JSON => file_contents,
+    };
 
-            std.debug.print("Detected OpenAPI version: {s}\n", .{detector.getOpenApiVersionString(version)});
+    try generateCodeFromJsonContents(allocator, io, json_contents, args);
+}
 
-            switch (version) {
-                .v2_0 => {
-                    var swagger = try models.SwaggerDocument.parseFromJson(allocator, file_contents);
-                    defer swagger.deinit(allocator);
-                    std.debug.print("Successfully parsed Swagger v2.0 document\n", .{});
-                    try generateCodeFromSwaggerDocument(allocator, io, swagger, args);
-                },
-                .v3_0 => {
-                    var openapi = try models.OpenApiDocument.parseFromJson(allocator, file_contents);
-                    defer openapi.deinit(allocator);
-                    std.debug.print("Successfully parsed OpenAPI v3.0 document\n", .{});
-                    try generateCodeFromOpenApiDocument(allocator, io, openapi, args);
-                },
-                .v3_1 => {
-                    var openapi31 = try models.OpenApi31Document.parseFromJson(allocator, file_contents);
-                    defer openapi31.deinit(allocator);
-                    std.debug.print("Successfully parsed OpenAPI v3.1 document\n", .{});
-                    try generateCodeFromOpenApi31Document(allocator, io, openapi31, args);
-                },
-                .v3_2 => {
-                    var openapi32 = try models.OpenApi32Document.parseFromJson(allocator, file_contents);
-                    defer openapi32.deinit(allocator);
-                    std.debug.print("Successfully parsed OpenAPI v3.2 document\n", .{});
-                    try generateCodeFromOpenApi32Document(allocator, io, openapi32, args);
-                },
-                else => {
-                    std.debug.print("Unsupported OpenAPI version: {s}\n", .{detector.getOpenApiVersionString(version)});
-                    return GeneratorErrors.UnsupportedExtension;
-                },
-            }
+fn generateCodeFromJsonContents(allocator: std.mem.Allocator, io: std.Io, json_contents: []const u8, args: cli.CliArgs) !void {
+    const version = detector.getOpenApiVersion(allocator, json_contents) catch |err| {
+        std.debug.print("Failed to parse OpenAPI version: {}\n", .{err});
+        return err;
+    };
+
+    std.debug.print("Detected OpenAPI version: {s}\n", .{detector.getOpenApiVersionString(version)});
+
+    switch (version) {
+        .v2_0 => {
+            var swagger = try models.SwaggerDocument.parseFromJson(allocator, json_contents);
+            defer swagger.deinit(allocator);
+            std.debug.print("Successfully parsed Swagger v2.0 document\n", .{});
+            try generateCodeFromSwaggerDocument(allocator, io, swagger, args);
+        },
+        .v3_0 => {
+            var openapi = try models.OpenApiDocument.parseFromJson(allocator, json_contents);
+            defer openapi.deinit(allocator);
+            std.debug.print("Successfully parsed OpenAPI v3.0 document\n", .{});
+            try generateCodeFromOpenApiDocument(allocator, io, openapi, args);
+        },
+        .v3_1 => {
+            var openapi31 = try models.OpenApi31Document.parseFromJson(allocator, json_contents);
+            defer openapi31.deinit(allocator);
+            std.debug.print("Successfully parsed OpenAPI v3.1 document\n", .{});
+            try generateCodeFromOpenApi31Document(allocator, io, openapi31, args);
+        },
+        .v3_2 => {
+            var openapi32 = try models.OpenApi32Document.parseFromJson(allocator, json_contents);
+            defer openapi32.deinit(allocator);
+            std.debug.print("Successfully parsed OpenAPI v3.2 document\n", .{});
+            try generateCodeFromOpenApi32Document(allocator, io, openapi32, args);
+        },
+        else => {
+            std.debug.print("Unsupported OpenAPI version: {s}\n", .{detector.getOpenApiVersionString(version)});
+            return GeneratorErrors.UnsupportedExtension;
         },
     }
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -29,6 +29,7 @@
 //! ```
 
 const std = @import("std");
+const yaml_loader = @import("yaml_loader.zig");
 
 // Core version detection
 pub const ApiVersion = @import("detector.zig").OpenApiVersion;
@@ -70,6 +71,7 @@ pub const UnifiedApiGenerator = @import("generators/unified/api_generator.zig").
 
 // CLI argument types for code generation
 pub const CliArgs = @import("cli.zig").CliArgs;
+pub const yamlToJson = yaml_loader.yamlToJson;
 
 /// Parse a JSON string containing an OpenAPI or Swagger specification and convert it to a unified document representation.
 /// The caller is responsible for calling `deinit()` on the returned document.
@@ -123,6 +125,45 @@ pub fn parseToUnified(allocator: std.mem.Allocator, json_content: []const u8) !U
             return error.UnsupportedApiVersion;
         },
     }
+}
+
+/// Detect the OpenAPI/Swagger version from a YAML specification.
+pub fn detectVersionFromYaml(allocator: std.mem.Allocator, yaml_content: []const u8) !ApiVersion {
+    const json_content = try yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+    return try detectVersion(allocator, json_content);
+}
+
+/// Parse a YAML string containing an OpenAPI v3.0 specification.
+/// The caller is responsible for calling `deinit()` on the returned document.
+pub fn parseOpenApiYaml(allocator: std.mem.Allocator, yaml_content: []const u8) !OpenApiDocument {
+    const json_content = try yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+    return try OpenApiDocument.parseFromJson(allocator, json_content);
+}
+
+/// Parse a YAML string containing an OpenAPI v3.1 specification.
+/// The caller is responsible for calling `deinit()` on the returned document.
+pub fn parseOpenApi31Yaml(allocator: std.mem.Allocator, yaml_content: []const u8) !OpenApi31Document {
+    const json_content = try yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+    return try OpenApi31Document.parseFromJson(allocator, json_content);
+}
+
+/// Parse a YAML string containing an OpenAPI v3.2 specification.
+/// The caller is responsible for calling `deinit()` on the returned document.
+pub fn parseOpenApi32Yaml(allocator: std.mem.Allocator, yaml_content: []const u8) !OpenApi32Document {
+    const json_content = try yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+    return try OpenApi32Document.parseFromJson(allocator, json_content);
+}
+
+/// Parse a YAML string containing a Swagger v2.0 specification.
+/// The caller is responsible for calling `deinit()` on the returned document.
+pub fn parseSwaggerYaml(allocator: std.mem.Allocator, yaml_content: []const u8) !SwaggerDocument {
+    const json_content = try yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+    return try SwaggerDocument.parseFromJson(allocator, json_content);
 }
 
 /// Parse a JSON string containing an OpenAPI v3.0 specification.

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5,6 +5,7 @@ const swagger_v2_tests = @import("tests/swagger_v2_tests.zig");
 const unified_converter_tests = @import("tests/unified_converter_tests.zig");
 const comprehensive_converter_tests = @import("tests/comprehensive_converter_tests.zig");
 const test_input_loader = @import("tests/test_input_loader.zig");
+const yaml_loader_tests = @import("tests/yaml_loader_tests.zig");
 const resource_wrapper_tests = @import("tests/resource_wrapper_tests.zig");
 const model_typing_tests = @import("tests/model_typing_tests.zig");
 comptime {
@@ -15,6 +16,7 @@ comptime {
     _ = unified_converter_tests;
     _ = comprehensive_converter_tests;
     _ = test_input_loader;
+    _ = yaml_loader_tests;
     _ = resource_wrapper_tests;
     _ = model_typing_tests;
 }

--- a/src/tests/yaml_loader_tests.zig
+++ b/src/tests/yaml_loader_tests.zig
@@ -1,0 +1,145 @@
+const std = @import("std");
+const detector = @import("../detector.zig");
+const OpenApiConverter = @import("../generators/converters/openapi_converter.zig").OpenApiConverter;
+const models = @import("../models.zig");
+const test_utils = @import("test_utils.zig");
+const yaml_loader = @import("../yaml_loader.zig");
+
+test "convert OpenAPI YAML to JSON and detect version" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const yaml_content =
+        \\openapi: 3.0.3
+        \\info:
+        \\  title: YAML Petstore
+        \\  version: 1.0.0
+        \\paths:
+        \\  /pets:
+        \\    get:
+        \\      operationId: listPets
+        \\      responses:
+        \\        '200':
+        \\          description: OK
+        \\components:
+        \\  schemas:
+        \\    Pet:
+        \\      type: object
+        \\      required:
+        \\        - name
+        \\      properties:
+        \\        name:
+        \\          type: string
+        \\          maxLength: 64
+        \\        age:
+        \\          type: integer
+        \\          minimum: 0
+    ;
+
+    const json_content = try yaml_loader.yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+
+    try std.testing.expectEqual(detector.OpenApiVersion.v3_0, try detector.getOpenApiVersion(allocator, json_content));
+
+    var parsed = try models.OpenApiDocument.parseFromJson(allocator, json_content);
+    defer parsed.deinit(allocator);
+
+    try std.testing.expectEqualStrings("3.0.3", parsed.openapi);
+    try std.testing.expectEqualStrings("YAML Petstore", parsed.info.title);
+}
+
+test "normalize OpenAPI YAML parser edge cases" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const yaml_content =
+        \\openapi: 3.0.3
+        \\info:
+        \\  title: Edge Case API
+        \\  description: |-
+        \\    First line
+        \\    Second line
+        \\  version: 1.0.0
+        \\paths:
+        \\  /pets/{petId}:
+        \\    get:
+        \\      operationId: getPet
+        \\      description: ""
+        \\      responses:
+        \\        '200':
+        \\          description: OK
+    ;
+
+    const json_content = try yaml_loader.yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+
+    var parsed = try models.OpenApiDocument.parseFromJson(allocator, json_content);
+    defer parsed.deinit(allocator);
+
+    try std.testing.expectEqualStrings("First line\nSecond line", parsed.info.description.?);
+    try std.testing.expect(parsed.paths.path_items.contains("/pets/{petId}"));
+    try std.testing.expectEqualStrings("", parsed.paths.path_items.get("/pets/{petId}").?.get.?.description.?);
+}
+
+test "convert Swagger YAML with quoted response keys" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const yaml_content =
+        \\swagger: '2.0'
+        \\info:
+        \\  title: YAML Swagger
+        \\  version: 1.0.0
+        \\paths:
+        \\  /pets:
+        \\    get:
+        \\      operationId: listPets
+        \\      responses:
+        \\        '200':
+        \\          description: OK
+    ;
+
+    const json_content = try yaml_loader.yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+
+    try std.testing.expectEqual(detector.OpenApiVersion.v2_0, try detector.getOpenApiVersion(allocator, json_content));
+
+    var parsed = try models.SwaggerDocument.parseFromJson(allocator, json_content);
+    defer parsed.deinit(allocator);
+
+    try std.testing.expectEqualStrings("2.0", parsed.swagger);
+    try std.testing.expectEqualStrings("YAML Swagger", parsed.info.title);
+}
+
+test "convert YAML specification to unified document" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const yaml_content =
+        \\openapi: 3.0.3
+        \\info:
+        \\  title: Unified YAML API
+        \\  version: 1.0.0
+        \\paths:
+        \\  /pets:
+        \\    get:
+        \\      operationId: listPets
+        \\      responses:
+        \\        '200':
+        \\          description: OK
+    ;
+
+    const json_content = try yaml_loader.yamlToJson(allocator, yaml_content);
+    defer allocator.free(json_content);
+
+    var parsed = try models.OpenApiDocument.parseFromJson(allocator, json_content);
+    defer parsed.deinit(allocator);
+
+    var converter = OpenApiConverter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+
+    try std.testing.expectEqualStrings("3.0.3", unified.version);
+    try std.testing.expectEqualStrings("Unified YAML API", unified.info.title);
+    try std.testing.expect(unified.paths.count() == 1);
+}

--- a/src/yaml_loader.zig
+++ b/src/yaml_loader.zig
@@ -1,0 +1,470 @@
+const std = @import("std");
+const yaml = @import("yaml");
+
+const YamlValue = yaml.Yaml.Value;
+const lbrace_placeholder = "__openapi2zig_lbrace__";
+const rbrace_placeholder = "__openapi2zig_rbrace__";
+
+pub const YamlToJsonError = error{
+    EmptyYamlDocument,
+    MultipleYamlDocumentsUnsupported,
+};
+
+pub fn yamlToJson(allocator: std.mem.Allocator, yaml_content: []const u8) ![]const u8 {
+    // Normalize common OpenAPI YAML forms that zig-yaml does not parse directly.
+    const block_folded_yaml = try foldBlockScalars(allocator, yaml_content);
+    defer allocator.free(block_folded_yaml);
+
+    const folded_yaml = try foldDoubleQuotedContinuations(allocator, block_folded_yaml);
+    defer allocator.free(folded_yaml);
+
+    const normalized_yaml = try normalizeQuotedMapKeys(allocator, folded_yaml);
+    defer allocator.free(normalized_yaml);
+
+    var parsed: yaml.Yaml = .{ .source = normalized_yaml };
+    defer parsed.deinit(allocator);
+
+    try parsed.load(allocator);
+
+    if (parsed.docs.items.len == 0) return YamlToJsonError.EmptyYamlDocument;
+    if (parsed.docs.items.len > 1) return YamlToJsonError.MultipleYamlDocumentsUnsupported;
+
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+
+    try writeJsonValue(allocator, &out.writer, parsed.docs.items[0], null);
+    return try out.toOwnedSlice();
+}
+
+fn foldBlockScalars(allocator: std.mem.Allocator, yaml_content: []const u8) ![]const u8 {
+    var source_lines = std.ArrayList([]const u8).empty;
+    defer source_lines.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, yaml_content, '\n');
+    while (lines.next()) |line| {
+        try source_lines.append(allocator, line);
+    }
+
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+
+    var line_index: usize = 0;
+    var first_output_line = true;
+    while (line_index < source_lines.items.len) {
+        const line = source_lines.items[line_index];
+        if (blockScalarHeader(line)) |header| {
+            if (!first_output_line) try out.append(allocator, '\n');
+            first_output_line = false;
+
+            try out.appendSlice(allocator, line[0 .. header.colon_index + 1]);
+            try out.appendSlice(allocator, " \"");
+
+            line_index += 1;
+            var block_indent: ?usize = null;
+            var first_block_line = true;
+            while (line_index < source_lines.items.len) {
+                const block_line = source_lines.items[line_index];
+                const trimmed_block_line = std.mem.trim(u8, block_line, " \t\r");
+                const indent = countIndent(block_line);
+                if (trimmed_block_line.len != 0 and indent <= header.parent_indent) break;
+
+                if (trimmed_block_line.len == 0) {
+                    if (!first_block_line and header.style == '|') try appendYamlDoubleQuotedChar(allocator, &out, '\n');
+                    line_index += 1;
+                    continue;
+                }
+
+                if (block_indent == null) block_indent = indent;
+                const content_start = @min(block_indent.?, block_line.len);
+                const content = block_line[content_start..];
+                if (!first_block_line) {
+                    if (header.style == '|') {
+                        try appendYamlDoubleQuotedChar(allocator, &out, '\n');
+                    } else {
+                        try out.append(allocator, ' ');
+                    }
+                }
+                try appendYamlDoubleQuotedContent(allocator, &out, content);
+                first_block_line = false;
+                line_index += 1;
+            }
+
+            try out.append(allocator, '"');
+            continue;
+        }
+
+        if (!first_output_line) try out.append(allocator, '\n');
+        first_output_line = false;
+        try out.appendSlice(allocator, line);
+        line_index += 1;
+    }
+
+    return try out.toOwnedSlice(allocator);
+}
+
+const BlockScalarHeader = struct {
+    parent_indent: usize,
+    colon_index: usize,
+    style: u8,
+};
+
+fn blockScalarHeader(line: []const u8) ?BlockScalarHeader {
+    const colon_index = std.mem.indexOfScalar(u8, line, ':') orelse return null;
+    const value = std.mem.trim(u8, line[colon_index + 1 ..], " \t\r");
+    if (value.len == 0) return null;
+    if (value[0] != '|' and value[0] != '>') return null;
+    return .{
+        .parent_indent = countIndent(line),
+        .colon_index = colon_index,
+        .style = value[0],
+    };
+}
+
+fn countIndent(line: []const u8) usize {
+    var indent: usize = 0;
+    while (indent < line.len and (line[indent] == ' ' or line[indent] == '\t')) : (indent += 1) {}
+    return indent;
+}
+
+fn appendYamlDoubleQuotedContent(allocator: std.mem.Allocator, out: *std.ArrayList(u8), content: []const u8) !void {
+    for (content) |char| {
+        try appendYamlDoubleQuotedChar(allocator, out, char);
+    }
+}
+
+fn appendYamlDoubleQuotedChar(allocator: std.mem.Allocator, out: *std.ArrayList(u8), char: u8) !void {
+    switch (char) {
+        '\n' => try out.appendSlice(allocator, "\\n"),
+        '\t' => try out.appendSlice(allocator, "\\t"),
+        '"' => try out.appendSlice(allocator, "\\\""),
+        else => try out.append(allocator, char),
+    }
+}
+
+fn foldDoubleQuotedContinuations(allocator: std.mem.Allocator, yaml_content: []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, yaml_content, '\n');
+    var first_output_line = true;
+    while (lines.next()) |line| {
+        if (!first_output_line) try out.append(allocator, '\n');
+        first_output_line = false;
+
+        if (!hasUnclosedDoubleQuote(line)) {
+            try out.appendSlice(allocator, line);
+            continue;
+        }
+
+        try out.appendSlice(allocator, stripTrailingContinuationBackslash(line));
+        while (lines.next()) |continuation_line| {
+            const continuation = trimLineStart(continuation_line);
+            const value = if (continuation.len > 0 and continuation[0] == '\\') continuation[1..] else continuation;
+            const finished = !hasTrailingContinuationBackslash(continuation_line);
+            try out.appendSlice(allocator, stripTrailingContinuationBackslash(value));
+            if (finished) break;
+        }
+    }
+
+    return try out.toOwnedSlice(allocator);
+}
+
+fn hasUnclosedDoubleQuote(line: []const u8) bool {
+    var quote_count: usize = 0;
+    var escaped = false;
+    for (line) |char| {
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (char == '\\') {
+            escaped = true;
+            continue;
+        }
+        if (char == '"') quote_count += 1;
+    }
+    return quote_count % 2 == 1;
+}
+
+fn hasTrailingContinuationBackslash(line: []const u8) bool {
+    const trimmed = trimLineEnd(line);
+    return trimmed.len > 0 and trimmed[trimmed.len - 1] == '\\';
+}
+
+fn stripTrailingContinuationBackslash(line: []const u8) []const u8 {
+    const trimmed = trimLineEnd(line);
+    if (trimmed.len == 0 or trimmed[trimmed.len - 1] != '\\') return line;
+    return trimmed[0 .. trimmed.len - 1];
+}
+
+fn trimLineStart(line: []const u8) []const u8 {
+    var index: usize = 0;
+    while (index < line.len and (line[index] == ' ' or line[index] == '\t')) : (index += 1) {}
+    return line[index..];
+}
+
+fn trimLineEnd(line: []const u8) []const u8 {
+    var end = line.len;
+    while (end > 0 and (line[end - 1] == ' ' or line[end - 1] == '\t' or line[end - 1] == '\r')) : (end -= 1) {}
+    return line[0..end];
+}
+
+fn normalizeQuotedMapKeys(allocator: std.mem.Allocator, yaml_content: []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, yaml_content, '\n');
+    var first_line = true;
+    while (lines.next()) |line| {
+        if (!first_line) try out.append(allocator, '\n');
+        first_line = false;
+
+        try appendNormalizedMapKeyLine(allocator, &out, line);
+    }
+
+    return try out.toOwnedSlice(allocator);
+}
+
+fn appendNormalizedMapKeyLine(allocator: std.mem.Allocator, out: *std.ArrayList(u8), line: []const u8) !void {
+    var index: usize = 0;
+    while (index < line.len and (line[index] == ' ' or line[index] == '\t')) : (index += 1) {}
+
+    if (index >= line.len or (line[index] != '\'' and line[index] != '"')) {
+        try appendLineWithEscapedKeyBraces(allocator, out, line);
+        return;
+    }
+
+    const quote = line[index];
+    const key_start = index + 1;
+    var key_end = key_start;
+    while (key_end < line.len) : (key_end += 1) {
+        if (line[key_end] != quote) continue;
+        if (quote == '\'' and key_end + 1 < line.len and line[key_end + 1] == '\'') {
+            key_end += 1;
+            continue;
+        }
+        break;
+    }
+
+    if (key_end >= line.len or key_end + 1 >= line.len or line[key_end + 1] != ':') {
+        try out.appendSlice(allocator, line);
+        return;
+    }
+
+    const key = if (quote == '\'')
+        try unescapeSingleQuoted(allocator, line[key_start..key_end])
+    else
+        try unescapeDoubleQuoted(allocator, line[key_start..key_end]);
+    defer allocator.free(key);
+
+    try out.appendSlice(allocator, line[0..index]);
+    try appendKeyWithEscapedBraces(allocator, out, key);
+    try out.appendSlice(allocator, line[key_end + 1 ..]);
+}
+
+fn appendLineWithEscapedKeyBraces(allocator: std.mem.Allocator, out: *std.ArrayList(u8), line: []const u8) !void {
+    const colon_index = std.mem.indexOfScalar(u8, line, ':') orelse {
+        try out.appendSlice(allocator, line);
+        return;
+    };
+
+    try appendKeyWithEscapedBraces(allocator, out, line[0..colon_index]);
+    try out.appendSlice(allocator, line[colon_index..]);
+}
+
+fn appendKeyWithEscapedBraces(allocator: std.mem.Allocator, out: *std.ArrayList(u8), key: []const u8) !void {
+    for (key) |char| {
+        switch (char) {
+            '{' => try out.appendSlice(allocator, lbrace_placeholder),
+            '}' => try out.appendSlice(allocator, rbrace_placeholder),
+            else => try out.append(allocator, char),
+        }
+    }
+}
+
+fn writeJsonValue(allocator: std.mem.Allocator, writer: *std.Io.Writer, value: YamlValue, current_key: ?[]const u8) !void {
+    switch (value) {
+        .empty => try writer.writeAll("null"),
+        .boolean => |boolean| try writer.writeAll(if (boolean) "true" else "false"),
+        .scalar => |scalar| try writeJsonScalar(writer, scalar, current_key),
+        .list => |list| {
+            try writer.writeByte('[');
+            for (list, 0..) |item, index| {
+                if (index != 0) try writer.writeByte(',');
+                try writeJsonValue(allocator, writer, item, null);
+            }
+            try writer.writeByte(']');
+        },
+        .map => |map| {
+            try writer.writeByte('{');
+            for (map.keys(), map.values(), 0..) |raw_key, item, index| {
+                if (index != 0) try writer.writeByte(',');
+
+                const key = try normalizeYamlKey(allocator, raw_key);
+                defer allocator.free(key);
+
+                try std.json.Stringify.value(key, .{}, writer);
+                try writer.writeByte(':');
+                try writeJsonValue(allocator, writer, item, key);
+            }
+            try writer.writeByte('}');
+        },
+    }
+}
+
+fn writeJsonScalar(writer: *std.Io.Writer, scalar: []const u8, current_key: ?[]const u8) !void {
+    const trimmed = std.mem.trim(u8, scalar, " \t\r\n");
+
+    if (isNullScalar(trimmed)) {
+        try writer.writeAll("null");
+        return;
+    }
+
+    if (parseBoolScalar(trimmed)) |boolean| {
+        try writer.writeAll(if (boolean) "true" else "false");
+        return;
+    }
+
+    if (current_key) |key| {
+        if (isFloatSchemaKeyword(key) and isJsonNumber(trimmed)) {
+            try writer.writeAll(trimmed);
+            if (!hasFractionOrExponent(trimmed)) try writer.writeAll(".0");
+            return;
+        }
+        if (isIntegerSchemaKeyword(key) and isJsonNumber(trimmed)) {
+            try writer.writeAll(trimmed);
+            return;
+        }
+    }
+
+    try std.json.Stringify.value(scalar, .{}, writer);
+}
+
+fn normalizeYamlKey(allocator: std.mem.Allocator, raw_key: []const u8) ![]const u8 {
+    const trimmed = std.mem.trim(u8, raw_key, " \t\r\n");
+    const unquoted = if (trimmed.len >= 2 and trimmed[0] == '\'' and trimmed[trimmed.len - 1] == '\'')
+        try unescapeSingleQuoted(allocator, trimmed[1 .. trimmed.len - 1])
+    else if (trimmed.len >= 2 and trimmed[0] == '"' and trimmed[trimmed.len - 1] == '"')
+        try unescapeDoubleQuoted(allocator, trimmed[1 .. trimmed.len - 1])
+    else
+        try allocator.dupe(u8, trimmed);
+    defer allocator.free(unquoted);
+
+    return try replaceKeyPlaceholders(allocator, unquoted);
+}
+
+fn replaceKeyPlaceholders(allocator: std.mem.Allocator, key: []const u8) ![]const u8 {
+    const with_lbraces = try std.mem.replaceOwned(u8, allocator, key, lbrace_placeholder, "{");
+    defer allocator.free(with_lbraces);
+    return try std.mem.replaceOwned(u8, allocator, with_lbraces, rbrace_placeholder, "}");
+}
+
+fn unescapeSingleQuoted(allocator: std.mem.Allocator, value: []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+
+    var index: usize = 0;
+    while (index < value.len) : (index += 1) {
+        if (value[index] == '\'' and index + 1 < value.len and value[index + 1] == '\'') {
+            try out.append(allocator, '\'');
+            index += 1;
+            continue;
+        }
+        try out.append(allocator, value[index]);
+    }
+
+    return try out.toOwnedSlice(allocator);
+}
+
+fn unescapeDoubleQuoted(allocator: std.mem.Allocator, value: []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+
+    var index: usize = 0;
+    while (index < value.len) : (index += 1) {
+        if (value[index] != '\\' or index + 1 >= value.len) {
+            try out.append(allocator, value[index]);
+            continue;
+        }
+
+        index += 1;
+        const escaped = switch (value[index]) {
+            '0' => 0,
+            'a' => 0x07,
+            'b' => 0x08,
+            't', '\t' => 0x09,
+            'n' => '\n',
+            'v' => 0x0b,
+            'f' => 0x0c,
+            'r' => '\r',
+            'e' => 0x1b,
+            '"', '/', '\\' => value[index],
+            else => value[index],
+        };
+        try out.append(allocator, escaped);
+    }
+
+    return try out.toOwnedSlice(allocator);
+}
+
+fn isNullScalar(value: []const u8) bool {
+    return std.mem.eql(u8, value, "~") or std.ascii.eqlIgnoreCase(value, "null");
+}
+
+fn parseBoolScalar(value: []const u8) ?bool {
+    if (std.ascii.eqlIgnoreCase(value, "true")) return true;
+    if (std.ascii.eqlIgnoreCase(value, "false")) return false;
+    return null;
+}
+
+fn isFloatSchemaKeyword(key: []const u8) bool {
+    return std.mem.eql(u8, key, "multipleOf") or
+        std.mem.eql(u8, key, "maximum") or
+        std.mem.eql(u8, key, "minimum");
+}
+
+fn isIntegerSchemaKeyword(key: []const u8) bool {
+    return std.mem.eql(u8, key, "maxLength") or
+        std.mem.eql(u8, key, "minLength") or
+        std.mem.eql(u8, key, "maxItems") or
+        std.mem.eql(u8, key, "minItems") or
+        std.mem.eql(u8, key, "maxProperties") or
+        std.mem.eql(u8, key, "minProperties");
+}
+
+fn hasFractionOrExponent(value: []const u8) bool {
+    return std.mem.indexOfAny(u8, value, ".eE") != null;
+}
+
+fn isJsonNumber(value: []const u8) bool {
+    if (value.len == 0) return false;
+
+    var index: usize = 0;
+    if (value[index] == '-') {
+        index += 1;
+        if (index == value.len) return false;
+    }
+
+    if (value[index] == '0') {
+        index += 1;
+    } else if (std.ascii.isDigit(value[index])) {
+        while (index < value.len and std.ascii.isDigit(value[index])) : (index += 1) {}
+    } else {
+        return false;
+    }
+
+    if (index < value.len and value[index] == '.') {
+        index += 1;
+        if (index == value.len or !std.ascii.isDigit(value[index])) return false;
+        while (index < value.len and std.ascii.isDigit(value[index])) : (index += 1) {}
+    }
+
+    if (index < value.len and (value[index] == 'e' or value[index] == 'E')) {
+        index += 1;
+        if (index < value.len and (value[index] == '+' or value[index] == '-')) index += 1;
+        if (index == value.len or !std.ascii.isDigit(value[index])) return false;
+        while (index < value.len and std.ascii.isDigit(value[index])) : (index += 1) {}
+    }
+
+    return index == value.len;
+}

--- a/vendor/zig-yaml/LICENSE
+++ b/vendor/zig-yaml/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2021 Jakub Konka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/zig-yaml/README.md
+++ b/vendor/zig-yaml/README.md
@@ -1,0 +1,163 @@
+# zig-yaml
+
+YAML parser for Zig
+
+## What is it?
+
+This lib is meant to serve as a basic (or maybe not?) YAML parser for Zig. It will strive to be YAML 1.2 compatible
+but one step at a time.
+
+This is very much a work-in-progress, so expect things to break on a regular basis. Oh, I'd love to get the
+community involved in helping out with this btw! Feel free to fork and submit patches, enhancements, and of course
+issues.
+
+
+## Basic installation
+
+The library can be installed using the Zig tools. First, you need to fetch the required release of the library into your project. 
+```
+zig fetch --save https://github.com/kubkon/zig-yaml/archive/refs/tags/[RELEASE_VERSION].tar.gz
+```
+
+It's more convenient to save the library with a desired name, for example, like this (assuming you are targeting latest release of Zig):
+```
+zig fetch --save=yaml https://github.com/kubkon/zig-yaml/archive/refs/tags/0.1.1.tar.gz
+```
+
+And then add those lines to your project's `build.zig` file:
+```
+// add that code after "b.installArtifact(exe)" line
+const yaml = b.dependency("yaml", .{
+  .target = target,
+  .optimize = optimize,
+});
+exe.root_module.addImport("yaml", yaml.module("yaml"));
+```
+
+After that, you can simply import the zig-yaml library in your project's code by using `const yaml = @import("yaml");`.
+
+For zig-0.14, please use any release after `0.1.0`. For pre-zig-0.14 (e.g., zig-0.13), use `0.0.1`.
+
+## Basic usage
+
+The parser currently understands a few YAML primitives such as:
+* explicit documents (`---`, `...`)
+* mappings (`:`)
+* sequences (`-`, `[`, `]`)
+
+In fact, if you head over to `examples/` dir, you will find YAML examples that have been tested against this
+parser. You can also have a look at end-to-end test inputs in `test/` directory.
+
+If you want to use the parser as a library, add it as a package the usual way, and then:
+
+```zig
+const std = @import("std");
+const Yaml = @import("yaml").Yaml;
+const gpa = std.testing.allocator;
+
+const source =
+    \\names: [ John Doe, MacIntosh, Jane Austin ]
+    \\numbers:
+    \\  - 10
+    \\  - -8
+    \\  - 6
+    \\nested:
+    \\  some: one
+    \\  wick: john doe
+    \\finally: [ 8.17,
+    \\           19.78      , 17 ,
+    \\           21 ]
+;
+
+var yaml: Yaml = .{ .source = source };
+defer yaml.deinit(gpa);
+```
+
+1. For untyped, raw representation of YAML, use `Yaml.load`:
+
+```zig
+try yaml.load(gpa, source);
+
+try std.testing.expectEqual(untyped.docs.items.len, 1);
+
+const map = untyped.docs.items[0].map;
+try std.testing.expect(map.contains("names"));
+try std.testing.expectEqual(map.get("names").?.list.len, 3);
+```
+
+2. For typed representation of YAML, use `Yaml.parse`:
+
+```zig
+const Simple = struct {
+    names: []const []const u8,
+    numbers: []const i16,
+    nested: struct {
+        some: []const u8,
+        wick: []const u8,
+    },
+    finally: [4]f16,
+};
+
+var arena = std.heap.ArenaAllocator.init(gpa);
+defer arena.deinit();
+
+const simple = try yaml.parse(arena.allocator(), Simple);
+try std.testing.expectEqual(simple.names.len, 3);
+```
+
+3. To convert `Yaml` structure back into text representation, use `Yaml.stringify`:
+
+```zig
+try yaml.stringify(std.io.getStdOut().writer());
+```
+
+which should write the following output to standard output when run:
+
+```sh
+names: [ John Doe, MacIntosh, Jane Austin  ]
+numbers: [ 10, -8, 6  ]
+nested:
+    some: one
+    wick: john doe
+finally: [ 8.17, 19.78, 17, 21  ]
+```
+
+### Error handling
+
+The library currently reports user-friendly, more informative parsing errors only which are stored out-of-band.
+They can be accessed via `Yaml.parse_errors: std.zig.ErrorBundle`, but typically you would only hook them up to
+your error reporting setup.
+
+For example, `example/yaml.zig` binary does it like so:
+
+```zig
+var yaml: Yaml = .{ .source = source };
+defer yaml.deinit(allocator);
+
+yaml.load(allocator) catch |err| switch (err) {
+    error.ParseFailure => {
+        assert(yaml.parse_errors.errorMessageCount() > 0);
+        yaml.parse_errors.renderToStdErr(.{ .ttyconf = std.io.tty.detectConfig(std.io.getStdErr()) });
+        return error.ParseFailure;
+    },
+    else => return err,
+};
+```
+
+## Running YAML spec test suite
+
+Remember to clone the repo with submodules first
+
+```sh
+git clone --recurse-submodules
+```
+
+Then, you can run the test suite as follows
+
+```sh
+zig build test -Denable-spec-tests
+```
+
+See also [issue #48](https://github.com/kubkon/zig-yaml/issues/48) for a meta issue tracking failing spec tests.
+
+Any test that you think of working on and would like to include in the spec tests (that was previously skipped), can be removed from the skipped tests lists in https://github.com/kubkon/zig-yaml/blob/b3cc3a3319ab40fa466a4d5e9c8483267e6ffbee/test/spec.zig#L239-L562

--- a/vendor/zig-yaml/build.zig
+++ b/vendor/zig-yaml/build.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const yaml_module = b.addModule("yaml", .{
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const yaml_tests = b.addTest(.{
+        .root_module = yaml_module,
+    });
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&b.addRunArtifact(yaml_tests).step);
+}

--- a/vendor/zig-yaml/build.zig.zon
+++ b/vendor/zig-yaml/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = .zig_yaml,
+    .version = "0.3.0",
+    .fingerprint = 0x225b4a67d67a5d0b, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.16.0",
+    .paths = .{
+        "src",
+        "test",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
+}

--- a/vendor/zig-yaml/src/Parser.zig
+++ b/vendor/zig-yaml/src/Parser.zig
@@ -1,0 +1,801 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.parser);
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+const ErrorBundle = std.zig.ErrorBundle;
+const LineCol = Tree.LineCol;
+const List = Tree.List;
+const Map = Tree.Map;
+const Node = Tree.Node;
+const Tokenizer = @import("Tokenizer.zig");
+const Token = Tokenizer.Token;
+const TokenIterator = Tokenizer.TokenIterator;
+const TokenWithLineCol = Tree.TokenWithLineCol;
+const Tree = @import("Tree.zig");
+const String = Tree.String;
+const Parser = @This();
+const Yaml = @import("Yaml.zig");
+
+source: []const u8,
+tokens: std.MultiArrayList(TokenWithLineCol) = .empty,
+token_it: TokenIterator = undefined,
+docs: std.ArrayListUnmanaged(Node.Index) = .empty,
+nodes: std.MultiArrayList(Node) = .empty,
+extra: std.ArrayListUnmanaged(u32) = .empty,
+string_bytes: std.ArrayListUnmanaged(u8) = .empty,
+errors: ErrorBundle.Wip,
+
+pub fn init(gpa: Allocator, source: []const u8) Allocator.Error!Parser {
+    var self: Parser = .{ .source = source, .errors = undefined };
+    try self.errors.init(gpa);
+    return self;
+}
+
+pub fn deinit(self: *Parser, gpa: Allocator) void {
+    self.tokens.deinit(gpa);
+    self.docs.deinit(gpa);
+    self.nodes.deinit(gpa);
+    self.extra.deinit(gpa);
+    self.string_bytes.deinit(gpa);
+    self.errors.deinit();
+    self.* = undefined;
+}
+
+pub fn parse(self: *Parser, gpa: Allocator) ParseError!void {
+    var tokenizer = Tokenizer{ .buffer = self.source };
+    var line: u32 = 0;
+    var prev_line_last_col: u32 = 0;
+
+    while (true) {
+        const tok = tokenizer.next();
+        const tok_index = try self.tokens.addOne(gpa);
+
+        self.tokens.set(tok_index, .{
+            .token = tok,
+            .line_col = .{
+                .line = line,
+                .col = @intCast(tok.loc.start - prev_line_last_col),
+            },
+        });
+
+        switch (tok.id) {
+            .eof => break,
+            .new_line => {
+                line += 1;
+                prev_line_last_col = @intCast(tok.loc.end);
+            },
+            else => {},
+        }
+    }
+
+    self.token_it = .{ .buffer = self.tokens.items(.token) };
+
+    self.eatCommentsAndSpace(&.{});
+
+    while (true) {
+        self.eatCommentsAndSpace(&.{});
+        const tok = self.token_it.next() orelse break;
+
+        log.debug("(main) next {s}@{d}", .{ @tagName(tok.id), @intFromEnum(self.token_it.pos) - 1 });
+
+        switch (tok.id) {
+            .eof => break,
+            else => {
+                self.token_it.seekBy(-1);
+                const node_index = try self.doc(gpa);
+                try self.docs.append(gpa, node_index);
+            },
+        }
+    }
+}
+
+pub fn toOwnedTree(self: *Parser, gpa: Allocator) Allocator.Error!Tree {
+    return .{
+        .source = self.source,
+        .tokens = self.tokens.toOwnedSlice(),
+        .docs = try self.docs.toOwnedSlice(gpa),
+        .nodes = self.nodes.toOwnedSlice(),
+        .extra = try self.extra.toOwnedSlice(gpa),
+        .string_bytes = try self.string_bytes.toOwnedSlice(gpa),
+    };
+}
+
+fn addString(self: *Parser, gpa: Allocator, string: []const u8) Allocator.Error!String {
+    const index: u32 = @intCast(self.string_bytes.items.len);
+    try self.string_bytes.ensureUnusedCapacity(gpa, string.len);
+    self.string_bytes.appendSliceAssumeCapacity(string);
+    return .{ .index = @enumFromInt(index), .len = @intCast(string.len) };
+}
+
+fn addExtra(self: *Parser, gpa: Allocator, extra: anytype) Allocator.Error!u32 {
+    const fields = std.meta.fields(@TypeOf(extra));
+    try self.extra.ensureUnusedCapacity(gpa, fields.len);
+    return self.addExtraAssumeCapacity(extra);
+}
+
+fn addExtraAssumeCapacity(self: *Parser, extra: anytype) u32 {
+    const result: u32 = @intCast(self.extra.items.len);
+    self.extra.appendSliceAssumeCapacity(&payloadToExtraItems(extra));
+    return result;
+}
+
+fn payloadToExtraItems(data: anytype) [@typeInfo(@TypeOf(data)).@"struct".fields.len]u32 {
+    const fields = @typeInfo(@TypeOf(data)).@"struct".fields;
+    var result: [fields.len]u32 = undefined;
+    inline for (&result, fields) |*val, field| {
+        val.* = switch (field.type) {
+            u32 => @field(data, field.name),
+            i32 => @bitCast(@field(data, field.name)),
+            Node.Index, Node.OptionalIndex, Token.Index => @intFromEnum(@field(data, field.name)),
+            else => @compileError("bad field type: " ++ @typeName(field.type)),
+        };
+    }
+    return result;
+}
+
+fn value(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
+    self.eatCommentsAndSpace(&.{});
+
+    const pos = self.token_it.pos;
+    const tok = self.token_it.next() orelse return error.UnexpectedEof;
+
+    log.debug("  next {s}@{d}", .{ @tagName(tok.id), pos });
+
+    switch (tok.id) {
+        .literal => if (self.eatToken(.map_value_ind, &.{ .new_line, .comment })) |_| {
+            // map
+            self.token_it.seekTo(pos);
+            return self.map(gpa);
+        } else {
+            // leaf value
+            self.token_it.seekTo(pos);
+            return self.leafValue(gpa);
+        },
+        .single_quoted, .double_quoted => {
+            // leaf value
+            self.token_it.seekBy(-1);
+            return self.leafValue(gpa);
+        },
+        .seq_item_ind => {
+            // list
+            self.token_it.seekBy(-1);
+            return self.list(gpa);
+        },
+        .flow_seq_start => {
+            // list
+            self.token_it.seekBy(-1);
+            return self.listBracketed(gpa);
+        },
+        else => return .none,
+    }
+}
+
+fn doc(self: *Parser, gpa: Allocator) ParseError!Node.Index {
+    const node_index = try self.nodes.addOne(gpa);
+    const node_start = self.token_it.pos;
+
+    log.debug("(doc) begin {s}@{d}", .{ @tagName(self.token(node_start).id), node_start });
+
+    // Parse header
+    const header: union(enum) {
+        directive: Token.Index,
+        explicit,
+        implicit,
+    } = if (self.eatToken(.doc_start, &.{})) |doc_pos| explicit: {
+        if (self.getCol(doc_pos) > 0) return error.MalformedYaml;
+        if (self.eatToken(.tag, &.{ .new_line, .comment })) |_| {
+            break :explicit .{ .directive = try self.expectToken(.literal, &.{ .new_line, .comment }) };
+        }
+        break :explicit .explicit;
+    } else .implicit;
+    const directive = switch (header) {
+        .directive => |index| index,
+        else => null,
+    };
+    const is_explicit = switch (header) {
+        .directive, .explicit => true,
+        .implicit => false,
+    };
+
+    // Parse value
+    const value_index = try self.value(gpa);
+    if (value_index == .none) {
+        self.token_it.seekBy(-1);
+    }
+
+    // Parse footer
+    const node_end: Token.Index = footer: {
+        if (self.eatToken(.doc_end, &.{})) |pos| {
+            if (!is_explicit) {
+                self.token_it.seekBy(-1);
+                return self.fail(gpa, self.token_it.pos, "missing explicit document open marker '---'", .{});
+            }
+            if (self.getCol(pos) > 0) return error.MalformedYaml;
+            break :footer pos;
+        }
+        if (self.eatToken(.doc_start, &.{})) |pos| {
+            if (!is_explicit) return error.UnexpectedToken;
+            if (self.getCol(pos) > 0) return error.MalformedYaml;
+            self.token_it.seekBy(-1);
+            break :footer @enumFromInt(@intFromEnum(pos) - 1);
+        }
+        if (self.eatToken(.eof, &.{})) |pos| {
+            break :footer @enumFromInt(@intFromEnum(pos) - 1);
+        }
+
+        return self.fail(gpa, self.token_it.pos, "expected end of document", .{});
+    };
+
+    log.debug("(doc) end {s}@{d}", .{ @tagName(self.token(node_end).id), node_end });
+
+    self.nodes.set(node_index, .{
+        .tag = if (directive == null) .doc else .doc_with_directive,
+        .scope = .{
+            .start = node_start,
+            .end = node_end,
+        },
+        .data = if (directive == null) .{
+            .maybe_node = value_index,
+        } else .{
+            .doc_with_directive = .{
+                .maybe_node = value_index,
+                .directive = directive.?,
+            },
+        },
+    });
+
+    return @enumFromInt(node_index);
+}
+
+fn map(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
+    const node_index = try self.nodes.addOne(gpa);
+    const node_start = self.token_it.pos;
+
+    var entries: std.ArrayListUnmanaged(Map.Entry) = .empty;
+    defer entries.deinit(gpa);
+
+    log.debug("(map) begin {s}@{d}", .{ @tagName(self.token(node_start).id), node_start });
+
+    const col = self.getCol(node_start);
+
+    while (true) {
+        self.eatCommentsAndSpace(&.{});
+
+        // Parse key
+        const key_pos = self.token_it.pos;
+        if (self.getCol(key_pos) < col) break;
+
+        const key = self.token_it.next() orelse return error.UnexpectedEof;
+        switch (key.id) {
+            .literal => {},
+            .doc_start, .doc_end, .eof => {
+                self.token_it.seekBy(-1);
+                break;
+            },
+            .flow_map_end => {
+                break;
+            },
+            else => return self.fail(gpa, self.token_it.pos, "unexpected token for 'key': {}", .{key}),
+        }
+
+        log.debug("(map) key {s}@{d}", .{ self.rawString(key_pos, key_pos), key_pos });
+
+        // Separator
+        _ = self.expectToken(.map_value_ind, &.{ .new_line, .comment }) catch
+            return self.fail(gpa, self.token_it.pos, "expected map separator ':'", .{});
+
+        // Parse value
+        const value_index = try self.value(gpa);
+
+        if (value_index.unwrap()) |v| {
+            const value_start = self.nodes.items(.scope)[@intFromEnum(v)].start;
+            if (self.getCol(value_start) < self.getCol(key_pos)) {
+                return error.MalformedYaml;
+            }
+            if (self.nodes.items(.tag)[@intFromEnum(v)] == .value) {
+                if (self.getCol(value_start) == self.getCol(key_pos)) {
+                    return self.fail(gpa, value_start, "'value' in map should have more indentation than the 'key'", .{});
+                }
+            }
+        }
+
+        try entries.append(gpa, .{
+            .key = key_pos,
+            .maybe_node = value_index,
+        });
+    }
+
+    const node_end: Token.Index = @enumFromInt(@intFromEnum(self.token_it.pos) - 1);
+
+    log.debug("(map) end {s}@{d}", .{ @tagName(self.token(node_end).id), node_end });
+
+    const scope: Node.Scope = .{
+        .start = node_start,
+        .end = node_end,
+    };
+
+    if (entries.items.len == 1) {
+        const entry = entries.items[0];
+
+        self.nodes.set(node_index, .{
+            .tag = .map_single,
+            .scope = scope,
+            .data = .{ .map = .{
+                .key = entry.key,
+                .maybe_node = entry.maybe_node,
+            } },
+        });
+    } else {
+        try self.extra.ensureUnusedCapacity(gpa, entries.items.len * 2 + 1);
+        const extra_index: u32 = @intCast(self.extra.items.len);
+
+        _ = self.addExtraAssumeCapacity(Map{ .map_len = @intCast(entries.items.len) });
+
+        for (entries.items) |entry| {
+            _ = self.addExtraAssumeCapacity(entry);
+        }
+
+        self.nodes.set(node_index, .{
+            .tag = .map_many,
+            .scope = scope,
+            .data = .{ .extra = @enumFromInt(extra_index) },
+        });
+    }
+
+    return @as(Node.Index, @enumFromInt(node_index)).toOptional();
+}
+
+fn list(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
+    const node_index: Node.Index = @enumFromInt(try self.nodes.addOne(gpa));
+    const node_start = self.token_it.pos;
+
+    var values: std.ArrayListUnmanaged(List.Entry) = .empty;
+    defer values.deinit(gpa);
+
+    const first_col = self.getCol(node_start);
+
+    log.debug("(list) begin {s}@{d}", .{ @tagName(self.token(node_start).id), node_start });
+
+    while (true) {
+        self.eatCommentsAndSpace(&.{});
+
+        const pos = self.eatToken(.seq_item_ind, &.{}) orelse {
+            log.debug("(list {d}) break", .{first_col});
+            break;
+        };
+        const cur_col = self.getCol(pos);
+        if (cur_col < first_col) {
+            log.debug("(list {d}) << break", .{first_col});
+            // this hyphen belongs to an outer list
+            self.token_it.seekBy(-1);
+            // this will end this list
+            break;
+        }
+        //  an inner list will be parsed by self.value() so
+        //  checking for  cur_col > first_col is not necessary here
+
+        const value_index = try self.value(gpa);
+        if (value_index == .none) return error.MalformedYaml;
+
+        try values.append(gpa, .{ .node = value_index.unwrap().? });
+    }
+
+    const node_end: Token.Index = @enumFromInt(@intFromEnum(self.token_it.pos) - 1);
+
+    log.debug("(list) end {s}@{d}", .{ @tagName(self.token(node_end).id), node_end });
+
+    try self.encodeList(gpa, node_index, values.items, .{
+        .start = node_start,
+        .end = node_end,
+    });
+
+    return node_index.toOptional();
+}
+
+fn listBracketed(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
+    const node_index: Node.Index = @enumFromInt(try self.nodes.addOne(gpa));
+    const node_start = self.token_it.pos;
+
+    var values: std.ArrayListUnmanaged(List.Entry) = .empty;
+    defer values.deinit(gpa);
+
+    log.debug("(list) begin {s}@{d}", .{ @tagName(self.token(node_start).id), node_start });
+
+    _ = try self.expectToken(.flow_seq_start, &.{});
+
+    const node_end: Token.Index = while (true) {
+        self.eatCommentsAndSpace(&.{.comment});
+
+        if (self.eatToken(.flow_seq_end, &.{.comment})) |pos|
+            break pos;
+
+        _ = self.eatToken(.comma, &.{.comment});
+
+        if (self.eatToken(.flow_seq_end, &.{.comment})) |pos|
+            break pos;
+
+        const value_raw_pos = self.token_it.pos;
+        const value_index = try self.value(gpa);
+        if (value_index == .none) {
+            return self.fail(gpa, value_raw_pos, "expecting a value in flow sequence", .{});
+        }
+
+        try values.append(gpa, .{ .node = value_index.unwrap().? });
+    };
+
+    if (self.eatToken(.comment, &.{.comment})) |pos| {
+        return self.fail(gpa, pos, "comments must be separated from other tokens by white space characters", .{});
+    }
+
+    log.debug("(list) end {s}@{d}", .{ @tagName(self.token(node_end).id), node_end });
+
+    try self.encodeList(gpa, node_index, values.items, .{
+        .start = node_start,
+        .end = node_end,
+    });
+
+    return node_index.toOptional();
+}
+
+fn encodeList(
+    self: *Parser,
+    gpa: Allocator,
+    node_index: Node.Index,
+    values: []const List.Entry,
+    node_scope: Node.Scope,
+) Allocator.Error!void {
+    const index = @intFromEnum(node_index);
+    switch (values.len) {
+        0 => {
+            self.nodes.set(index, .{
+                .tag = .list_empty,
+                .scope = node_scope,
+                .data = undefined,
+            });
+        },
+        1 => {
+            self.nodes.set(index, .{
+                .tag = .list_one,
+                .scope = node_scope,
+                .data = .{ .node = values[0].node },
+            });
+        },
+        2 => {
+            self.nodes.set(index, .{
+                .tag = .list_two,
+                .scope = node_scope,
+                .data = .{ .list = .{
+                    .el1 = values[0].node,
+                    .el2 = values[1].node,
+                } },
+            });
+        },
+        else => {
+            try self.extra.ensureUnusedCapacity(gpa, values.len + 1);
+            const extra_index: u32 = @intCast(self.extra.items.len);
+
+            _ = self.addExtraAssumeCapacity(List{ .list_len = @intCast(values.len) });
+
+            for (values) |entry| {
+                _ = self.addExtraAssumeCapacity(entry);
+            }
+
+            self.nodes.set(index, .{
+                .tag = .list_many,
+                .scope = node_scope,
+                .data = .{ .extra = @enumFromInt(extra_index) },
+            });
+        },
+    }
+}
+
+fn leafValue(self: *Parser, gpa: Allocator) ParseError!Node.OptionalIndex {
+    const node_index: Node.Index = @enumFromInt(try self.nodes.addOne(gpa));
+    const node_start = self.token_it.pos;
+
+    // TODO handle multiline strings in new block scope
+    while (self.token_it.next()) |tok| {
+        switch (tok.id) {
+            .single_quoted => {
+                const node_end: Token.Index = @enumFromInt(@intFromEnum(self.token_it.pos) - 1);
+                const raw = self.rawString(node_start, node_end);
+                log.debug("(leaf) {s}", .{raw});
+                assert(raw.len > 0);
+                const string = try self.parseSingleQuoted(gpa, raw);
+
+                self.nodes.set(@intFromEnum(node_index), .{
+                    .tag = .string_value,
+                    .scope = .{
+                        .start = node_start,
+                        .end = node_end,
+                    },
+                    .data = .{ .string = string },
+                });
+
+                return node_index.toOptional();
+            },
+            .double_quoted => {
+                const node_end: Token.Index = @enumFromInt(@intFromEnum(self.token_it.pos) - 1);
+                const raw = self.rawString(node_start, node_end);
+                log.debug("(leaf) {s}", .{raw});
+                assert(raw.len > 0);
+                const string = try self.parseDoubleQuoted(gpa, raw);
+
+                self.nodes.set(@intFromEnum(node_index), .{
+                    .tag = .string_value,
+                    .scope = .{
+                        .start = node_start,
+                        .end = node_end,
+                    },
+                    .data = .{ .string = string },
+                });
+
+                return node_index.toOptional();
+            },
+            .literal => {},
+            .space => {
+                const trailing = @intFromEnum(self.token_it.pos) - 2;
+                self.eatCommentsAndSpace(&.{});
+                if (self.token_it.peek()) |peek| {
+                    if (peek.id != .literal) {
+                        const node_end: Token.Index = @enumFromInt(trailing);
+                        log.debug("(leaf) {s}", .{self.rawString(node_start, node_end)});
+                        self.nodes.set(@intFromEnum(node_index), .{
+                            .tag = .value,
+                            .scope = .{
+                                .start = node_start,
+                                .end = node_end,
+                            },
+                            .data = undefined,
+                        });
+                        return node_index.toOptional();
+                    }
+                }
+            },
+            else => {
+                self.token_it.seekBy(-1);
+                const node_end: Token.Index = @enumFromInt(@intFromEnum(self.token_it.pos) - 1);
+                log.debug("(leaf) {s}", .{self.rawString(node_start, node_end)});
+                self.nodes.set(@intFromEnum(node_index), .{
+                    .tag = .value,
+                    .scope = .{
+                        .start = node_start,
+                        .end = node_end,
+                    },
+                    .data = undefined,
+                });
+                return node_index.toOptional();
+            },
+        }
+    }
+
+    return error.MalformedYaml;
+}
+
+fn eatCommentsAndSpace(self: *Parser, comptime exclusions: []const Token.Id) void {
+    log.debug("eatCommentsAndSpace", .{});
+    outer: while (self.token_it.next()) |tok| {
+        log.debug("  (token '{s}')", .{@tagName(tok.id)});
+        switch (tok.id) {
+            .comment, .space, .new_line => |space| {
+                inline for (exclusions) |excl| {
+                    if (excl == space) {
+                        self.token_it.seekBy(-1);
+                        break :outer;
+                    }
+                } else continue;
+            },
+            else => {
+                self.token_it.seekBy(-1);
+                break;
+            },
+        }
+    }
+}
+
+fn eatToken(self: *Parser, id: Token.Id, comptime exclusions: []const Token.Id) ?Token.Index {
+    log.debug("eatToken('{s}')", .{@tagName(id)});
+    self.eatCommentsAndSpace(exclusions);
+    const pos = self.token_it.pos;
+    const tok = self.token_it.next() orelse return null;
+    if (tok.id == id) {
+        log.debug("  (found at {d})", .{pos});
+        return pos;
+    } else {
+        log.debug("  (not found)", .{});
+        self.token_it.seekBy(-1);
+        return null;
+    }
+}
+
+fn expectToken(self: *Parser, id: Token.Id, comptime exclusions: []const Token.Id) ParseError!Token.Index {
+    log.debug("expectToken('{s}')", .{@tagName(id)});
+    return self.eatToken(id, exclusions) orelse error.UnexpectedToken;
+}
+
+fn getLine(self: *Parser, index: Token.Index) usize {
+    return self.tokens.items(.line_col)[@intFromEnum(index)].line;
+}
+
+fn getCol(self: *Parser, index: Token.Index) usize {
+    return self.tokens.items(.line_col)[@intFromEnum(index)].col;
+}
+
+fn parseSingleQuoted(self: *Parser, gpa: Allocator, raw: []const u8) ParseError!String {
+    assert(raw[0] == '\'' and raw[raw.len - 1] == '\'');
+    const raw_no_quotes = raw[1 .. raw.len - 1];
+
+    try self.string_bytes.ensureUnusedCapacity(gpa, raw_no_quotes.len);
+    var string: String = .{
+        .index = @enumFromInt(@as(u32, @intCast(self.string_bytes.items.len))),
+        .len = 0,
+    };
+
+    var state: enum {
+        start,
+        escape,
+    } = .start;
+
+    var index: usize = 0;
+
+    while (index < raw_no_quotes.len) : (index += 1) {
+        const c = raw_no_quotes[index];
+        switch (state) {
+            .start => switch (c) {
+                '\'' => {
+                    state = .escape;
+                },
+                else => {
+                    self.string_bytes.appendAssumeCapacity(c);
+                    string.len += 1;
+                },
+            },
+            .escape => switch (c) {
+                '\'' => {
+                    state = .start;
+                    self.string_bytes.appendAssumeCapacity(c);
+                    string.len += 1;
+                },
+                else => return error.InvalidEscapeSequence,
+            },
+        }
+    }
+
+    return string;
+}
+
+fn parseDoubleQuoted(self: *Parser, gpa: Allocator, raw: []const u8) ParseError!String {
+    assert(raw[0] == '"' and raw[raw.len - 1] == '"');
+    const raw_no_quotes = raw[1 .. raw.len - 1];
+
+    try self.string_bytes.ensureUnusedCapacity(gpa, raw_no_quotes.len);
+    var string: String = .{
+        .index = @enumFromInt(@as(u32, @intCast(self.string_bytes.items.len))),
+        .len = 0,
+    };
+
+    var state: enum {
+        start,
+        escape,
+    } = .start;
+
+    var index: usize = 0;
+
+    while (index < raw_no_quotes.len) : (index += 1) {
+        const c = raw_no_quotes[index];
+        switch (state) {
+            .start => switch (c) {
+                '\\' => {
+                    state = .escape;
+                },
+                else => {
+                    self.string_bytes.appendAssumeCapacity(c);
+                    string.len += 1;
+                },
+            },
+            .escape => switch (c) {
+                'n' => {
+                    state = .start;
+                    self.string_bytes.appendAssumeCapacity('\n');
+                    string.len += 1;
+                },
+                't' => {
+                    state = .start;
+                    self.string_bytes.appendAssumeCapacity('\t');
+                    string.len += 1;
+                },
+                '"' => {
+                    state = .start;
+                    self.string_bytes.appendAssumeCapacity('"');
+                    string.len += 1;
+                },
+                else => return error.InvalidEscapeSequence,
+            },
+        }
+    }
+
+    return string;
+}
+
+fn rawString(self: Parser, start: Token.Index, end: Token.Index) []const u8 {
+    const start_token = self.token(start);
+    const end_token = self.token(end);
+    return self.source[start_token.loc.start..end_token.loc.end];
+}
+
+fn token(self: Parser, index: Token.Index) Token {
+    return self.tokens.items(.token)[@intFromEnum(index)];
+}
+
+fn fail(self: *Parser, gpa: Allocator, token_index: Token.Index, comptime format: []const u8, args: anytype) ParseError {
+    const line_col = self.tokens.items(.line_col)[@intFromEnum(token_index)];
+    const msg = try std.fmt.allocPrint(gpa, format, args);
+    defer gpa.free(msg);
+    const line_info = getLineInfo(self.source, line_col);
+    try self.errors.addRootErrorMessage(.{
+        .msg = try self.errors.addString(msg),
+        .src_loc = try self.errors.addSourceLocation(.{
+            .src_path = try self.errors.addString("(memory)"),
+            .line = line_col.line,
+            .column = line_col.col,
+            .span_start = line_info.span_start,
+            .span_main = line_info.span_main,
+            .span_end = line_info.span_end,
+            .source_line = try self.errors.addString(line_info.line),
+        }),
+        .notes_len = 0,
+    });
+    return error.ParseFailure;
+}
+
+fn getLineInfo(source: []const u8, line_col: LineCol) struct {
+    line: []const u8,
+    span_start: u32,
+    span_main: u32,
+    span_end: u32,
+} {
+    const line = line: {
+        var it = mem.splitScalar(u8, source, '\n');
+        var line_count: usize = 0;
+        const line = while (it.next()) |line| {
+            defer line_count += 1;
+            if (line_count == line_col.line) break line;
+        } else return .{
+            .line = &.{},
+            .span_start = 0,
+            .span_main = 0,
+            .span_end = 0,
+        };
+        break :line line;
+    };
+
+    const span_start: u32 = span_start: {
+        const trimmed = mem.trimStart(u8, line, " ");
+        break :span_start @intCast(mem.indexOf(u8, line, trimmed).?);
+    };
+
+    const span_end: u32 = @intCast(mem.trimEnd(u8, line, " \r\n").len);
+
+    return .{
+        .line = line,
+        .span_start = span_start,
+        .span_main = line_col.col,
+        .span_end = span_end,
+    };
+}
+
+pub const ParseError = error{
+    InvalidEscapeSequence,
+    MalformedYaml,
+    NestedDocuments,
+    UnexpectedEof,
+    UnexpectedToken,
+    ParseFailure,
+} || Allocator.Error;
+
+test {
+    std.testing.refAllDecls(@This());
+    _ = @import("Parser/test.zig");
+}

--- a/vendor/zig-yaml/src/Parser/test.zig
+++ b/vendor/zig-yaml/src/Parser/test.zig
@@ -1,0 +1,916 @@
+const std = @import("std");
+const mem = std.mem;
+const testing = std.testing;
+
+const List = Tree.List;
+const Map = Tree.Map;
+const Node = Tree.Node;
+const Parser = @import("../Parser.zig");
+const Tree = @import("../Tree.zig");
+
+fn expectNodeScope(tree: Tree, node: Node.Index, from: usize, to: usize) !void {
+    const scope = tree.nodeScope(node);
+    try testing.expectEqual(from, @intFromEnum(scope.start));
+    try testing.expectEqual(to, @intFromEnum(scope.end));
+}
+
+fn expectValueMapEntry(tree: Tree, entry_data: Map.Entry, exp_key: []const u8, exp_value: []const u8) !void {
+    const key = tree.token(entry_data.key);
+    try testing.expectEqual(key.id, .literal);
+    try testing.expectEqualStrings(exp_key, tree.rawString(entry_data.key, entry_data.key));
+
+    const maybe_value = entry_data.maybe_node;
+    try testing.expect(maybe_value != .none);
+    try testing.expectEqual(.value, tree.nodeTag(maybe_value.unwrap().?));
+
+    const value = maybe_value.unwrap().?;
+    const string = tree.nodeScope(value).rawString(tree);
+    try testing.expectEqualStrings(exp_value, string);
+}
+
+fn expectStringValueMapEntry(tree: Tree, entry_data: Map.Entry, exp_key: []const u8, exp_value: []const u8) !void {
+    const key = tree.token(entry_data.key);
+    try testing.expectEqual(key.id, .literal);
+    try testing.expectEqualStrings(exp_key, tree.rawString(entry_data.key, entry_data.key));
+
+    const maybe_value = entry_data.maybe_node;
+    try testing.expect(maybe_value != .none);
+    try testing.expectEqual(.string_value, tree.nodeTag(maybe_value.unwrap().?));
+
+    const value = maybe_value.unwrap().?;
+    const string = tree.nodeData(value).string.slice(tree);
+    try testing.expectEqualStrings(exp_value, string);
+}
+
+fn expectValueListEntry(tree: Tree, entry_data: List.Entry, exp_value: []const u8) !void {
+    const value = entry_data.node;
+    try testing.expectEqual(.value, tree.nodeTag(value));
+
+    const string = tree.nodeScope(value).rawString(tree);
+    try testing.expectEqualStrings(exp_value, string);
+}
+
+fn expectNestedMapListEntry(tree: Tree, list_entry_data: List.Entry, exp_key: []const u8, exp_value: []const u8) !void {
+    const value = list_entry_data.node;
+    try testing.expectEqual(.map_single, tree.nodeTag(value));
+
+    const map_data = tree.nodeData(value).map;
+    try expectValueMapEntry(tree, .{
+        .key = map_data.key,
+        .maybe_node = map_data.maybe_node,
+    }, exp_key, exp_value);
+}
+
+test "explicit doc" {
+    const source =
+        \\--- !tapi-tbd
+        \\tbd-version: 4
+        \\abc-version: 5
+        \\...
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try testing.expectEqual(.doc_with_directive, tree.nodeTag(doc));
+
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const directive = tree.directive(doc).?;
+    try testing.expectEqualStrings("tapi-tbd", directive);
+
+    const doc_value = tree.nodeData(doc).doc_with_directive.maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map_many, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, map, 5, 14);
+
+    const map_data = tree.extraData(Map, tree.nodeData(map).extra);
+    try testing.expectEqual(2, map_data.data.map_len);
+
+    var entry_data = tree.extraData(Map.Entry, map_data.end);
+    try expectValueMapEntry(tree, entry_data.data, "tbd-version", "4");
+
+    entry_data = tree.extraData(Map.Entry, entry_data.end);
+    try expectValueMapEntry(tree, entry_data.data, "abc-version", "5");
+}
+
+test "leaf in quotes" {
+    const source =
+        \\key1: no quotes, comma
+        \\key2: 'single quoted'
+        \\key3: "double quoted"
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try testing.expectEqual(.doc, tree.nodeTag(doc));
+
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map_many, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.extraData(Map, tree.nodeData(map).extra);
+    try testing.expectEqual(3, map_data.data.map_len);
+
+    var entry_data = tree.extraData(Map.Entry, map_data.end);
+    try expectValueMapEntry(tree, entry_data.data, "key1", "no quotes, comma");
+
+    entry_data = tree.extraData(Map.Entry, entry_data.end);
+    try expectStringValueMapEntry(tree, entry_data.data, "key2", "single quoted");
+
+    entry_data = tree.extraData(Map.Entry, entry_data.end);
+    try expectStringValueMapEntry(tree, entry_data.data, "key3", "double quoted");
+}
+
+test "nested maps" {
+    const source =
+        \\key1:
+        \\  key1_1 : value1_1
+        \\  key1_2 : value1_2
+        \\key2   : value2
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try testing.expectEqual(.doc, tree.nodeTag(doc));
+
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map_many, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.extraData(Map, tree.nodeData(map).extra);
+    try testing.expectEqual(2, map_data.data.map_len);
+
+    var entry_data = tree.extraData(Map.Entry, map_data.end);
+    {
+        const key = tree.token(entry_data.data.key);
+        try testing.expectEqual(key.id, .literal);
+        try testing.expectEqualStrings("key1", tree.rawString(entry_data.data.key, entry_data.data.key));
+
+        const maybe_nested_map = entry_data.data.maybe_node;
+        try testing.expect(maybe_nested_map != .none);
+        try testing.expectEqual(.map_many, tree.nodeTag(maybe_nested_map.unwrap().?));
+
+        const nested_map = maybe_nested_map.unwrap().?;
+
+        try expectNodeScope(tree, nested_map, 4, 16);
+
+        const nested_map_data = tree.extraData(Map, tree.nodeData(nested_map).extra);
+        try testing.expectEqual(2, nested_map_data.data.map_len);
+
+        var nested_entry_data = tree.extraData(Map.Entry, nested_map_data.end);
+        try expectValueMapEntry(tree, nested_entry_data.data, "key1_1", "value1_1");
+
+        nested_entry_data = tree.extraData(Map.Entry, nested_entry_data.end);
+        try expectValueMapEntry(tree, nested_entry_data.data, "key1_2", "value1_2");
+    }
+
+    entry_data = tree.extraData(Map.Entry, entry_data.end);
+    try expectValueMapEntry(tree, entry_data.data, "key2", "value2");
+}
+
+test "map of list of values" {
+    const source =
+        \\ints:
+        \\  - 0
+        \\  - 1
+        \\  - 2
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map_single, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.nodeData(map).map;
+
+    {
+        const key = tree.token(map_data.key);
+        try testing.expectEqual(key.id, .literal);
+        try testing.expectEqualStrings("ints", tree.rawString(map_data.key, map_data.key));
+
+        const maybe_nested_list = map_data.maybe_node;
+        try testing.expect(maybe_nested_list != .none);
+        try testing.expectEqual(.list_many, tree.nodeTag(maybe_nested_list.unwrap().?));
+
+        const nested_list = maybe_nested_list.unwrap().?;
+
+        try expectNodeScope(tree, nested_list, 4, tree.tokens.len - 2);
+
+        const nested_list_data = tree.extraData(List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "0");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "1");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "2");
+    }
+}
+
+test "map of list of maps" {
+    const source =
+        \\key1:
+        \\- key2 : value2
+        \\- key3 : value3
+        \\- key4 : value4
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map_single, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.nodeData(map).map;
+
+    {
+        const key = tree.token(map_data.key);
+        try testing.expectEqual(key.id, .literal);
+        try testing.expectEqualStrings("key1", tree.rawString(map_data.key, map_data.key));
+
+        const maybe_nested_list = map_data.maybe_node;
+        try testing.expect(maybe_nested_list != .none);
+        try testing.expectEqual(.list_many, tree.nodeTag(maybe_nested_list.unwrap().?));
+
+        const nested_list = maybe_nested_list.unwrap().?;
+
+        try expectNodeScope(tree, nested_list, 3, tree.tokens.len - 2);
+
+        const nested_list_data = tree.extraData(List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(List.Entry, nested_list_data.end);
+        try expectNestedMapListEntry(tree, nested_entry_data.data, "key2", "value2");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectNestedMapListEntry(tree, nested_entry_data.data, "key3", "value3");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectNestedMapListEntry(tree, nested_entry_data.data, "key4", "value4");
+    }
+}
+
+test "map of list of maps with inner list" {
+    const source =
+        \\ outer:
+        \\   - a: foo
+        \\     fooers:
+        \\       - name: inner-foo
+        \\   - b: bar
+        \\     fooers:
+        \\       - name: inner-bar
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(tree, doc, 1, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map_single, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, map, 1, tree.tokens.len - 2);
+
+    const map_data = tree.nodeData(map).map;
+
+    {
+        const key = tree.token(map_data.key);
+        try testing.expectEqual(key.id, .literal);
+        try testing.expectEqualStrings("outer", tree.rawString(map_data.key, map_data.key));
+
+        const maybe_nested_list = map_data.maybe_node;
+        try testing.expect(maybe_nested_list != .none);
+        try testing.expectEqual(.list_two, tree.nodeTag(maybe_nested_list.unwrap().?));
+
+        const nested_list = maybe_nested_list.unwrap().?;
+
+        try expectNodeScope(tree, nested_list, 5, tree.tokens.len - 2);
+
+        const nested_list_data = tree.nodeData(nested_list).list;
+
+        {
+            const nested_map = nested_list_data.el1;
+            try testing.expectEqual(.map_many, tree.nodeTag(nested_map));
+
+            const nested_map_data = tree.extraData(Map, tree.nodeData(nested_map).extra);
+            try testing.expectEqual(2, nested_map_data.data.map_len);
+
+            var nested_nested_entry_data = tree.extraData(Map.Entry, nested_map_data.end);
+            try expectValueMapEntry(tree, nested_nested_entry_data.data, "a", "foo");
+
+            nested_nested_entry_data = tree.extraData(Map.Entry, nested_nested_entry_data.end);
+            {
+                const nested_nested_map_entry = nested_nested_entry_data.data;
+                const nested_nested_key = tree.token(nested_nested_map_entry.key);
+                try testing.expectEqual(nested_nested_key.id, .literal);
+                try testing.expectEqualStrings("fooers", tree.rawString(nested_nested_map_entry.key, nested_nested_map_entry.key));
+
+                const nested_nested_value = nested_nested_map_entry.maybe_node;
+                try testing.expect(nested_nested_value != .none);
+                try testing.expectEqual(.list_one, tree.nodeTag(nested_nested_value.unwrap().?));
+
+                const nested_nested_list = nested_nested_value.unwrap().?;
+                const nested_nested_list_data = tree.nodeData(nested_nested_list).node;
+                try expectNestedMapListEntry(tree, .{ .node = nested_nested_list_data }, "name", "inner-foo");
+            }
+        }
+
+        {
+            const nested_map = nested_list_data.el2;
+            try testing.expectEqual(.map_many, tree.nodeTag(nested_map));
+
+            const nested_map_data = tree.extraData(Map, tree.nodeData(nested_map).extra);
+            try testing.expectEqual(2, nested_map_data.data.map_len);
+
+            var nested_nested_entry_data = tree.extraData(Map.Entry, nested_map_data.end);
+            try expectValueMapEntry(tree, nested_nested_entry_data.data, "b", "bar");
+
+            nested_nested_entry_data = tree.extraData(Map.Entry, nested_nested_entry_data.end);
+            {
+                const nested_nested_map_entry = nested_nested_entry_data.data;
+                const nested_nested_key = tree.token(nested_nested_map_entry.key);
+                try testing.expectEqual(nested_nested_key.id, .literal);
+                try testing.expectEqualStrings("fooers", tree.rawString(nested_nested_map_entry.key, nested_nested_map_entry.key));
+
+                const nested_nested_value = nested_nested_map_entry.maybe_node;
+                try testing.expect(nested_nested_value != .none);
+                try testing.expectEqual(.list_one, tree.nodeTag(nested_nested_value.unwrap().?));
+
+                const nested_nested_list = nested_nested_value.unwrap().?;
+                const nested_nested_list_data = tree.nodeData(nested_nested_list).node;
+                try expectNestedMapListEntry(tree, .{ .node = nested_nested_list_data }, "name", "inner-bar");
+            }
+        }
+    }
+}
+
+test "list of lists" {
+    const source =
+        \\- [name        , hr, avg  ]
+        \\- [Mark McGwire , 65, 0.278]
+        \\- [Sammy Sosa   , 63, 0.288]
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.list_many, tree.nodeTag(doc_value.unwrap().?));
+
+    const list = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, list, 0, tree.tokens.len - 2);
+
+    const list_data = tree.extraData(List, tree.nodeData(list).extra);
+    try testing.expectEqual(3, list_data.data.list_len);
+
+    var entry_data = tree.extraData(List.Entry, list_data.end);
+    {
+        const nested_list = entry_data.data.node;
+
+        try expectNodeScope(tree, nested_list, 1, 11);
+
+        const nested_list_data = tree.extraData(List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "name");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "hr");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "avg");
+    }
+
+    entry_data = tree.extraData(List.Entry, entry_data.end);
+    {
+        const nested_list = entry_data.data.node;
+
+        try expectNodeScope(tree, nested_list, 14, 25);
+
+        const nested_list_data = tree.extraData(List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "Mark McGwire");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "65");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "0.278");
+    }
+
+    entry_data = tree.extraData(List.Entry, entry_data.end);
+    {
+        const nested_list = entry_data.data.node;
+
+        try expectNodeScope(tree, nested_list, 28, 39);
+
+        const nested_list_data = tree.extraData(List, tree.nodeData(nested_list).extra);
+        try testing.expectEqual(3, nested_list_data.data.list_len);
+
+        var nested_entry_data = tree.extraData(List.Entry, nested_list_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "Sammy Sosa");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "63");
+
+        nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+        try expectValueListEntry(tree, nested_entry_data.data, "0.288");
+    }
+}
+
+test "inline list" {
+    const source =
+        \\[name        , hr, avg  ]
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.list_many, tree.nodeTag(doc_value.unwrap().?));
+
+    const list = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, list, 0, tree.tokens.len - 2);
+
+    const list_data = tree.extraData(List, tree.nodeData(list).extra);
+    try testing.expectEqual(3, list_data.data.list_len);
+
+    var entry_data = tree.extraData(List.Entry, list_data.end);
+    try expectValueListEntry(tree, entry_data.data, "name");
+
+    entry_data = tree.extraData(List.Entry, entry_data.end);
+    try expectValueListEntry(tree, entry_data.data, "hr");
+
+    entry_data = tree.extraData(List.Entry, entry_data.end);
+    try expectValueListEntry(tree, entry_data.data, "avg");
+}
+
+test "inline list as mapping value" {
+    const source =
+        \\key : [
+        \\        name        ,
+        \\        hr, avg  ]
+    ;
+
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+
+    var tree = try parser.toOwnedTree(testing.allocator);
+    defer tree.deinit(testing.allocator);
+
+    try testing.expectEqual(1, tree.docs.len);
+
+    const doc = tree.docs[0];
+    try expectNodeScope(tree, doc, 0, tree.tokens.len - 2);
+
+    const doc_value = tree.nodeData(doc).maybe_node;
+    try testing.expect(doc_value != .none);
+    try testing.expectEqual(.map_single, tree.nodeTag(doc_value.unwrap().?));
+
+    const map = doc_value.unwrap().?;
+
+    try expectNodeScope(tree, map, 0, tree.tokens.len - 2);
+
+    const map_data = tree.nodeData(map).map;
+
+    const key = tree.token(map_data.key);
+    try testing.expectEqual(key.id, .literal);
+    try testing.expectEqualStrings("key", tree.rawString(map_data.key, map_data.key));
+
+    const maybe_nested_list = map_data.maybe_node;
+    try testing.expect(maybe_nested_list != .none);
+    try testing.expectEqual(.list_many, tree.nodeTag(maybe_nested_list.unwrap().?));
+
+    const nested_list = maybe_nested_list.unwrap().?;
+
+    try expectNodeScope(tree, nested_list, 4, tree.tokens.len - 2);
+
+    const nested_list_data = tree.extraData(List, tree.nodeData(nested_list).extra);
+    try testing.expectEqual(3, nested_list_data.data.list_len);
+
+    var nested_entry_data = tree.extraData(List.Entry, nested_list_data.end);
+    try expectValueListEntry(tree, nested_entry_data.data, "name");
+
+    nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+    try expectValueListEntry(tree, nested_entry_data.data, "hr");
+
+    nested_entry_data = tree.extraData(List.Entry, nested_entry_data.end);
+    try expectValueListEntry(tree, nested_entry_data.data, "avg");
+}
+
+fn parseSuccess(comptime source: []const u8) !void {
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try parser.parse(testing.allocator);
+}
+
+fn parseError(comptime source: []const u8, err: Parser.ParseError) !void {
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+    try testing.expectError(err, parser.parse(testing.allocator));
+}
+
+fn parseError2(source: []const u8, comptime format: []const u8, args: anytype) !void {
+    var parser = try Parser.init(testing.allocator, source);
+    defer parser.deinit(testing.allocator);
+
+    const res = parser.parse(testing.allocator);
+    try testing.expectError(error.ParseFailure, res);
+
+    var bundle = try parser.errors.toOwnedBundle("");
+    defer bundle.deinit(testing.allocator);
+    try testing.expect(bundle.errorMessageCount() > 0);
+
+    var given: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer given.deinit();
+    try bundle.renderToWriter(.{}, &given.writer);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, format, args);
+    defer testing.allocator.free(expected);
+    try testing.expectEqualStrings(expected, given.written());
+}
+
+test "empty doc with spaces and comments" {
+    try parseSuccess(
+        \\
+        \\
+        \\   # this is a comment in a weird place
+        \\# and this one is too
+    );
+}
+
+test "comment between --- and ! in document start" {
+    try parseError2(
+        \\--- # what is it?
+        \\!
+    ,
+        \\(memory):2:1: error: expected end of document
+        \\!
+        \\^
+        \\
+    , .{});
+}
+
+test "correct doc start with tag" {
+    try parseSuccess(
+        \\--- !some-tag
+        \\
+    );
+}
+
+test "doc close without explicit doc open" {
+    try parseError2(
+        \\
+        \\
+        \\# something cool
+        \\...
+    ,
+        \\(memory):4:1: error: missing explicit document open marker '---'
+        \\...
+        \\^~~
+        \\
+    , .{});
+}
+
+test "doc open and close are ok" {
+    try parseSuccess(
+        \\---
+        \\# first doc
+        \\
+        \\
+        \\---
+        \\# second doc
+        \\
+        \\
+        \\...
+    );
+}
+
+test "doc with a single string is ok" {
+    try parseSuccess(
+        \\a string of some sort
+        \\
+    );
+}
+
+test "explicit doc with a single string is ok" {
+    try parseSuccess(
+        \\--- !anchor
+        \\# nothing to see here except one string
+        \\  # not a lot to go on with
+        \\a single string
+        \\...
+    );
+}
+
+test "doc with two string is bad" {
+    try parseError2(
+        \\first
+        \\second
+        \\# this should fail already
+    ,
+        \\(memory):2:1: error: expected end of document
+        \\second
+        \\^~~~~~
+        \\
+    , .{});
+}
+
+test "single quote string can have new lines" {
+    try parseSuccess(
+        \\'what is this
+        \\ thing?'
+    );
+}
+
+test "single quote string on one line is fine" {
+    try parseSuccess(
+        \\'here''s an apostrophe'
+    );
+}
+
+test "double quote string can have new lines" {
+    try parseSuccess(
+        \\"what is this
+        \\ thing?"
+    );
+}
+
+test "double quote string on one line is fine" {
+    try parseSuccess(
+        \\"a newline\nand a\ttab"
+    );
+}
+
+test "map with key and value literals" {
+    try parseSuccess(
+        \\key1: val1
+        \\key2 : val2
+    );
+}
+
+test "map of maps" {
+    try parseSuccess(
+        \\
+        \\# the first key
+        \\key1:
+        \\  # the first subkey
+        \\  key1_1: 0
+        \\  key1_2: 1
+        \\# the second key
+        \\key2:
+        \\  key2_1: -1
+        \\  key2_2: -2
+        \\# the end of map
+    );
+}
+
+test "map value indicator needs to be on the same line" {
+    try parseError2(
+        \\a
+        \\  : b
+    ,
+        \\(memory):2:3: error: expected end of document
+        \\  : b
+        \\  ^~~
+        \\
+    , .{});
+}
+
+test "value needs to be indented" {
+    try parseError2(
+        \\a:
+        \\b
+    ,
+        \\(memory):2:1: error: 'value' in map should have more indentation than the 'key'
+        \\b
+        \\^
+        \\
+    , .{});
+}
+
+test "comment between a key and a value is fine" {
+    try parseSuccess(
+        \\a:
+        \\  # this is a value
+        \\  b
+    );
+}
+
+test "simple list" {
+    try parseSuccess(
+        \\# first el
+        \\- a
+        \\# second el
+        \\-  b
+        \\# third el
+        \\-   c
+    );
+}
+
+test "list indentation matters" {
+    try parseError2(
+        \\  - a
+        \\- b
+    ,
+        \\(memory):2:1: error: expected end of document
+        \\- b
+        \\^~~
+        \\
+    , .{});
+
+    try parseSuccess(
+        \\- a
+        \\  - b
+    );
+}
+
+test "unindented list is fine too" {
+    try parseSuccess(
+        \\a:
+        \\- 0
+        \\- 1
+    );
+}
+
+test "empty values in a map" {
+    try parseSuccess(
+        \\a:
+        \\b:
+        \\- 0
+    );
+}
+
+test "weirdly nested map of maps of lists" {
+    try parseSuccess(
+        \\a:
+        \\ b:
+        \\  - 0
+        \\  - 1
+    );
+}
+
+test "square brackets denote a list" {
+    try parseSuccess(
+        \\[ a,
+        \\  b, c ]
+    );
+}
+
+test "empty list" {
+    try parseSuccess(
+        \\[ ]
+    );
+}
+
+test "empty map" {
+    try parseSuccess(
+        \\a:
+        \\  b: {}
+        \\  c: { }
+    );
+}
+
+test "comment within a bracketed list is an error" {
+    try parseError(
+        \\[ # something
+        \\]
+    , error.ParseFailure);
+}
+
+test "mixed ints with floats in a list" {
+    try parseSuccess(
+        \\[0, 1.0]
+    );
+}
+
+test "expect end of document" {
+    try parseError2(
+        \\  key1: value1
+        \\key2: value2
+    ,
+        \\(memory):2:1: error: expected end of document
+        \\key2: value2
+        \\^~~~~~~~~~~~
+        \\
+    , .{});
+}
+
+test "expect map separator" {
+    try parseError2(
+        \\key1: value1
+        \\key2
+    ,
+        \\(memory):2:5: error: expected map separator ':'
+        \\key2
+        \\~~~~^
+        \\
+    , .{});
+}

--- a/vendor/zig-yaml/src/Tokenizer.zig
+++ b/vendor/zig-yaml/src/Tokenizer.zig
@@ -1,0 +1,659 @@
+const Tokenizer = @This();
+
+const std = @import("std");
+const log = std.log.scoped(.tokenizer);
+const testing = std.testing;
+
+buffer: []const u8,
+index: usize = 0,
+in_flow: usize = 0,
+
+pub const Token = struct {
+    id: Id,
+    loc: Loc,
+
+    pub const Loc = struct {
+        start: usize,
+        end: usize,
+    };
+
+    pub const Id = enum {
+        // zig fmt: off
+        eof,
+
+        new_line,
+        doc_start,      // ---
+        doc_end,        // ...
+        seq_item_ind,   // -
+        map_value_ind,  // :
+        flow_map_start, // {
+        flow_map_end,   // }
+        flow_seq_start, // [
+        flow_seq_end,   // ]
+
+        comma,
+        space,
+        tab,
+        comment,        // #
+        alias,          // *
+        anchor,         // &
+        tag,            // !
+
+        single_quoted,   // '...'
+        double_quoted,   // "..."
+        literal,
+        // zig fmt: on
+    };
+
+    pub const Index = enum(u32) {
+        _,
+    };
+};
+
+pub const TokenIterator = struct {
+    buffer: []const Token,
+    pos: Token.Index = @enumFromInt(0),
+
+    pub fn next(self: *TokenIterator) ?Token {
+        const token = self.peek() orelse return null;
+        self.pos = @enumFromInt(@intFromEnum(self.pos) + 1);
+        return token;
+    }
+
+    pub fn peek(self: TokenIterator) ?Token {
+        const pos = @intFromEnum(self.pos);
+        if (pos >= self.buffer.len) return null;
+        return self.buffer[pos];
+    }
+
+    pub fn reset(self: *TokenIterator) void {
+        self.pos = @enumFromInt(0);
+    }
+
+    pub fn seekTo(self: *TokenIterator, pos: Token.Index) void {
+        self.pos = pos;
+    }
+
+    pub fn seekBy(self: *TokenIterator, offset: isize) void {
+        var pos = @intFromEnum(self.pos);
+        if (offset < 0) {
+            pos -|= @intCast(@abs(offset));
+        } else {
+            pos +|= @intCast(@as(usize, @bitCast(offset)));
+        }
+        self.pos = @enumFromInt(pos);
+    }
+};
+
+fn stringMatchesPattern(comptime pattern: []const u8, slice: []const u8) bool {
+    comptime var count: usize = 0;
+    inline while (count < pattern.len) : (count += 1) {
+        if (count >= slice.len) return false;
+        const c = slice[count];
+        if (pattern[count] != c) return false;
+    }
+    return true;
+}
+
+fn matchesPattern(self: Tokenizer, comptime pattern: []const u8) bool {
+    return stringMatchesPattern(pattern, self.buffer[self.index..]);
+}
+
+pub fn next(self: *Tokenizer) Token {
+    var result = Token{
+        .id = .eof,
+        .loc = .{
+            .start = self.index,
+            .end = undefined,
+        },
+    };
+
+    var state: enum {
+        start,
+        new_line,
+        space,
+        tab,
+        comment,
+        single_quoted,
+        double_quoted,
+        literal,
+    } = .start;
+
+    while (self.index < self.buffer.len) : (self.index += 1) {
+        const c = self.buffer[self.index];
+        switch (state) {
+            .start => switch (c) {
+                ' ' => {
+                    state = .space;
+                },
+                '\t' => {
+                    state = .tab;
+                },
+                '\n' => {
+                    result.id = .new_line;
+                    self.index += 1;
+                    break;
+                },
+                '\r' => {
+                    state = .new_line;
+                },
+
+                '-' => if (self.matchesPattern("---")) {
+                    result.id = .doc_start;
+                    self.index += "---".len;
+                    break;
+                } else if (self.matchesPattern("- ")) {
+                    result.id = .seq_item_ind;
+                    self.index += "- ".len;
+                    break;
+                } else if (self.matchesPattern("-\n")) {
+                    result.id = .seq_item_ind;
+                    // we do not skip the newline
+                    self.index += "-".len;
+                    break;
+                } else {
+                    state = .literal;
+                },
+
+                '.' => if (self.matchesPattern("...")) {
+                    result.id = .doc_end;
+                    self.index += "...".len;
+                    break;
+                } else {
+                    state = .literal;
+                },
+
+                ',' => {
+                    result.id = .comma;
+                    self.index += 1;
+                    break;
+                },
+                '#' => {
+                    result.id = .comment;
+                    state = .comment;
+                },
+                '*' => {
+                    result.id = .alias;
+                    self.index += 1;
+                    break;
+                },
+                '&' => {
+                    result.id = .anchor;
+                    self.index += 1;
+                    break;
+                },
+                '!' => {
+                    result.id = .tag;
+                    self.index += 1;
+                    break;
+                },
+                '[' => {
+                    result.id = .flow_seq_start;
+                    self.index += 1;
+                    self.in_flow += 1;
+                    break;
+                },
+                ']' => {
+                    result.id = .flow_seq_end;
+                    self.index += 1;
+                    self.in_flow -|= 1;
+                    break;
+                },
+                ':' => {
+                    result.id = .map_value_ind;
+                    self.index += 1;
+                    break;
+                },
+                '{' => {
+                    result.id = .flow_map_start;
+                    self.index += 1;
+                    self.in_flow += 1;
+                    break;
+                },
+                '}' => {
+                    result.id = .flow_map_end;
+                    self.index += 1;
+                    self.in_flow -|= 1;
+                    break;
+                },
+                '\'' => {
+                    state = .single_quoted;
+                },
+                '"' => {
+                    state = .double_quoted;
+                },
+                else => {
+                    state = .literal;
+                },
+            },
+
+            .comment => switch (c) {
+                '\r', '\n' => {
+                    result.id = .comment;
+                    break;
+                },
+                else => {},
+            },
+
+            .space => switch (c) {
+                ' ' => {},
+                else => {
+                    result.id = .space;
+                    break;
+                },
+            },
+
+            .tab => switch (c) {
+                '\t' => {},
+                else => {
+                    result.id = .tab;
+                    break;
+                },
+            },
+
+            .new_line => switch (c) {
+                '\n' => {
+                    result.id = .new_line;
+                    self.index += 1;
+                    break;
+                },
+                else => {}, // TODO this should be an error condition
+            },
+
+            .single_quoted => switch (c) {
+                '\'' => if (!self.matchesPattern("''")) {
+                    result.id = .single_quoted;
+                    self.index += 1;
+                    break;
+                } else {
+                    self.index += "''".len - 1;
+                },
+                else => {},
+            },
+
+            .double_quoted => switch (c) {
+                '"' => {
+                    if (stringMatchesPattern("\\", self.buffer[self.index - 1 ..])) {
+                        self.index += 1;
+                    } else {
+                        result.id = .double_quoted;
+                        self.index += 1;
+                        break;
+                    }
+                },
+                else => {},
+            },
+
+            .literal => switch (c) {
+                '\r', '\n', ' ', '\'', '"', ']', '}' => {
+                    result.id = .literal;
+                    break;
+                },
+                ',', '[', '{' => {
+                    result.id = .literal;
+                    if (self.in_flow > 0) {
+                        break;
+                    }
+                },
+                ':' => {
+                    result.id = .literal;
+                    if (self.matchesPattern(": ") or self.matchesPattern(":\n") or self.matchesPattern(":\r")) {
+                        break;
+                    }
+                },
+                else => {
+                    result.id = .literal;
+                },
+            },
+        }
+    }
+
+    if (self.index >= self.buffer.len) {
+        switch (state) {
+            .literal => {
+                result.id = .literal;
+            },
+            else => {},
+        }
+    }
+
+    result.loc.end = self.index;
+
+    log.debug("{any}", .{result});
+    log.debug("    | {s}", .{self.buffer[result.loc.start..result.loc.end]});
+
+    return result;
+}
+
+fn testExpected(source: []const u8, expected: []const Token.Id) !void {
+    var tokenizer = Tokenizer{
+        .buffer = source,
+    };
+
+    var given = std.array_list.Managed(Token.Id).init(testing.allocator);
+    defer given.deinit();
+
+    while (true) {
+        const token = tokenizer.next();
+        try given.append(token.id);
+        if (token.id == .eof) break;
+    }
+
+    try testing.expectEqualSlices(Token.Id, expected, given.items);
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}
+
+test "empty doc" {
+    try testExpected("", &[_]Token.Id{.eof});
+}
+
+test "empty doc with explicit markers" {
+    try testExpected(
+        \\---
+        \\...
+    , &[_]Token.Id{
+        .doc_start, .new_line, .doc_end, .eof,
+    });
+}
+
+test "empty doc with explicit markers and a directive" {
+    try testExpected(
+        \\--- !tbd-v1
+        \\...
+    , &[_]Token.Id{
+        .doc_start,
+        .space,
+        .tag,
+        .literal,
+        .new_line,
+        .doc_end,
+        .eof,
+    });
+}
+
+test "sequence of values" {
+    try testExpected(
+        \\- 0
+        \\- 1
+        \\- 2
+    , &[_]Token.Id{
+        .seq_item_ind,
+        .literal,
+        .new_line,
+        .seq_item_ind,
+        .literal,
+        .new_line,
+        .seq_item_ind,
+        .literal,
+        .eof,
+    });
+}
+
+test "sequence of sequences" {
+    try testExpected(
+        \\- [ val1, val2]
+        \\- [val3, val4 ]
+    , &[_]Token.Id{
+        .seq_item_ind,
+        .flow_seq_start,
+        .space,
+        .literal,
+        .comma,
+        .space,
+        .literal,
+        .flow_seq_end,
+        .new_line,
+        .seq_item_ind,
+        .flow_seq_start,
+        .literal,
+        .comma,
+        .space,
+        .literal,
+        .space,
+        .flow_seq_end,
+        .eof,
+    });
+}
+
+test "mappings" {
+    try testExpected(
+        \\key1: value1
+        \\key2: value2
+    , &[_]Token.Id{
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .eof,
+    });
+}
+
+test "inline mapped sequence of values" {
+    try testExpected(
+        \\key :  [ val1, 
+        \\          val2 ]
+    , &[_]Token.Id{
+        .literal,
+        .space,
+        .map_value_ind,
+        .space,
+        .flow_seq_start,
+        .space,
+        .literal,
+        .comma,
+        .space,
+        .new_line,
+        .space,
+        .literal,
+        .space,
+        .flow_seq_end,
+        .eof,
+    });
+}
+
+test "part of tbd" {
+    try testExpected(
+        \\--- !tapi-tbd
+        \\tbd-version:     4
+        \\targets:         [ x86_64-macos ]
+        \\
+        \\uuids:
+        \\  - target:          x86_64-macos
+        \\    value:           F86CC732-D5E4-30B5-AA7D-167DF5EC2708
+        \\
+        \\install-name:    '/usr/lib/libSystem.B.dylib'
+        \\...
+    , &[_]Token.Id{
+        .doc_start,
+        .space,
+        .tag,
+        .literal,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .space,
+        .flow_seq_start,
+        .space,
+        .literal,
+        .space,
+        .flow_seq_end,
+        .new_line,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .new_line,
+        .space,
+        .seq_item_ind,
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .new_line,
+        .space,
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .new_line,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .space,
+        .single_quoted,
+        .new_line,
+        .doc_end,
+        .eof,
+    });
+}
+
+test "Unindented list" {
+    try testExpected(
+        \\b:
+        \\- foo: 1
+        \\c: 1
+    , &[_]Token.Id{
+        .literal,
+        .map_value_ind,
+        .new_line,
+        .seq_item_ind,
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal,
+        .eof,
+    });
+}
+
+test "escape sequences" {
+    try testExpected(
+        \\a: 'here''s an apostrophe'
+        \\b: "a newline\nand a\ttab"
+        \\c: "\"here\" and there"
+    , &[_]Token.Id{
+        .literal,
+        .map_value_ind,
+        .space,
+        .single_quoted,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .space,
+        .double_quoted,
+        .new_line,
+        .literal,
+        .map_value_ind,
+        .space,
+        .double_quoted,
+        .eof,
+    });
+}
+
+test "comments" {
+    try testExpected(
+        \\key: # some comment about the key
+        \\# first value
+        \\- val1
+        \\# second value
+        \\- val2
+    , &[_]Token.Id{
+        .literal,
+        .map_value_ind,
+        .space,
+        .comment,
+        .new_line,
+        .comment,
+        .new_line,
+        .seq_item_ind,
+        .literal,
+        .new_line,
+        .comment,
+        .new_line,
+        .seq_item_ind,
+        .literal,
+        .eof,
+    });
+}
+
+test "quoted literals" {
+    try testExpected(
+        \\'#000000'
+        \\'[000000'
+        \\"&someString"
+    , &[_]Token.Id{
+        .single_quoted,
+        .new_line,
+        .single_quoted,
+        .new_line,
+        .double_quoted,
+        .eof,
+    });
+}
+
+test "unquoted literals" {
+    try testExpected(
+        \\key1: helloWorld
+        \\key2: hello,world
+        \\key3: [hello,world]
+    , &[_]Token.Id{
+        // key1
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal, // helloWorld
+        .new_line,
+        // key2
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal, // hello,world
+        .new_line,
+        // key3
+        .literal,
+        .map_value_ind,
+        .space,
+        .flow_seq_start,
+        .literal, // hello
+        .comma,
+        .literal, // world
+        .flow_seq_end,
+        .eof,
+    });
+}
+
+test "unquoted literal containing colon" {
+    try testExpected(
+        \\key1: val:ue
+        \\key2: val::ue
+    , &[_]Token.Id{
+        // key1
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal, // val:ue
+        .new_line,
+        // key2
+        .literal,
+        .map_value_ind,
+        .space,
+        .literal, // val::ue
+        .eof,
+    });
+}

--- a/vendor/zig-yaml/src/Tree.zig
+++ b/vendor/zig-yaml/src/Tree.zig
@@ -1,0 +1,256 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+const Token = @import("Tokenizer.zig").Token;
+const Tree = @This();
+
+source: []const u8,
+tokens: std.MultiArrayList(TokenWithLineCol).Slice,
+docs: []const Node.Index,
+nodes: std.MultiArrayList(Node).Slice,
+extra: []const u32,
+string_bytes: []const u8,
+
+pub fn deinit(self: *Tree, gpa: Allocator) void {
+    self.tokens.deinit(gpa);
+    self.nodes.deinit(gpa);
+    gpa.free(self.docs);
+    gpa.free(self.extra);
+    gpa.free(self.string_bytes);
+    self.* = undefined;
+}
+
+pub fn nodeTag(tree: Tree, node: Node.Index) Node.Tag {
+    return tree.nodes.items(.tag)[@intFromEnum(node)];
+}
+
+pub fn nodeData(tree: Tree, node: Node.Index) Node.Data {
+    return tree.nodes.items(.data)[@intFromEnum(node)];
+}
+
+pub fn nodeScope(tree: Tree, node: Node.Index) Node.Scope {
+    return tree.nodes.items(.scope)[@intFromEnum(node)];
+}
+
+/// Returns the requested data, as well as the new index which is at the start of the
+/// trailers for the object.
+pub fn extraData(tree: Tree, comptime T: type, index: Extra) struct { data: T, end: Extra } {
+    const fields = std.meta.fields(T);
+    var i = @intFromEnum(index);
+    var result: T = undefined;
+    inline for (fields) |field| {
+        @field(result, field.name) = switch (field.type) {
+            u32 => tree.extra[i],
+            i32 => @bitCast(tree.extra[i]),
+            Node.Index, Node.OptionalIndex, Token.Index => @enumFromInt(tree.extra[i]),
+            else => @compileError("bad field type: " ++ @typeName(field.type)),
+        };
+        i += 1;
+    }
+    return .{
+        .data = result,
+        .end = @enumFromInt(i),
+    };
+}
+
+/// Returns the directive metadata if present.
+pub fn directive(self: Tree, node_index: Node.Index) ?[]const u8 {
+    const tag = self.nodeTag(node_index);
+    switch (tag) {
+        .doc => return null,
+        .doc_with_directive => {
+            const data = self.nodeData(node_index).doc_with_directive;
+            return self.rawString(data.directive, data.directive);
+        },
+        else => unreachable,
+    }
+}
+
+/// Returns the raw string such that it matches the range [start, end) in the Token stream.
+pub fn rawString(self: Tree, start: Token.Index, end: Token.Index) []const u8 {
+    const start_token = self.token(start);
+    const end_token = self.token(end);
+    return self.source[start_token.loc.start..end_token.loc.end];
+}
+
+pub fn token(self: Tree, index: Token.Index) Token {
+    return self.tokens.items(.token)[@intFromEnum(index)];
+}
+
+pub const Node = struct {
+    tag: Tag,
+    scope: Scope,
+    data: Data,
+
+    pub const Tag = enum(u8) {
+        /// Document with no extra metadata.
+        /// Comprises an index into another Node.
+        /// Payload is maybe_value.
+        doc,
+
+        /// Document with directive.
+        /// Payload is doc_with_directive.
+        doc_with_directive,
+
+        /// Map with a single key-value pair.
+        /// Payload is map.
+        map_single,
+
+        /// Map with more than one key-value pair.
+        /// Comprises an index into extras where payload is Map.
+        /// Payload is extra.
+        map_many,
+
+        /// Empty list.
+        /// Payload is unused.
+        list_empty,
+
+        /// List with one element.
+        /// Payload is value.
+        list_one,
+
+        /// List with two elements.
+        /// Payload is list.
+        list_two,
+
+        /// List of more than 2 elements.
+        /// Comprises an index into extras where payload is List.
+        /// Payload is extra.
+        list_many,
+
+        /// String that didn't require any preprocessing.
+        /// Value is encoded directly as scope.
+        /// Payload is unused.
+        value,
+
+        /// String that required preprocessing such as a quoted string.
+        /// Payload is string.
+        string_value,
+    };
+
+    /// Describes the Token range that encapsulates this Node.
+    pub const Scope = struct {
+        start: Token.Index,
+        end: Token.Index,
+
+        pub fn rawString(scope: Scope, tree: Tree) []const u8 {
+            return tree.rawString(scope.start, scope.end);
+        }
+    };
+
+    pub const Data = union {
+        /// Node index.
+        node: Index,
+
+        /// Optional Node index.
+        maybe_node: OptionalIndex,
+
+        /// Document with a directive metadata.
+        doc_with_directive: struct {
+            maybe_node: OptionalIndex,
+            directive: Token.Index,
+        },
+
+        /// Map with exactly one key-value pair.
+        map: struct {
+            key: Token.Index,
+            maybe_node: OptionalIndex,
+        },
+
+        /// List with exactly two elements.
+        list: struct {
+            el1: Index,
+            el2: Index,
+        },
+
+        /// Index and length into the string table.
+        string: String,
+
+        /// Index into extra array.
+        extra: Extra,
+    };
+
+    pub const Index = enum(u32) {
+        _,
+
+        pub fn toOptional(ind: Index) OptionalIndex {
+            const result: OptionalIndex = @enumFromInt(@intFromEnum(ind));
+            assert(result != .none);
+            return result;
+        }
+    };
+
+    pub const OptionalIndex = enum(u32) {
+        none = std.math.maxInt(u32),
+        _,
+
+        pub fn unwrap(opt: OptionalIndex) ?Index {
+            if (opt == .none) return null;
+            return @enumFromInt(@intFromEnum(opt));
+        }
+    };
+
+    // Make sure we don't accidentally make nodes bigger than expected.
+    // Note that in safety builds, Zig is allowed to insert a secret field for safety checks.
+    comptime {
+        if (!std.debug.runtime_safety) {
+            assert(@sizeOf(Data) == 8);
+        }
+    }
+};
+
+/// Index into extra array.
+pub const Extra = enum(u32) {
+    _,
+};
+
+/// Trailing is a list of MapEntries.
+pub const Map = struct {
+    map_len: u32,
+
+    pub const Entry = struct {
+        key: Token.Index,
+        maybe_node: Node.OptionalIndex,
+    };
+};
+
+/// Trailing is a list of Node indexes.
+pub const List = struct {
+    list_len: u32,
+
+    pub const Entry = struct {
+        node: Node.Index,
+    };
+};
+
+/// Index and length into string table.
+pub const String = struct {
+    index: Index,
+    len: u32,
+
+    pub const Index = enum(u32) {
+        _,
+    };
+
+    pub fn slice(str: String, tree: Tree) []const u8 {
+        return tree.string_bytes[@intFromEnum(str.index)..][0..str.len];
+    }
+};
+
+/// Tracked line-column information for each Token.
+pub const LineCol = struct {
+    line: u32,
+    col: u32,
+};
+
+/// Token with line-column information.
+pub const TokenWithLineCol = struct {
+    token: Token,
+    line_col: LineCol,
+};
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/vendor/zig-yaml/src/Yaml.zig
+++ b/vendor/zig-yaml/src/Yaml.zig
@@ -1,0 +1,671 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const math = std.math;
+const mem = std.mem;
+const log = std.log.scoped(.yaml);
+
+const Allocator = mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+const ErrorBundle = std.zig.ErrorBundle;
+const Node = Tree.Node;
+const Parser = @import("Parser.zig");
+const ParseError = Parser.ParseError;
+const Tokenizer = @import("Tokenizer.zig");
+const Token = Tokenizer.Token;
+const Tree = @import("Tree.zig");
+const Yaml = @This();
+
+source: []const u8,
+docs: std.ArrayListUnmanaged(Value) = .empty,
+tree: ?Tree = null,
+parse_errors: ErrorBundle = .empty,
+
+pub fn deinit(self: *Yaml, gpa: Allocator) void {
+    for (self.docs.items) |*value| {
+        value.deinit(gpa);
+    }
+    self.docs.deinit(gpa);
+    if (self.tree) |*tree| {
+        tree.deinit(gpa);
+    }
+    self.parse_errors.deinit(gpa);
+    self.* = undefined;
+}
+
+pub fn load(self: *Yaml, gpa: Allocator) !void {
+    var parser = try Parser.init(gpa, self.source);
+    defer parser.deinit(gpa);
+
+    parser.parse(gpa) catch |err| switch (err) {
+        error.ParseFailure => {
+            self.parse_errors = try parser.errors.toOwnedBundle("");
+            return error.ParseFailure;
+        },
+        else => return err,
+    };
+
+    self.tree = try parser.toOwnedTree(gpa);
+
+    try self.docs.ensureTotalCapacityPrecise(gpa, self.tree.?.docs.len);
+
+    for (self.tree.?.docs) |node| {
+        const value = try Value.fromNode(gpa, self.tree.?, node);
+        self.docs.appendAssumeCapacity(value);
+    }
+}
+
+pub fn parse(self: Yaml, arena: Allocator, comptime T: type) Error!T {
+    if (self.docs.items.len == 0) {
+        if (@typeInfo(T) == .void) return {};
+        return error.TypeMismatch;
+    }
+
+    if (self.docs.items.len == 1) {
+        return self.parseValue(arena, T, self.docs.items[0]);
+    }
+
+    switch (@typeInfo(T)) {
+        .array => |info| {
+            var parsed: T = undefined;
+            for (self.docs.items, 0..) |doc, i| {
+                parsed[i] = try self.parseValue(arena, info.child, doc);
+            }
+            return parsed;
+        },
+        .pointer => |info| {
+            switch (info.size) {
+                .slice => {
+                    var parsed = try arena.alloc(info.child, self.docs.items.len);
+                    for (self.docs.items, 0..) |doc, i| {
+                        parsed[i] = try self.parseValue(arena, info.child, doc);
+                    }
+                    return parsed;
+                },
+                else => return error.TypeMismatch,
+            }
+        },
+        .@"union" => return error.Unimplemented,
+        else => return error.TypeMismatch,
+    }
+}
+
+fn parseValue(self: Yaml, arena: Allocator, comptime T: type, value: Value) Error!T {
+    return switch (@typeInfo(T)) {
+        .int => self.parseInt(T, value),
+        .bool => self.parseBoolean(bool, value),
+        .float => self.parseFloat(T, value),
+        .@"struct" => if (value.asMap()) |map| {
+            return self.parseStruct(arena, T, map);
+        } else return error.TypeMismatch,
+        .@"union" => self.parseUnion(arena, T, value),
+        .array => if (value.asList()) |list| {
+            return self.parseArray(arena, T, list);
+        } else return error.TypeMismatch,
+        .pointer => if (value.asList()) |list| {
+            return self.parsePointer(arena, T, .{ .list = list });
+        } else if (value.asScalar()) |scalar| {
+            return self.parsePointer(arena, T, .{ .scalar = try arena.dupe(u8, scalar) });
+        } else if (value.asMap()) |map| {
+            return self.parsePointer(arena, T, .{ .map = map });
+        } else return error.TypeMismatch,
+        .@"enum" => self.parseEnum(T, value),
+        .void => error.TypeMismatch,
+        .optional => unreachable,
+        else => error.Unimplemented,
+    };
+}
+
+fn parseInt(self: Yaml, comptime T: type, value: Value) Error!T {
+    _ = self;
+    const scalar = value.asScalar() orelse return error.TypeMismatch;
+    return try std.fmt.parseInt(T, scalar, 0);
+}
+
+fn parseFloat(self: Yaml, comptime T: type, value: Value) Error!T {
+    _ = self;
+    const scalar = value.asScalar() orelse return error.TypeMismatch;
+    return try std.fmt.parseFloat(T, scalar);
+}
+
+fn parseBoolean(self: Yaml, comptime T: type, value: Value) Error!T {
+    _ = self;
+    const raw = value.asScalar() orelse return error.TypeMismatch;
+
+    if (raw.len > 0 and raw.len <= longestBooleanValueString) {
+        var buffer: [longestBooleanValueString]u8 = undefined;
+        const lower_raw = std.ascii.lowerString(&buffer, raw);
+
+        for (supportedTruthyBooleanValue) |v| {
+            if (std.mem.eql(u8, v, lower_raw)) {
+                return true;
+            }
+        }
+
+        for (supportedFalsyBooleanValue) |v| {
+            if (std.mem.eql(u8, v, lower_raw)) {
+                return false;
+            }
+        }
+    }
+
+    return error.TypeMismatch;
+}
+
+fn parseUnion(self: Yaml, arena: Allocator, comptime T: type, value: Value) Error!T {
+    const union_info = @typeInfo(T).@"union";
+
+    if (union_info.tag_type) |_| {
+        inline for (union_info.fields) |field| {
+            if (self.parseValue(arena, field.type, value)) |u_value| {
+                return @unionInit(T, field.name, u_value);
+            } else |err| switch (err) {
+                error.InvalidCharacter => {},
+                error.TypeMismatch => {},
+                error.StructFieldMissing => {},
+                else => return err,
+            }
+        }
+    } else return error.UntaggedUnion;
+
+    return error.UnionTagMissing;
+}
+
+fn parseOptional(self: Yaml, arena: Allocator, comptime T: type, value: ?Value) Error!T {
+    const unwrapped = value orelse return null;
+    const opt_info = @typeInfo(T).optional;
+    return @as(T, try self.parseValue(arena, opt_info.child, unwrapped));
+}
+
+fn parseStruct(self: Yaml, arena: Allocator, comptime T: type, map: Map) Error!T {
+    const struct_info = @typeInfo(T).@"struct";
+    var parsed: T = undefined;
+
+    inline for (struct_info.fields) |field| {
+        var value: ?Value = map.get(field.name) orelse blk: {
+            const field_name = try mem.replaceOwned(u8, arena, field.name, "_", "-");
+            break :blk map.get(field_name);
+        };
+
+        if (@typeInfo(field.type) == .optional) {
+            if (value == null) blk: {
+                const maybe_default_value = field.defaultValue() orelse break :blk;
+                value = Value.encode(arena, maybe_default_value) catch break :blk;
+            }
+            @field(parsed, field.name) = try self.parseOptional(arena, field.type, value);
+            continue;
+        }
+
+        if (field.defaultValue()) |default_value| {
+            if (value == null) blk: {
+                value = Value.encode(arena, default_value) catch break :blk;
+            }
+        }
+
+        const unwrapped = value orelse {
+            log.debug("missing struct field: {s}: {s}", .{ field.name, @typeName(field.type) });
+            return error.StructFieldMissing;
+        };
+        @field(parsed, field.name) = try self.parseValue(arena, field.type, unwrapped);
+    }
+
+    return parsed;
+}
+
+fn parsePointer(self: Yaml, arena: Allocator, comptime T: type, value: Value) Error!T {
+    const ptr_info = @typeInfo(T).pointer;
+
+    switch (ptr_info.size) {
+        .slice => {
+            if (ptr_info.child == u8) {
+                const scalar = value.asScalar() orelse return error.TypeMismatch;
+                return try arena.dupe(u8, scalar);
+            }
+
+            if (value.asList()) |list| {
+                var parsed = try arena.alloc(ptr_info.child, list.len);
+                for (list, 0..) |elem, i| {
+                    parsed[i] = try self.parseValue(arena, ptr_info.child, elem);
+                }
+                return parsed;
+            }
+
+            return error.TypeMismatch;
+        },
+        .one => {
+            const parsed = try arena.create(ptr_info.child);
+            parsed.* = try self.parseValue(arena, ptr_info.child, value);
+            return parsed;
+        },
+        else => return error.Unimplemented,
+    }
+}
+
+fn parseArray(self: Yaml, arena: Allocator, comptime T: type, list: List) Error!T {
+    const array_info = @typeInfo(T).array;
+    if (array_info.len != list.len) return error.ArraySizeMismatch;
+
+    var parsed: T = undefined;
+    for (list, 0..) |elem, i| {
+        parsed[i] = try self.parseValue(arena, array_info.child, elem);
+    }
+
+    return parsed;
+}
+
+fn parseEnum(self: Yaml, comptime T: type, value: Value) Error!T {
+    _ = self;
+
+    const scalar = value.asScalar() orelse return error.TypeMismatch;
+    return std.meta.stringToEnum(T, scalar) orelse error.InvalidEnum;
+}
+
+pub fn stringify(self: Yaml, writer: *std.Io.Writer) !void {
+    for (self.docs.items, self.tree.?.docs) |doc, node| {
+        try writer.writeAll("---");
+        if (self.tree.?.directive(node)) |directive| {
+            try writer.print(" !{s}", .{directive});
+        }
+        try writer.writeByte('\n');
+        try doc.stringify(writer, .{});
+        try writer.writeByte('\n');
+    }
+    try writer.writeAll("...\n");
+}
+
+const supportedTruthyBooleanValue: [4][]const u8 = .{ "y", "yes", "on", "true" };
+const supportedFalsyBooleanValue: [4][]const u8 = .{ "n", "no", "off", "false" };
+
+const longestBooleanValueString = blk: {
+    var lengths: [supportedTruthyBooleanValue.len + supportedFalsyBooleanValue.len]usize = undefined;
+    for (supportedTruthyBooleanValue, 0..) |v, i| {
+        lengths[i] = v.len;
+    }
+    for (supportedFalsyBooleanValue, supportedTruthyBooleanValue.len..) |v, i| {
+        lengths[i] = v.len;
+    }
+    break :blk mem.max(usize, &lengths);
+};
+
+pub const Error = error{
+    InvalidCharacter,
+    Unimplemented,
+    TypeMismatch,
+    StructFieldMissing,
+    ArraySizeMismatch,
+    UntaggedUnion,
+    UnionTagMissing,
+    Overflow,
+    OutOfMemory,
+    InvalidEnum,
+};
+
+pub const YamlError = error{
+    UnexpectedNodeType,
+    DuplicateMapKey,
+    OutOfMemory,
+    CannotEncodeValue,
+} || ParseError || std.fmt.ParseIntError;
+
+pub const StringifyError = error{
+    OutOfMemory,
+} || YamlError || std.Io.Writer.Error;
+
+pub const List = []Value;
+pub const Map = std.StringArrayHashMapUnmanaged(Value);
+
+pub const Value = union(enum) {
+    empty,
+    scalar: []const u8,
+    list: List,
+    map: Map,
+    boolean: bool,
+
+    pub fn deinit(self: *Value, gpa: Allocator) void {
+        switch (self.*) {
+            .scalar => |scalar| gpa.free(scalar),
+            .list => |list| {
+                for (list) |*value| {
+                    value.deinit(gpa);
+                }
+                gpa.free(list);
+            },
+            .map => |*map| {
+                for (map.keys(), map.values()) |key, *value| {
+                    gpa.free(key);
+                    value.deinit(gpa);
+                }
+                map.deinit(gpa);
+            },
+            .empty, .boolean => {},
+        }
+    }
+
+    pub fn asScalar(self: Value) ?[]const u8 {
+        if (self != .scalar) return null;
+        return self.scalar;
+    }
+
+    pub fn asList(self: Value) ?List {
+        if (self != .list) return null;
+        return self.list;
+    }
+
+    pub fn asMap(self: Value) ?Map {
+        if (self != .map) return null;
+        return self.map;
+    }
+
+    const StringifyArgs = struct {
+        indentation: usize = 0,
+        should_inline_first_key: bool = false,
+    };
+
+    pub fn stringify(self: Value, writer: *std.Io.Writer, args: StringifyArgs) StringifyError!void {
+        switch (self) {
+            .empty => return,
+            .scalar => |scalar| return writer.print("{s}", .{scalar}),
+            .list => |list| {
+                const len = list.len;
+                if (len == 0) return;
+
+                const first = list[0];
+                if (first.isCompound()) {
+                    for (list, 0..) |elem, i| {
+                        const indentation = try writer.writableSlice(args.indentation);
+                        @memset(indentation, ' ');
+                        try writer.writeAll("- ");
+                        try elem.stringify(writer, .{
+                            .indentation = args.indentation + 2,
+                            .should_inline_first_key = true,
+                        });
+                        if (i < len - 1) {
+                            try writer.writeByte('\n');
+                        }
+                    }
+                    return;
+                }
+
+                try writer.writeAll("[ ");
+                for (list, 0..) |elem, i| {
+                    try elem.stringify(writer, args);
+                    if (i < len - 1) {
+                        try writer.writeAll(", ");
+                    }
+                }
+                try writer.writeAll(" ]");
+            },
+            .map => |map| {
+                const len = map.count();
+                if (len == 0) return;
+
+                var i: usize = 0;
+                for (map.keys(), map.values()) |key, value| {
+                    if (!args.should_inline_first_key or i != 0) {
+                        const indentation = try writer.writableSlice(args.indentation);
+                        @memset(indentation, ' ');
+                    }
+                    try writer.print("{s}: ", .{key});
+
+                    const should_inline = blk: {
+                        if (!value.isCompound()) break :blk true;
+                        if (value == .list and value.list.len > 0 and !value.list[0].isCompound()) break :blk true;
+                        break :blk false;
+                    };
+
+                    if (should_inline) {
+                        try value.stringify(writer, args);
+                    } else {
+                        try writer.writeByte('\n');
+                        try value.stringify(writer, .{
+                            .indentation = args.indentation + 4,
+                        });
+                    }
+
+                    if (i < len - 1) {
+                        try writer.writeByte('\n');
+                    }
+
+                    i += 1;
+                }
+            },
+            .boolean => |value| return writer.writeAll(if (value) "true" else "false"),
+        }
+    }
+
+    fn isCompound(self: Value) bool {
+        return switch (self) {
+            .list, .map => true,
+            else => false,
+        };
+    }
+
+    fn fromNode(gpa: Allocator, tree: Tree, node_index: Node.Index) YamlError!Value {
+        const tag = tree.nodeTag(node_index);
+        switch (tag) {
+            .doc => {
+                const inner = tree.nodeData(node_index).maybe_node.unwrap() orelse return .empty;
+                return Value.fromNode(gpa, tree, inner);
+            },
+            .doc_with_directive => {
+                const inner = tree.nodeData(node_index).doc_with_directive.maybe_node.unwrap() orelse return .empty;
+                return Value.fromNode(gpa, tree, inner);
+            },
+            .map_single => {
+                const entry = tree.nodeData(node_index).map;
+
+                // TODO use ContextAdapted HashMap and do not duplicate keys, intern
+                // in a contiguous string buffer.
+                var out_map: Map = .empty;
+                errdefer out_map.deinit(gpa);
+                try out_map.ensureTotalCapacity(gpa, 1);
+
+                const key = try gpa.dupe(u8, tree.rawString(entry.key, entry.key));
+                errdefer gpa.free(key);
+
+                const gop = out_map.getOrPutAssumeCapacity(key);
+                if (gop.found_existing) return error.DuplicateMapKey;
+
+                gop.value_ptr.* = if (entry.maybe_node.unwrap()) |value|
+                    try Value.fromNode(gpa, tree, value)
+                else
+                    .empty;
+
+                return Value{ .map = out_map };
+            },
+            .map_many => {
+                const extra_index = tree.nodeData(node_index).extra;
+                const map = tree.extraData(Tree.Map, extra_index);
+
+                // TODO use ContextAdapted HashMap and do not duplicate keys, intern
+                // in a contiguous string buffer.
+                var out_map: Map = .empty;
+                errdefer {
+                    for (out_map.keys(), out_map.values()) |key, *value| {
+                        gpa.free(key);
+                        value.deinit(gpa);
+                    }
+                    out_map.deinit(gpa);
+                }
+                try out_map.ensureTotalCapacity(gpa, map.data.map_len);
+
+                var extra_end = map.end;
+                for (0..map.data.map_len) |_| {
+                    const entry = tree.extraData(Tree.Map.Entry, extra_end);
+                    extra_end = entry.end;
+
+                    const key = try gpa.dupe(u8, tree.rawString(entry.data.key, entry.data.key));
+                    errdefer gpa.free(key);
+
+                    const gop = out_map.getOrPutAssumeCapacity(key);
+                    if (gop.found_existing) return error.DuplicateMapKey;
+
+                    gop.value_ptr.* = if (entry.data.maybe_node.unwrap()) |value|
+                        try Value.fromNode(gpa, tree, value)
+                    else
+                        .empty;
+                }
+
+                return Value{ .map = out_map };
+            },
+            .list_empty => {
+                return Value{ .list = &.{} };
+            },
+            .list_one => {
+                const value_index = tree.nodeData(node_index).node;
+                const out_list = try gpa.alloc(Value, 1);
+                errdefer gpa.free(out_list);
+                const value = try Value.fromNode(gpa, tree, value_index);
+                out_list[0] = value;
+                return Value{ .list = out_list };
+            },
+            .list_two => {
+                const list = tree.nodeData(node_index).list;
+                const out_list = try gpa.alloc(Value, 2);
+                errdefer {
+                    for (out_list) |*value| {
+                        value.deinit(gpa);
+                    }
+                    gpa.free(out_list);
+                }
+                for (out_list, &[2]Node.Index{ list.el1, list.el2 }) |*out, value_index| {
+                    out.* = try Value.fromNode(gpa, tree, value_index);
+                }
+                return Value{ .list = out_list };
+            },
+            .list_many => {
+                const extra_index = tree.nodeData(node_index).extra;
+                const list = tree.extraData(Tree.List, extra_index);
+
+                var out_list: std.ArrayListUnmanaged(Value) = .empty;
+                errdefer for (out_list.items) |*value| {
+                    value.deinit(gpa);
+                };
+                defer out_list.deinit(gpa);
+                try out_list.ensureTotalCapacityPrecise(gpa, list.data.list_len);
+
+                var extra_end = list.end;
+                for (0..list.data.list_len) |_| {
+                    const elem = tree.extraData(Tree.List.Entry, extra_end);
+                    extra_end = elem.end;
+
+                    const value = try Value.fromNode(gpa, tree, elem.data.node);
+                    out_list.appendAssumeCapacity(value);
+                }
+
+                return Value{ .list = try out_list.toOwnedSlice(gpa) };
+            },
+            .string_value => {
+                const raw = tree.nodeData(node_index).string.slice(tree);
+                return Value{ .scalar = try gpa.dupe(u8, raw) };
+            },
+            .value => {
+                const raw = tree.nodeScope(node_index).rawString(tree);
+                return Value{ .scalar = try gpa.dupe(u8, raw) };
+            },
+        }
+    }
+
+    pub fn encode(arena: Allocator, input: anytype) YamlError!?Value {
+        switch (@typeInfo(@TypeOf(input))) {
+            .comptime_int,
+            .int,
+            .comptime_float,
+            .float,
+            => return Value{ .scalar = try std.fmt.allocPrint(arena, "{d}", .{input}) },
+
+            .@"struct" => |info| if (info.is_tuple) {
+                var list: std.ArrayListUnmanaged(Value) = .empty;
+                try list.ensureTotalCapacityPrecise(arena, info.fields.len);
+
+                inline for (info.fields) |field| {
+                    if (try encode(arena, @field(input, field.name))) |value| {
+                        list.appendAssumeCapacity(value);
+                    }
+                }
+
+                return Value{ .list = try list.toOwnedSlice(arena) };
+            } else {
+                var map: Map = .empty;
+                try map.ensureTotalCapacity(arena, info.fields.len);
+
+                inline for (info.fields) |field| {
+                    if (try encode(arena, @field(input, field.name))) |value| {
+                        const key = try arena.dupe(u8, field.name);
+                        map.putAssumeCapacityNoClobber(key, value);
+                    }
+                }
+
+                return Value{ .map = map };
+            },
+
+            .@"union" => |info| if (info.tag_type) |tag_type| {
+                inline for (info.fields) |field| {
+                    if (@field(tag_type, field.name) == input) {
+                        return try encode(arena, @field(input, field.name));
+                    }
+                } else unreachable;
+            } else return error.UntaggedUnion,
+
+            .array => return encode(arena, &input),
+
+            .pointer => |info| switch (info.size) {
+                .one => switch (@typeInfo(info.child)) {
+                    .array => |child_info| {
+                        const Slice = []const child_info.child;
+                        return encode(arena, @as(Slice, input));
+                    },
+                    else => {
+                        return encode(arena, input);
+                    },
+                },
+                .slice => {
+                    if (info.child == u8) {
+                        return Value{ .scalar = try arena.dupe(u8, input) };
+                    }
+
+                    var list: std.ArrayListUnmanaged(Value) = .empty;
+                    try list.ensureTotalCapacityPrecise(arena, input.len);
+
+                    for (input) |elem| {
+                        if (try encode(arena, elem)) |value| {
+                            list.appendAssumeCapacity(value);
+                        } else {
+                            log.debug("Could not encode value in a list: {any}", .{elem});
+                            return error.CannotEncodeValue;
+                        }
+                    }
+
+                    return Value{ .list = try list.toOwnedSlice(arena) };
+                },
+                else => {
+                    @compileError("Unhandled type: " ++ @typeName(@TypeOf(input)));
+                },
+            },
+
+            // TODO we should probably have an option to encode `null` and also
+            // allow for some default value too.
+            .optional => return if (input) |val| encode(arena, val) else null,
+
+            .null => return null,
+            .bool => return Value{ .boolean = input },
+            .@"enum" => return Value{ .scalar = try arena.dupe(u8, @tagName(input)) },
+
+            else => {
+                @compileError("Unhandled type: " ++ @typeName(@TypeOf(input)));
+            },
+        }
+    }
+};
+
+pub const ErrorMsg = struct {
+    msg: []const u8,
+    line_col: Tree.LineCol,
+
+    pub fn deinit(err: *ErrorMsg, gpa: Allocator) void {
+        gpa.free(err.msg);
+    }
+};
+
+test {
+    _ = @import("Yaml/test.zig");
+}

--- a/vendor/zig-yaml/src/Yaml/test.zig
+++ b/vendor/zig-yaml/src/Yaml/test.zig
@@ -1,0 +1,975 @@
+const std = @import("std");
+const mem = std.mem;
+const stringify = @import("../stringify.zig").stringify;
+const testing = std.testing;
+
+const Arena = std.heap.ArenaAllocator;
+const Yaml = @import("../Yaml.zig");
+
+test "simple list" {
+    const source =
+        \\- a
+        \\- b
+        \\- c
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const list = yaml.docs.items[0].list;
+    try testing.expectEqual(list.len, 3);
+
+    try testing.expectEqualStrings("a", list[0].scalar);
+    try testing.expectEqualStrings("b", list[1].scalar);
+    try testing.expectEqualStrings("c", list[2].scalar);
+}
+
+test "simple list parsed as booleans" {
+    const source =
+        \\- true
+        \\- false
+        \\- true
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const parsed = try yaml.parse(arena.allocator(), []const bool);
+    try testing.expectEqual(parsed.len, 3);
+
+    try testing.expect(parsed[0]);
+    try testing.expect(!parsed[1]);
+    try testing.expect(parsed[2]);
+}
+
+test "simple list typed as array of strings" {
+    const source =
+        \\- a
+        \\- b
+        \\- c
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const arr = try yaml.parse(arena.allocator(), [3][]const u8);
+    try testing.expectEqual(3, arr.len);
+    try testing.expectEqualStrings("a", arr[0]);
+    try testing.expectEqualStrings("b", arr[1]);
+    try testing.expectEqualStrings("c", arr[2]);
+}
+
+test "simple list typed as array of ints" {
+    const source =
+        \\- 0
+        \\- 1
+        \\- 2
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const arr = try yaml.parse(arena.allocator(), [3]u8);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0, 1, 2 }, &arr);
+}
+
+test "list of mixed sign integer" {
+    const source =
+        \\- 0
+        \\- -1
+        \\- 2
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const arr = try yaml.parse(arena.allocator(), [3]i8);
+    try testing.expectEqualSlices(i8, &[_]i8{ 0, -1, 2 }, &arr);
+}
+
+test "several integer bases" {
+    const source =
+        \\- 10
+        \\- -10
+        \\- 0x10
+        \\- -0X10
+        \\- 0o10
+        \\- -0O10
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const arr = try yaml.parse(arena.allocator(), [6]i8);
+    try testing.expectEqualSlices(i8, &[_]i8{ 10, -10, 16, -16, 8, -8 }, &arr);
+}
+
+test "simple flow sequence / bracket list" {
+    const source =
+        \\a_key: [a, b, c]
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+
+    const list = map.get("a_key").?.list;
+    try testing.expectEqual(list.len, 3);
+
+    try testing.expectEqualStrings("a", list[0].scalar);
+    try testing.expectEqualStrings("b", list[1].scalar);
+    try testing.expectEqualStrings("c", list[2].scalar);
+}
+
+test "simple flow sequence / bracket list with trailing comma" {
+    const source =
+        \\a_key: [a, b, c,]
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+
+    const list = map.get("a_key").?.list;
+    try testing.expectEqual(list.len, 3);
+
+    try testing.expectEqualStrings("a", list[0].scalar);
+    try testing.expectEqualStrings("b", list[1].scalar);
+    try testing.expectEqualStrings("c", list[2].scalar);
+}
+
+test "simple flow sequence / bracket list with invalid comment" {
+    const source =
+        \\a_key: [a, b, c]#invalid
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    const err = yaml.load(testing.allocator);
+
+    try std.testing.expectError(error.ParseFailure, err);
+}
+
+test "simple flow sequence / bracket list with double trailing commas" {
+    const source =
+        \\a_key: [a, b, c,,]
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    const err = yaml.load(testing.allocator);
+
+    try std.testing.expectError(error.ParseFailure, err);
+}
+
+test "more bools" {
+    const source =
+        \\- false
+        \\- true
+        \\- off
+        \\- on
+        \\- no
+        \\- yes
+        \\- n
+        \\- y
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const arr = try yaml.parse(arena.allocator(), [8]bool);
+    try testing.expectEqualSlices(bool, &[_]bool{
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+    }, &arr);
+}
+
+test "invalid enum" {
+    const TestEnum = enum {
+        alpha,
+        bravo,
+        charlie,
+    };
+
+    const source =
+        \\- delta
+        \\- echo
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = yaml.parse(arena.allocator(), [2]TestEnum);
+    try testing.expectError(Yaml.Error.InvalidEnum, result);
+}
+
+test "simple map untyped" {
+    const source =
+        \\a: 0
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("a"));
+    try testing.expectEqualStrings("0", map.get("a").?.scalar);
+}
+
+test "simple map untyped with a list of maps" {
+    const source =
+        \\a: 0
+        \\b:
+        \\  - foo: 1
+        \\    bar: 2
+        \\  - foo: 3
+        \\    bar: 4
+        \\c: 1
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("a"));
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqualStrings("0", map.get("a").?.scalar);
+    try testing.expectEqualStrings("1", map.get("c").?.scalar);
+    try testing.expectEqualStrings("1", map.get("b").?.list[0].map.get("foo").?.scalar);
+    try testing.expectEqualStrings("2", map.get("b").?.list[0].map.get("bar").?.scalar);
+    try testing.expectEqualStrings("3", map.get("b").?.list[1].map.get("foo").?.scalar);
+    try testing.expectEqualStrings("4", map.get("b").?.list[1].map.get("bar").?.scalar);
+}
+
+test "simple map untyped with a list of maps. no indent" {
+    const source =
+        \\b:
+        \\- foo: 1
+        \\c: 1
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqualStrings("1", map.get("c").?.scalar);
+    try testing.expectEqualStrings("1", map.get("b").?.list[0].map.get("foo").?.scalar);
+}
+
+test "simple map untyped with a list of maps. no indent 2" {
+    const source =
+        \\a: 0
+        \\b:
+        \\- foo: 1
+        \\  bar: 2
+        \\- foo: 3
+        \\  bar: 4
+        \\c: 1
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("a"));
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqualStrings("0", map.get("a").?.scalar);
+    try testing.expectEqualStrings("1", map.get("c").?.scalar);
+    try testing.expectEqualStrings("1", map.get("b").?.list[0].map.get("foo").?.scalar);
+    try testing.expectEqualStrings("2", map.get("b").?.list[0].map.get("bar").?.scalar);
+    try testing.expectEqualStrings("3", map.get("b").?.list[1].map.get("foo").?.scalar);
+    try testing.expectEqualStrings("4", map.get("b").?.list[1].map.get("bar").?.scalar);
+}
+
+test "simple map typed" {
+    const source =
+        \\a: 0
+        \\b: hello there
+        \\c: 'wait, what?'
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const simple = try yaml.parse(arena.allocator(), struct { a: usize, b: []const u8, c: []const u8 });
+    try testing.expectEqual(@as(usize, 0), simple.a);
+    try testing.expectEqualStrings("hello there", simple.b);
+    try testing.expectEqualStrings("wait, what?", simple.c);
+}
+
+test "typed nested structs" {
+    const source =
+        \\a:
+        \\  b: hello there
+        \\  c: 'wait, what?'
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const simple = try yaml.parse(arena.allocator(), struct {
+        a: struct {
+            b: []const u8,
+            c: []const u8,
+        },
+    });
+    try testing.expectEqualStrings("hello there", simple.a.b);
+    try testing.expectEqualStrings("wait, what?", simple.a.c);
+}
+
+test "typed union with nested struct" {
+    const source =
+        \\a:
+        \\  b: hello there
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const simple = try yaml.parse(arena.allocator(), union(enum) {
+        tag_a: struct {
+            a: struct {
+                b: []const u8,
+            },
+        },
+        tag_c: struct {
+            c: struct {
+                d: []const u8,
+            },
+        },
+    });
+    try testing.expectEqualStrings("hello there", simple.tag_a.a.b);
+}
+
+test "typed union with nested struct 2" {
+    const source =
+        \\c:
+        \\  d: hello there
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const simple = try yaml.parse(arena.allocator(), union(enum) {
+        tag_a: struct {
+            a: struct {
+                b: []const u8,
+            },
+        },
+        tag_c: struct {
+            c: struct {
+                d: []const u8,
+            },
+        },
+    });
+    try testing.expectEqualStrings("hello there", simple.tag_c.c.d);
+}
+
+test "single quoted string" {
+    const source =
+        \\- 'hello'
+        \\- 'here''s an escaped quote'
+        \\- 'newlines and tabs\nare not\tsupported'
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const arr = try yaml.parse(arena.allocator(), [3][]const u8);
+    try testing.expectEqual(arr.len, 3);
+    try testing.expectEqualStrings("hello", arr[0]);
+    try testing.expectEqualStrings("here's an escaped quote", arr[1]);
+    try testing.expectEqualStrings("newlines and tabs\\nare not\\tsupported", arr[2]);
+}
+
+test "double quoted string" {
+    const source =
+        \\- "hello"
+        \\- "\"here\" are some escaped quotes"
+        \\- "newlines and tabs\nare\tsupported"
+        \\- "let's have
+        \\some fun!"
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const arr = try yaml.parse(arena.allocator(), [4][]const u8);
+    try testing.expectEqual(arr.len, 4);
+    try testing.expectEqualStrings("hello", arr[0]);
+    try testing.expectEqualStrings(
+        \\"here" are some escaped quotes
+    , arr[1]);
+    try testing.expectEqualStrings("newlines and tabs\nare\tsupported", arr[2]);
+    try testing.expectEqualStrings(
+        \\let's have
+        \\some fun!
+    , arr[3]);
+}
+
+test "commas in string" {
+    const source =
+        \\a: 900,50,50
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const simple = try yaml.parse(arena.allocator(), struct {
+        a: []const u8,
+    });
+    try testing.expectEqualStrings("900,50,50", simple.a);
+}
+
+test "multidoc typed as a slice of structs" {
+    const source =
+        \\---
+        \\a: 0
+        \\---
+        \\a: 1
+        \\...
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    {
+        const result = try yaml.parse(arena.allocator(), [2]struct { a: usize });
+        try testing.expectEqual(result.len, 2);
+        try testing.expectEqual(result[0].a, 0);
+        try testing.expectEqual(result[1].a, 1);
+    }
+
+    {
+        const result = try yaml.parse(arena.allocator(), []struct { a: usize });
+        try testing.expectEqual(result.len, 2);
+        try testing.expectEqual(result[0].a, 0);
+        try testing.expectEqual(result[1].a, 1);
+    }
+}
+
+test "multidoc typed as a struct is an error" {
+    const source =
+        \\---
+        \\a: 0
+        \\---
+        \\b: 1
+        \\...
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    try testing.expectError(Yaml.Error.TypeMismatch, yaml.parse(arena.allocator(), struct { a: usize }));
+    try testing.expectError(Yaml.Error.TypeMismatch, yaml.parse(arena.allocator(), struct { b: usize }));
+    try testing.expectError(Yaml.Error.TypeMismatch, yaml.parse(arena.allocator(), struct { a: usize, b: usize }));
+}
+
+test "multidoc typed as a slice of structs with optionals" {
+    const source =
+        \\---
+        \\a: 0
+        \\c: 1.0
+        \\---
+        \\a: 1
+        \\b: different field
+        \\...
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = try yaml.parse(arena.allocator(), []struct { a: usize, b: ?[]const u8, c: ?f16 });
+    try testing.expectEqual(result.len, 2);
+
+    try testing.expectEqual(result[0].a, 0);
+    try testing.expect(result[0].b == null);
+    try testing.expect(result[0].c != null);
+    try testing.expectEqual(result[0].c.?, 1.0);
+
+    try testing.expectEqual(result[1].a, 1);
+    try testing.expect(result[1].b != null);
+    try testing.expectEqualStrings("different field", result[1].b.?);
+    try testing.expect(result[1].c == null);
+}
+
+test "empty yaml can be represented as void" {
+    const source = "";
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = try yaml.parse(arena.allocator(), void);
+    try testing.expect(@TypeOf(result) == void);
+}
+
+test "nonempty yaml cannot be represented as void" {
+    const source =
+        \\a: b
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    try testing.expectError(Yaml.Error.TypeMismatch, yaml.parse(arena.allocator(), void));
+}
+
+test "typed array size mismatch" {
+    const source =
+        \\- 0
+        \\- 0
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    try testing.expectError(Yaml.Error.ArraySizeMismatch, yaml.parse(arena.allocator(), [1]usize));
+    try testing.expectError(Yaml.Error.ArraySizeMismatch, yaml.parse(arena.allocator(), [5]usize));
+}
+
+test "comments" {
+    const source =
+        \\
+        \\key: # this is the key
+        \\# first value
+        \\
+        \\- val1
+        \\
+        \\# second value
+        \\- val2
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const simple = try yaml.parse(arena.allocator(), struct {
+        key: []const []const u8,
+    });
+    try testing.expect(simple.key.len == 2);
+    try testing.expectEqualStrings("val1", simple.key[0]);
+    try testing.expectEqualStrings("val2", simple.key[1]);
+}
+
+test "promote ints to floats in a list mixed numeric types" {
+    const source =
+        \\a_list: [0, 1.0]
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const simple = try yaml.parse(arena.allocator(), struct {
+        a_list: []const f64,
+    });
+    try testing.expectEqualSlices(f64, &[_]f64{ 0.0, 1.0 }, simple.a_list);
+}
+
+test "demoting floats to ints in a list is an error" {
+    const source =
+        \\a_list: [0, 1.0]
+    ;
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    try testing.expectError(error.InvalidCharacter, yaml.parse(arena.allocator(), struct {
+        a_list: []const u64,
+    }));
+}
+
+test "duplicate map keys" {
+    const source =
+        \\a: b
+        \\a: c
+    ;
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try testing.expectError(error.DuplicateMapKey, yaml.load(testing.allocator));
+}
+
+fn testStringify(expected: []const u8, input: anytype) !void {
+    var writer: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer writer.deinit();
+
+    try stringify(testing.allocator, input, &writer.writer);
+    try testing.expectEqualStrings(expected, writer.written());
+}
+
+test "stringify an int" {
+    try testStringify("128", @as(u32, 128));
+}
+
+test "stringify a simple struct" {
+    try testStringify(
+        \\a: 1
+        \\b: 2
+        \\c: 2.5
+    , struct { a: i64, b: f64, c: f64 }{ .a = 1, .b = 2.0, .c = 2.5 });
+}
+
+test "stringify a struct with an optional" {
+    try testStringify(
+        \\a: 1
+        \\b: 2
+        \\c: 2.5
+    , struct { a: i64, b: ?f64, c: f64 }{ .a = 1, .b = 2.0, .c = 2.5 });
+
+    try testStringify(
+        \\a: 1
+        \\c: 2.5
+    , struct { a: i64, b: ?f64, c: f64 }{ .a = 1, .b = null, .c = 2.5 });
+}
+
+test "stringify a struct with all optionals" {
+    try testStringify("", struct { a: ?i64, b: ?f64 }{ .a = null, .b = null });
+}
+
+test "stringify an optional" {
+    try testStringify("", null);
+    try testStringify("", @as(?u64, null));
+}
+
+test "stringify a union" {
+    const Dummy = union(enum) {
+        x: u64,
+        y: f64,
+    };
+    try testStringify("a: 1", struct { a: Dummy }{ .a = .{ .x = 1 } });
+    try testStringify("a: 2.1", struct { a: Dummy }{ .a = .{ .y = 2.1 } });
+}
+
+test "stringify a string" {
+    try testStringify("a: name", struct { a: []const u8 }{ .a = "name" });
+    try testStringify("name", "name");
+}
+
+test "stringify a list" {
+    try testStringify("[ 1, 2, 3 ]", @as([]const u64, &.{ 1, 2, 3 }));
+    try testStringify("[ 1, 2, 3 ]", .{ @as(i64, 1), 2, 3 });
+    try testStringify("[ 1, name, 3 ]", .{ 1, "name", 3 });
+
+    const arr: [3]i64 = .{ 1, 2, 3 };
+    try testStringify("[ 1, 2, 3 ]", arr);
+}
+
+test "pointer of a value" {
+    const TestStruct = struct {
+        a: usize,
+        b: i64,
+        c: u12,
+        d: ?*const @This() = null,
+    };
+
+    const source =
+        \\a: 1
+        \\b: 2
+        \\c: 3
+        \\d:
+        \\  a: 4
+        \\  b: 5
+        \\  c: 6
+    ;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var yaml = Yaml{ .source = source };
+    try yaml.load(arena.allocator());
+
+    const parsed = try yaml.parse(arena.allocator(), *TestStruct);
+    try testing.expectEqual(1, parsed.a);
+    try testing.expectEqual(2, parsed.b);
+    try testing.expectEqual(3, parsed.c);
+    try testing.expectEqual(4, parsed.d.?.a);
+    try testing.expectEqual(5, parsed.d.?.b);
+    try testing.expectEqual(6, parsed.d.?.c);
+    try testing.expectEqual(@as(?*const TestStruct, null), parsed.d.?.d);
+}
+
+test "struct default value test" {
+    const TestStruct = struct {
+        a: i32,
+        b: ?[]const u8 = "test",
+        c: ?u8 = 5,
+        d: u8 = 12,
+    };
+
+    const TestCase = struct {
+        yaml: []const u8,
+        container: TestStruct,
+    };
+
+    const tcs = [_]TestCase{
+        .{
+            .yaml =
+            \\---
+            \\a: 1
+            \\b: "asd"
+            \\c: 3
+            \\d: 1
+            \\...
+            ,
+            .container = .{
+                .a = 1,
+                .b = "asd",
+                .c = 3,
+                .d = 1,
+            },
+        },
+        .{
+            .yaml =
+            \\---
+            \\a: 1
+            \\c: 3
+            \\d: 1
+            \\...
+            ,
+            .container = .{
+                .a = 1,
+                .b = "test",
+                .c = 3,
+                .d = 1,
+            },
+        },
+        .{
+            .yaml =
+            \\---
+            \\a: 1
+            \\b: "asd"
+            \\d: 1
+            \\...
+            ,
+            .container = .{
+                .a = 1,
+                .b = "asd",
+                .c = 5,
+                .d = 1,
+            },
+        },
+        .{
+            .yaml =
+            \\---
+            \\a: 1
+            \\b: "asd"
+            \\...
+            ,
+            .container = .{
+                .a = 1,
+                .b = "asd",
+                .c = 5,
+                .d = 12,
+            },
+        },
+    };
+
+    for (&tcs) |tc| {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        var yamlParser = Yaml{ .source = tc.yaml };
+        try yamlParser.load(arena.allocator());
+        const parsed = try yamlParser.parse(arena.allocator(), TestStruct);
+        try testing.expectEqual(tc.container.a, parsed.a);
+        try testing.expectEqualDeep(tc.container.b, parsed.b);
+        try testing.expectEqual(tc.container.c, parsed.c);
+        try testing.expectEqual(tc.container.d, parsed.d);
+    }
+}
+
+test "enums" {
+    const source =
+        \\- a
+        \\- b
+        \\- c
+    ;
+
+    const Enum = enum { a, b, c };
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const parsed = try yaml.parse(arena.allocator(), []const Enum);
+    try testing.expectEqualDeep(&[_]Enum{
+        .a,
+        .b,
+        .c,
+    }, parsed);
+}
+
+test "stringify a bool" {
+    try testStringify("false", false);
+    try testStringify("true", true);
+}
+
+test "stringify an enum" {
+    const TestEnum = enum {
+        alpha,
+        bravo,
+        charlie,
+    };
+
+    try testStringify("alpha", TestEnum.alpha);
+    try testStringify("bravo", TestEnum.bravo);
+    try testStringify("charlie", TestEnum.charlie);
+}
+
+test "parse struct as list of structs" {
+    const source =
+        \\a: 1
+    ;
+
+    const Struct = struct { a: u32 };
+
+    var yaml: Yaml = .{ .source = source };
+    defer yaml.deinit(testing.allocator);
+    try yaml.load(testing.allocator);
+
+    var arena = Arena.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = yaml.parse(arena.allocator(), []Struct);
+    try testing.expectError(error.TypeMismatch, result);
+
+    const parsed = try yaml.parse(arena.allocator(), Struct);
+    try testing.expectEqualDeep(Struct{ .a = 1 }, parsed);
+}

--- a/vendor/zig-yaml/src/lib.zig
+++ b/vendor/zig-yaml/src/lib.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+
+pub const Parser = @import("Parser.zig");
+pub const Tokenizer = @import("Tokenizer.zig");
+pub const Tree = @import("Tree.zig");
+pub const Yaml = @import("Yaml.zig");
+
+pub const stringify = @import("stringify.zig").stringify;
+
+test {
+    std.testing.refAllDecls(Parser);
+    std.testing.refAllDecls(Tokenizer);
+    std.testing.refAllDecls(Tree);
+    std.testing.refAllDecls(Yaml);
+}

--- a/vendor/zig-yaml/src/stringify.zig
+++ b/vendor/zig-yaml/src/stringify.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+
+const Yaml = @import("Yaml.zig");
+
+pub fn stringify(gpa: std.mem.Allocator, input: anytype, writer: *std.Io.Writer) Yaml.StringifyError!void {
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+
+    const maybe_value = try Yaml.Value.encode(arena.allocator(), input);
+
+    if (maybe_value) |value| {
+        // TODO should we output as an explicit doc?
+        // How can allow the user to specify?
+        try value.stringify(writer, .{});
+    }
+}

--- a/vendor/zig-yaml/test/multi_lib.tbd
+++ b/vendor/zig-yaml/test/multi_lib.tbd
@@ -1,0 +1,31 @@
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos ]
+uuids:
+  - target:          x86_64-macos
+    value:           F86CC732-D5E4-30B5-AA7D-167DF5EC2708
+install-name:    '/usr/lib/libSystem.B.dylib'
+current-version: 1292.60.1
+reexported-libraries:
+  - targets:         [ x86_64-macos ]
+    libraries:       [ '/usr/lib/system/libcache.dylib' ]
+exports:
+  - targets:         [ x86_64-macos ]
+    symbols:         [ 'R8289209$_close', 'R8289209$_fork' ]
+  - targets:         [ x86_64-macos ]
+    symbols:         [ ___crashreporter_info__, _libSystem_atfork_child ]
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos ]
+uuids:
+  - target:          x86_64-macos
+    value:           2F7F7303-DB23-359E-85CD-8B2F93223E2A
+install-name:    '/usr/lib/system/libcache.dylib'
+current-version: 83
+parent-umbrella:
+  - targets:         [ x86_64-macos ]
+    umbrella:        System
+exports:
+  - targets:         [ x86_64-macos ]
+    symbols:         [ _cache_create, _cache_destroy ]
+...

--- a/vendor/zig-yaml/test/simple.yaml
+++ b/vendor/zig-yaml/test/simple.yaml
@@ -1,0 +1,14 @@
+names: [ John Doe, MacIntosh, Jane Austin ]
+numbers:
+  - 10
+  - -8
+  - 6
+isyaml: false
+hasBoolean: NO
+nested:
+  some: one
+  wick: john doe
+  ok: TRUE
+finally: [ 8.17,
+           19.78      , 17 ,
+           21 ]

--- a/vendor/zig-yaml/test/single_lib.tbd
+++ b/vendor/zig-yaml/test/single_lib.tbd
@@ -1,0 +1,33 @@
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos, x86_64-maccatalyst, arm64-macos, arm64-maccatalyst, 
+                   arm64e-macos, arm64e-maccatalyst ]
+uuids:
+  - target:          x86_64-macos
+    value:           F86CC732-D5E4-30B5-AA7D-167DF5EC2708
+  - target:          x86_64-maccatalyst
+    value:           F86CC732-D5E4-30B5-AA7D-167DF5EC2708
+  - target:          arm64-macos
+    value:           00000000-0000-0000-0000-000000000000
+  - target:          arm64-maccatalyst
+    value:           00000000-0000-0000-0000-000000000000
+  - target:          arm64e-macos
+    value:           A17E8744-051E-356E-8619-66F2A6E89AD4
+  - target:          arm64e-maccatalyst
+    value:           A17E8744-051E-356E-8619-66F2A6E89AD4
+install-name:    '/usr/lib/libSystem.B.dylib'
+current-version: 1292.60.1
+reexported-libraries:
+  - targets:         [ x86_64-macos, x86_64-maccatalyst, arm64-macos, arm64-maccatalyst, 
+                       arm64e-macos, arm64e-maccatalyst ]
+    libraries:       [ '/usr/lib/system/libcache.dylib', '/usr/lib/system/libcommonCrypto.dylib', 
+                       '/usr/lib/system/libcompiler_rt.dylib', '/usr/lib/system/libcopyfile.dylib', 
+                       '/usr/lib/system/libxpc.dylib' ]
+exports:
+  - targets:         [ x86_64-maccatalyst, x86_64-macos ]
+    symbols:         [ 'R8289209$_close', 'R8289209$_fork', 'R8289209$_fsync', 'R8289209$_getattrlist', 
+                       'R8289209$_write' ]
+  - targets:         [ x86_64-maccatalyst, x86_64-macos, arm64e-maccatalyst, arm64e-macos, 
+                       arm64-macos, arm64-maccatalyst ]
+    symbols:         [ ___crashreporter_info__, _libSystem_atfork_child, _libSystem_atfork_parent, 
+                       _libSystem_atfork_prepare, _mach_init_routine ]

--- a/vendor/zig-yaml/test/spec.zig
+++ b/vendor/zig-yaml/test/spec.zig
@@ -1,0 +1,639 @@
+const std = @import("std");
+const fs = std.fs;
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+const Step = std.Build.Step;
+const SpecTest = @This();
+
+pub const base_id: Step.Id = .custom;
+
+step: Step,
+output_file: std.Build.GeneratedFile,
+
+const test_filename = "yaml_test_suite.zig";
+
+const preamble =
+    \\// This file is generated from the YAML 1.2 test database.
+    \\
+    \\const std = @import("std");
+    \\const testing = std.testing;
+    \\
+    \\const Yaml = @import("yaml").Yaml;
+    \\
+    \\const alloc = testing.allocator;
+    \\const io = testing.io;
+    \\
+    \\fn loadFromFile(file_path: []const u8) !Yaml {
+    \\    const file = try std.Io.Dir.openFileAbsolute(io, file_path, .{});
+    \\    defer file.close(io);
+    \\    var buffer: [1024]u8 = undefined;
+    \\    var reader = file.reader(io, &buffer);
+    \\
+    \\    const source = try reader.interface.allocRemaining(alloc, .unlimited);
+    \\    defer alloc.free(source);
+    \\
+    \\    var yaml: Yaml = .{ .source = source };
+    \\    errdefer yaml.deinit(alloc);
+    \\    try yaml.load(alloc);
+    \\    return yaml;
+    \\}
+    \\
+    \\fn loadFileString(file_path: []const u8) ![]u8 {
+    \\    const file = try std.Io.Dir.openFileAbsolute(io, file_path, .{});
+    \\    defer file.close(io);
+    \\
+    \\    var buffer: [1024]u8 = undefined;
+    \\    var reader = file.reader(io, &buffer);
+    \\
+    \\    const source = try reader.interface.allocRemaining(alloc, .unlimited);
+    \\    return source;
+    \\}
+    \\
+;
+
+pub fn create(owner: *std.Build) *SpecTest {
+    const spec_test = owner.allocator.create(SpecTest) catch @panic("OOM");
+
+    spec_test.* = .{
+        .step = Step.init(.{ .id = base_id, .name = "yaml-test-generate", .owner = owner, .makeFn = make }),
+        .output_file = std.Build.GeneratedFile{ .step = &spec_test.step },
+    };
+    return spec_test;
+}
+
+pub fn path(spec_test: *SpecTest) std.Build.LazyPath {
+    return std.Build.LazyPath{ .generated = .{ .file = &spec_test.output_file } };
+}
+
+const Testcase = struct {
+    name: []const u8,
+    path: []const u8,
+    result: union(enum) {
+        expected_output_path: []const u8,
+        error_expected,
+        none,
+        skip,
+    },
+    tags: std.BufSet,
+};
+
+fn make(step: *Step, make_options: Step.MakeOptions) !void {
+    _ = make_options;
+
+    const spec_test: *SpecTest = @fieldParentPtr("step", step);
+    const b = step.owner;
+    const io = b.graph.io;
+
+    const cwd = std.Io.Dir.cwd();
+    cwd.access(io, "test/yaml-test-suite/tags", .{}) catch {
+        return spec_test.step.fail("Testfiles not found, make sure you have loaded the submodule.", .{});
+    };
+    if (b.graph.host.result.os.tag == .windows) {
+        return spec_test.step.fail("Windows does not support symlinks in git properly, can't run testsuite.", .{});
+    }
+
+    var arena_allocator = std.heap.ArenaAllocator.init(b.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    var testcases = std.StringArrayHashMap(Testcase).init(arena);
+
+    const root_data_path = try fs.path.join(arena, &[_][]const u8{
+        b.build_root.path.?,
+        "test/yaml-test-suite",
+    });
+
+    const root_data_dir = try std.Io.Dir.openDirAbsolute(io, root_data_path, .{});
+
+    var itdir = try root_data_dir.openDir(io, "tags", .{
+        .iterate = true,
+        .access_sub_paths = true,
+    });
+
+    var walker = try itdir.walk(arena);
+    defer walker.deinit();
+
+    loop: {
+        while (walker.next(io)) |maybe_entry| {
+            if (maybe_entry) |entry| {
+                if (entry.kind != .sym_link) continue;
+                collectTest(io, arena, entry, &testcases) catch |err| switch (err) {
+                    error.OutOfMemory => @panic("OOM"),
+                    else => |e| return e,
+                };
+            } else {
+                break :loop;
+            }
+        } else |err| {
+            std.debug.print("err: {}", .{err});
+            break :loop;
+        }
+    }
+
+    var output_alloc = std.Io.Writer.Allocating.init(arena);
+    const writer = &output_alloc.writer;
+    try writer.writeAll(preamble);
+
+    while (testcases.pop()) |kv| {
+        try emitTest(writer, kv.value);
+    }
+
+    var man = b.graph.cache.obtain();
+    defer man.deinit();
+
+    const output = try output_alloc.toOwnedSlice();
+    man.hash.addBytes(output);
+
+    if (try step.cacheHit(&man)) {
+        const digest = man.final();
+        spec_test.output_file.path = try b.cache_root.join(b.allocator, &.{
+            &digest, test_filename,
+        });
+        return;
+    }
+    const digest = man.final();
+
+    const sub_path = b.pathJoin(&.{ &digest, test_filename });
+    const sub_path_dirname = fs.path.dirname(sub_path).?;
+
+    b.cache_root.handle.createDirPath(io, sub_path_dirname) catch |err| {
+        return step.fail("unable to make path '{?s}{s}': {any}", .{ b.cache_root.path, sub_path_dirname, err });
+    };
+
+    b.cache_root.handle.writeFile(io, .{ .sub_path = sub_path, .data = output }) catch |err| {
+        return step.fail("unable to write file: {}", .{err});
+    };
+    spec_test.output_file.path = try b.cache_root.join(b.allocator, &.{sub_path});
+    try man.writeManifest();
+}
+
+fn collectTest(io: std.Io, arena: Allocator, entry: std.Io.Dir.Walker.Entry, testcases: *std.StringArrayHashMap(Testcase)) !void {
+    var path_components_it = std.fs.path.componentIterator(entry.path);
+    const first_path = path_components_it.first().?;
+
+    var path_components = std.array_list.Managed([]const u8).init(arena);
+    while (path_components_it.next()) |component| {
+        try path_components.append(component.name);
+    }
+
+    const remaining_path = try fs.path.join(arena, path_components.items);
+    const result = try testcases.getOrPut(remaining_path);
+
+    var buffer: [256]u8 = undefined;
+
+    if (!result.found_existing) {
+        result.key_ptr.* = remaining_path;
+
+        const in_path = try fs.path.join(arena, &[_][]const u8{
+            entry.basename,
+            "in.yaml",
+        });
+        const real_in_path = try entry.dir.realPathFileAlloc(io, in_path, arena);
+
+        const name_file_path = try fs.path.join(arena, &[_][]const u8{
+            entry.basename,
+            "===",
+        });
+        const name_file = try entry.dir.openFile(io, name_file_path, .{});
+        defer name_file.close(io);
+        var reader = name_file.reader(io, &buffer);
+        const name = try reader.interface.allocRemaining(arena, .unlimited);
+
+        var tag_set = std.BufSet.init(arena);
+        try tag_set.insert(first_path.name);
+
+        const full_name = try std.fmt.allocPrint(arena, "{s} - {s}", .{
+            remaining_path,
+            name[0 .. name.len - 1],
+        });
+
+        result.value_ptr.* = .{
+            .name = full_name,
+            .path = real_in_path,
+            .result = .{ .none = {} },
+            .tags = tag_set,
+        };
+
+        if (skipTest(full_name)) {
+            result.value_ptr.result = .skip;
+            return;
+        }
+
+        const out_path = try fs.path.join(arena, &[_][]const u8{
+            entry.basename,
+            "out.yaml",
+        });
+        const err_path = try fs.path.join(arena, &[_][]const u8{
+            entry.basename,
+            "error",
+        });
+
+        if (canAccess(io, entry.dir, out_path)) {
+            const real_out_path = try entry.dir.realPathFileAlloc(io, out_path, arena);
+            result.value_ptr.result = .{ .expected_output_path = real_out_path };
+        } else if (canAccess(io, entry.dir, err_path)) {
+            result.value_ptr.result = .{ .error_expected = {} };
+        }
+    } else {
+        try result.value_ptr.tags.insert(first_path.name);
+    }
+}
+
+fn skipTest(name: []const u8) bool {
+    for (skipped_tests) |skipped_name| {
+        if (mem.eql(u8, name, skipped_name)) return true;
+    }
+    return false;
+}
+
+const skipped_tests = &[_][]const u8{
+    "JR7V - Question marks in scalars",
+    "UDM2 - Plain URL in flow mapping",
+    "8MK2 - Explicit Non-Specific Tag",
+    "6XDY - Two document start markers",
+    "652Z - Question mark at start of flow key",
+    "PUW8 - Document start on last line",
+    "FBC9 - Allowed characters in plain scalars",
+    "5TRB - Invalid document-start marker in doublequoted tring",
+    "9MQT/01 - Scalar doc with '...' in content",
+    "9MQT/00 - Scalar doc with '...' in content",
+    "CPZ3 - Doublequoted scalar starting with a tab",
+    "8XYN - Anchor with unicode character",
+    "Y2GN - Anchor with colon in the middle",
+    "KSS4 - Scalars on --- line",
+    "FTA2 - Single block sequence with anchor and explicit document start",
+    "3R3P - Single block sequence with anchor",
+    "F2C7 - Anchors and Tags",
+    "TS54 - Folded Block Scalar",
+    "MZX3 - Non-Specific Tags on Scalars",
+    "AB8U - Sequence entry that looks like two with wrong indentation",
+    "9MAG - Flow sequence with invalid comma at the beginning",
+    "YJV2 - Dash in flow sequence",
+    "FUP4 - Flow Sequence in Flow Sequence",
+    "33X3 - Three explicit integers in a block sequence",
+    "2AUY - Tags in Block Sequence",
+    "SM9W/00 - Single character streams",
+    "G5U8 - Plain dashes in flow sequence",
+    "DHP8 - Flow Sequence",
+    "3MYT - Plain Scalar looking like key, comment, anchor and tag",
+    "A984 - Multiline Scalar in Mapping",
+    "S7BG - Colon followed by comma",
+    "HM87/00 - Scalars in flow start with syntax char",
+    "HM87/01 - Scalars in flow start with syntax char",
+    "4V8U - Plain scalar with backslashes",
+    "H3Z8 - Literal unicode",
+    "82AN - Three dashes and content without space",
+    "BS4K - Comment between plain scalar lines",
+    "FH7J - Tags on Empty Scalars",
+    "CQ3W - Double quoted string without closing quote",
+    "Y79Y/001 - Tabs in various contexts",
+    "Y79Y/006 - Tabs in various contexts",
+    "Y79Y/010 - Tabs in various contexts",
+    "Y79Y/003 - Tabs in various contexts",
+    "Y79Y/004 - Tabs in various contexts",
+    "Y79Y/005 - Tabs in various contexts",
+    "Y79Y/002 - Tabs in various contexts",
+    "9YRD - Multiline Scalar at Top Level",
+    "CFD4 - Empty implicit key in single pair flow sequences",
+    "3UYS - Escaped slash in double quotes",
+    "Y79Y/008 - Tabs in various contexts",
+    "UV7Q - Legal tab after indentation",
+    "SKE5 - Anchor before zero indented sequence",
+    "EW3V - Wrong indendation in mapping",
+    "DK95/03 - Tabs that look like indentation",
+    "DK95/04 - Tabs that look like indentation",
+    "DK95/05 - Tabs that look like indentation",
+    "DK95/07 - Tabs that look like indentation",
+    "DK95/00 - Tabs that look like indentation",
+    "DK95/01 - Tabs that look like indentation",
+    "DK95/06 - Tabs that look like indentation",
+    "ZVH3 - Wrong indented sequence item",
+    "96NN/00 - Leading tab content in literals",
+    "96NN/01 - Leading tab content in literals",
+    "F6MC - More indented lines at the beginning of folded block scalars",
+    "Y79Y/009 - Tabs in various contexts",
+    "Y79Y/000 - Tabs in various contexts",
+    "Y79Y/007 - Tabs in various contexts",
+    "KH5V/01 - Inline tabs in double quoted",
+    "KH5V/02 - Inline tabs in double quoted",
+    "Q5MG - Tab at beginning of line followed by a flow mapping",
+    "4RWC - Trailing spaces after flow collection",
+    "LP6E - Whitespace After Scalars in Flow",
+    "NHX8 - Empty Lines at End of Document",
+    "NB6Z - Multiline plain value with tabs on empty lines",
+    "DE56/01 - Trailing tabs in double quoted",
+    "DE56/00 - Trailing tabs in double quoted",
+    "DE56/02 - Trailing tabs in double quoted",
+    "DE56/05 - Trailing tabs in double quoted",
+    "DE56/04 - Trailing tabs in double quoted",
+    "DE56/03 - Trailing tabs in double quoted",
+    "L24T/01 - Trailing line of spaces",
+    "L24T/00 - Trailing line of spaces",
+    "3RLN/01 - Leading tabs in double quoted",
+    "3RLN/04 - Leading tabs in double quoted",
+    "9MMA - Directive by itself with no document",
+    "MUS6/06 - Directive variants",
+    "MUS6/02 - Directive variants",
+    "MUS6/05 - Directive variants",
+    "MUS6/04 - Directive variants",
+    "MUS6/03 - Directive variants",
+    "XLQ9 - Multiline scalar that looks like a YAML directive",
+    "M2N8/01 - Question mark edge cases",
+    "M2N8/00 - Question mark edge cases",
+    "UKK6/01 - Syntax character edge cases",
+    "UKK6/00 - Syntax character edge cases",
+    "UKK6/02 - Syntax character edge cases",
+    "6H3V - Backslashes in singlequotes",
+    "U3C3 - Spec Example 6.16. “TAG” directive",
+    "DBG4 - Spec Example 7.10. Plain Characters",
+    "MJS9 - Spec Example 6.7. Block Folding",
+    "96L6 - Spec Example 2.14. In the folded scalars, newlines become spaces",
+    "4CQQ - Spec Example 2.18. Multi-line Flow Scalars",
+    "6CK3 - Spec Example 6.26. Tag Shorthands",
+    "BEC7 - Spec Example 6.14. “YAML” directive",
+    "WZ62 - Spec Example 7.2. Empty Content",
+    "5TYM - Spec Example 6.21. Local Tag Prefix",
+    "27NA - Spec Example 5.9. Directive Indicator",
+    "JHB9 - Spec Example 2.7. Two Documents in a Stream",
+    "LQZ7 - Spec Example 7.4. Double Quoted Implicit Keys",
+    "S4JQ - Spec Example 6.28. Non-Specific Tags",
+    "G992 - Spec Example 8.9. Folded Scalar",
+    "YD5X - Spec Example 2.5. Sequence of Sequences",
+    "8UDB - Spec Example 7.14. Flow Sequence Entries",
+    "6ZKB - Spec Example 9.6. Stream",
+    "G4RS - Spec Example 2.17. Quoted Scalars",
+    "6LVF - Spec Example 6.13. Reserved Directives",
+    "5KJE - Spec Example 7.13. Flow Sequence",
+    "6VJK - Spec Example 2.15. Folded newlines are preserved for \"more indented\" and blank lines",
+    "K527 - Spec Example 6.6. Line Folding",
+    "SU5Z - Comment without whitespace after doublequoted scalar",
+    "L383 - Two scalar docs with trailing comments",
+    "DC7X - Various trailing tabs",
+    "U3XV - Node and Mapping Key Anchors",
+    "Q9WF - Spec Example 6.12. Separation Spaces",
+    "7T8X - Spec Example 8.10. Folded Lines - 8.13. Final Empty Lines",
+    "CML9 - Missing comma in flow",
+    "P94K - Spec Example 6.11. Multi-Line Comments",
+    "7TMG - Comment in flow sequence before comma",
+    "DK3J - Zero indented block scalar with line that looks like a comment",
+    "SYW4 - Spec Example 2.2. Mapping Scalars to Scalars",
+    "735Y - Spec Example 8.20. Block Node Types",
+    "B3HG - Spec Example 8.9. Folded Scalar [1.3]",
+    "6WLZ - Spec Example 6.18. Primary Tag Handle [1.3]",
+    "EX5H - Multiline Scalar at Top Level [1.3]",
+    "4Q9F - Folded Block Scalar [1.3]",
+    "Q8AD - Spec Example 7.5. Double Quoted Line Breaks [1.3]",
+    "6WPF - Spec Example 6.8. Flow Folding [1.3]",
+    "SSW6 - Spec Example 7.7. Single Quoted Characters [1.3]",
+    "9DXL - Spec Example 9.6. Stream [1.3]",
+    "EXG3 - Three dashes and content without space [1.3]",
+    "T4YY - Spec Example 7.9. Single Quoted Lines [1.3]",
+    "9TFX - Spec Example 7.6. Double Quoted Lines [1.3]",
+    "93WF - Spec Example 6.6. Line Folding [1.3]",
+    "52DL - Explicit Non-Specific Tag [1.3]",
+    "2LFX - Spec Example 6.13. Reserved Directives [1.3]",
+    "PW8X - Anchors on Empty Scalars",
+    "XW4D - Various Trailing Comments",
+    "NP9H - Spec Example 7.5. Double Quoted Line Breaks",
+    "HS5T - Spec Example 7.12. Plain Lines",
+    "J3BT - Spec Example 5.12. Tabs and Spaces",
+    "PRH3 - Spec Example 7.9. Single Quoted Lines",
+    "7A4E - Spec Example 7.6. Double Quoted Lines",
+    "TL85 - Spec Example 6.8. Flow Folding",
+    "8G76 - Spec Example 6.10. Comment Lines",
+    "98YD - Spec Example 5.5. Comment Indicator",
+    "M29M - Literal Block Scalar",
+    "P2AD - Spec Example 8.1. Block Scalar Header",
+    "T26H - Spec Example 8.8. Literal Content [1.3]",
+    "W42U - Spec Example 8.15. Block Sequence Entry Types",
+    "XV9V - Spec Example 6.5. Empty Lines [1.3]",
+    "5GBF - Spec Example 6.5. Empty Lines",
+    "JEF9/01 - Trailing whitespace in streams",
+    "JEF9/00 - Trailing whitespace in streams",
+    "JEF9/02 - Trailing whitespace in streams",
+    "A6F9 - Spec Example 8.4. Chomping Final Line Break",
+    "4ZYM - Spec Example 6.4. Line Prefixes",
+    "6FWR - Block Scalar Keep",
+    "2G84/01 - Literal modifers",
+    "2G84/00 - Literal modifers",
+    "DWX9 - Spec Example 8.8. Literal Content",
+    "F8F9 - Spec Example 8.5. Chomping Trailing Lines",
+    "MYW6 - Block Scalar Strip",
+    "H2RW - Blank lines",
+    "6JQW - Spec Example 2.13. In literals, newlines are preserved",
+    "K858 - Spec Example 8.6. Empty Scalar Chomping",
+    "5BVJ - Spec Example 5.7. Block Scalar Indicators",
+    "T5N4 - Spec Example 8.7. Literal Scalar [1.3]",
+    "M9B4 - Spec Example 8.7. Literal Scalar",
+    "753E - Block Scalar Strip [1.3]",
+    "HMK4 - Spec Example 2.16. Indentation determines scope",
+    "Z9M4 - Spec Example 6.22. Global Tag Prefix",
+    "9WXW - Spec Example 6.18. Primary Tag Handle",
+    "565N - Construct Binary",
+    "P76L - Spec Example 6.19. Secondary Tag Handle",
+    "CC74 - Spec Example 6.20. Tag Handles",
+    "CUP7 - Spec Example 5.6. Node Property Indicators",
+    "6M2F - Aliases in Explicit Block Mapping",
+    "HMQ5 - Spec Example 6.23. Node Properties",
+    "JS2J - Spec Example 6.29. Node Anchors",
+    "LE5A - Spec Example 7.24. Flow Nodes",
+    "C4HZ - Spec Example 2.24. Global Tags",
+    "X38W - Aliases in Flow Objects",
+    "W5VH - Allowed characters in alias",
+    "V55R - Aliases in Block Sequence",
+    "6KGN - Anchor for empty node",
+    "4QFQ - Spec Example 8.2. Block Indentation Indicator [1.3]",
+    "R4YG - Spec Example 8.2. Block Indentation Indicator",
+    "6BCT - Spec Example 6.3. Separation Spaces",
+    "UT92 - Spec Example 9.4. Explicit Documents",
+    "7Z25 - Bare document after document end marker",
+    "EB22 - Missing document-end marker before directive",
+    "3HFZ - Invalid content after document end marker",
+    "QT73 - Comment and document-end marker",
+    "HWV9 - Document-end marker",
+    "RXY3 - Invalid document-end marker in single quoted string",
+    "RTP8 - Spec Example 9.2. Document Markers",
+    "W4TN - Spec Example 9.5. Directives Documents",
+    "M7A3 - Spec Example 9.3. Bare Documents",
+    "RZT7 - Spec Example 2.28. Log File",
+    "5T43 - Colon at the beginning of adjacent flow scalar",
+    "7BUB - Spec Example 2.10. Node for “Sammy Sosa” appears twice in this document",
+    "5C5M - Spec Example 7.15. Flow Mappings",
+    "ZCZ6 - Invalid mapping in plain single line value",
+    "5MUD - Colon and adjacent value on next line",
+    "54T7 - Flow Mapping",
+    "6SLA - Allowed characters in quoted mapping key",
+    "X8DW - Explicit key and value seperated by comment",
+    "S3PD - Spec Example 8.18. Implicit Block Mapping Entries",
+    "4ABK - Flow Mapping Separate Values",
+    "8KB6 - Multiline plain flow mapping key without value",
+    "7W2P - Block Mapping with Missing Values",
+    "ZWK4 - Key with anchor after missing explicit mapping value",
+    "2SXE - Anchors With Colon in Name",
+    "4FJ6 - Nested implicit complex keys",
+    "ZF4X - Spec Example 2.6. Mapping of Mappings",
+    "ZH7C - Anchors in Mapping",
+    "TE2A - Spec Example 8.16. Block Mappings",
+    "SM9W/01 - Single character streams",
+    "KK5P - Various combinations of explicit block mappings",
+    "5U3A - Sequence on same Line as Mapping Key",
+    "8QBE - Block Sequence in Block Mapping",
+    "26DV - Whitespace around colon in mappings",
+    "CT4Q - Spec Example 7.20. Single Pair Explicit Entry",
+    "NKF9 - Empty keys in block and flow mapping",
+    "R52L - Nested flow mapping sequence and mappings",
+    "87E4 - Spec Example 7.8. Single Quoted Implicit Keys",
+    "UGM3 - Spec Example 2.27. Invoice",
+    "NJ66 - Multiline plain flow mapping key",
+    "QF4Y - Spec Example 7.19. Single Pair Flow Mappings",
+    "E76Z - Aliases in Implicit Block Mapping",
+    "DFF7 - Spec Example 7.16. Flow Mapping Entries",
+    "6JWB - Tags for Block Objects",
+    "2JQS - Block Mapping with Missing Keys",
+    "D88J - Flow Sequence in Block Mapping",
+    "3GZX - Spec Example 7.1. Alias Nodes",
+    "5NYZ - Spec Example 6.9. Separated Comment",
+    "8CWC - Plain mapping key ending with colon",
+    "5WE3 - Spec Example 8.17. Explicit Block Mapping Entries",
+    "4EJS - Invalid tabs as indendation in a mapping",
+    "JTV5 - Block Mapping with Multiline Scalars",
+    "EHF6 - Tags for Flow Objects",
+    "M7NX - Nested flow collections",
+    "CN3R - Various location of anchors in flow sequence",
+    "K3WX - Colon and adjacent value after comment on next line",
+    "C2DT - Spec Example 7.18. Flow Mapping Adjacent Values",
+    "36F6 - Multiline plain scalar with empty line",
+    "Q88A - Spec Example 7.23. Flow Content",
+    "L9U5 - Spec Example 7.11. Plain Implicit Keys",
+    "F3CP - Nested flow collections on one line",
+    "93JH - Block Mappings in Block Sequence",
+    "V9D5 - Spec Example 8.19. Compact Block Mappings",
+    "74H7 - Tags in Implicit Mapping",
+    "RR7F - Mixed Block Mapping (implicit to explicit)",
+    "J9HZ - Spec Example 2.9. Single Document with Two Comments",
+    "229Q - Spec Example 2.4. Sequence of Mappings",
+    "57H4 - Spec Example 8.22. Block Collection Nodes",
+    "9SA2 - Multiline double quoted flow mapping key",
+    "MXS3 - Flow Mapping in Block Sequence",
+    "L94M - Tags in Explicit Mapping",
+    "J7VC - Empty Lines Between Mapping Elements",
+    "J7PZ - Spec Example 2.26. Ordered Mappings",
+    "9KAX - Various combinations of tags and anchors",
+    "7ZZ5 - Empty flow collections",
+    "9U5K - Spec Example 2.12. Compact Nested Mapping",
+    "6PBE - Zero-indented sequences in explicit mapping keys",
+    "ZL4Z - Invalid nested mapping",
+    "S4T7 - Document with footer",
+    "4MUZ/01 - Flow mapping colon on line after key",
+    "4MUZ/00 - Flow mapping colon on line after key",
+    "4MUZ/02 - Flow mapping colon on line after key",
+    "9KBC - Mapping starting at --- line",
+    "9BXH - Multiline doublequoted flow mapping key without value",
+    "9MMW - Single Pair Implicit Entries",
+    "7BMT - Node and Mapping Key Anchors [1.3]",
+    "LX3P - Implicit Flow Mapping Key on one line",
+    "PBJ2 - Spec Example 2.3. Mapping Scalars to Sequences",
+    "JQ4R - Spec Example 8.14. Block Sequence",
+    "2EBW - Allowed characters in keys",
+    "SBG9 - Flow Sequence in Flow Mapping",
+    "UDR7 - Spec Example 5.4. Flow Collection Indicators",
+    "FRK4 - Spec Example 7.3. Completely Empty Flow Nodes",
+    "35KP - Tags for Root Objects",
+    "58MP - Flow mapping edge cases",
+    "S9E8 - Spec Example 5.3. Block Structure Indicators",
+    "6BFJ - Mapping, key and flow sequence item anchors",
+    "RZP5 - Various Trailing Comments [1.3]",
+    "2XXW - Spec Example 2.25. Unordered Sets",
+    "7FWL - Spec Example 6.24. Verbatim Tags",
+    "M5DY - Spec Example 2.11. Mapping between Sequences",
+    "GH63 - Mixed Block Mapping (explicit to implicit)",
+    "HU3P - Invalid Mapping in plain scalar",
+    "6HB6 - Spec Example 6.1. Indentation Spaces",
+    "FP8R - Zero indented block scalar",
+    "Z67P - Spec Example 8.21. Block Scalar Nodes [1.3]",
+    "A2M4 - Spec Example 6.2. Indentation Indicators",
+    "VJP3/01 - Flow collections over many lines",
+    "6CA3 - Tab indented top flow",
+    "BU8L - Node Anchor and Tag on Seperate Lines",
+    "4HVU - Wrong indendation in Sequence",
+    "U44R - Bad indentation in mapping (2)",
+    "DMG6 - Wrong indendation in Map",
+    "ZK9H - Nested top level flow mapping",
+    "M6YH - Block sequence indentation",
+    "M5C3 - Spec Example 8.21. Block Scalar Nodes",
+    "9C9N - Wrong indented flow sequence",
+    "N4JP - Bad indentation in mapping",
+    "4WA9 - Literal scalars",
+    "QB6E - Wrong indented multiline quoted scalar",
+    "D83L - Block scalar indicator order",
+    "RLU9 - Sequence Indent",
+    "UV7Q - Legal tab after indentation",
+    "K54U - Tab after document header",
+};
+
+const skip_test_template =
+    \\ return error.SkipZigTest;
+;
+
+const no_output_template =
+    \\    var yaml = try loadFromFile("{s}");
+    \\    defer yaml.deinit(alloc);
+    \\
+;
+
+const expect_file_template =
+    \\    var yaml = try loadFromFile("{s}");
+    \\    defer yaml.deinit(alloc);
+    \\
+    \\    const expected = try loadFileString("{s}");
+    \\    defer alloc.free(expected);
+    \\
+    \\    var buf = std.ArrayList(u8).init(alloc);
+    \\    defer buf.deinit();
+    \\    try yaml.stringify(&buf.writer());
+    \\    const actual = try buf.toOwnedSlice();
+    \\    try testing.expect(std.meta.eql(expected, actual));
+    \\
+;
+
+const expect_err_template =
+    \\    var yaml = loadFromFile("{s}") catch return;
+    \\    defer yaml.deinit(alloc);
+    \\    return error.UnexpectedSuccess;
+    \\
+;
+
+fn emitTest(output: *std.Io.Writer, testcase: Testcase) !void {
+    try output.print("test \"{f}\" {{\n", .{
+        std.zig.fmtString(testcase.name),
+    });
+
+    switch (testcase.result) {
+        .skip => {
+            try output.writeAll(skip_test_template);
+        },
+        .none => {
+            try output.print(no_output_template, .{testcase.path});
+        },
+        .expected_output_path => {
+            try output.print(expect_file_template, .{
+                testcase.path,
+                testcase.result.expected_output_path,
+            });
+        },
+        .error_expected => {
+            try output.print(expect_err_template, .{testcase.path});
+        },
+    }
+
+    try output.writeAll("}\n\n");
+}
+
+fn canAccess(io: std.Io, dir: std.Io.Dir, file_path: []const u8) bool {
+    if (dir.access(io, file_path, .{})) {
+        return true;
+    } else |_| {
+        return false;
+    }
+}

--- a/vendor/zig-yaml/test/test.zig
+++ b/vendor/zig-yaml/test/test.zig
@@ -1,0 +1,332 @@
+const std = @import("std");
+const mem = std.mem;
+const testing = std.testing;
+
+const Allocator = mem.Allocator;
+const Arena = std.heap.ArenaAllocator;
+const Yaml = @import("yaml").Yaml;
+
+const gpa = testing.allocator;
+const io = testing.io;
+
+fn loadFromFile(file_path: []const u8) !Yaml {
+    const file = try std.Io.Dir.cwd().openFile(io, file_path, .{});
+    defer file.close(io);
+    var buffer: [1024]u8 = undefined;
+    var reader = file.reader(io, &buffer);
+
+    const source = try reader.interface.allocRemaining(gpa, .unlimited);
+    defer gpa.free(source);
+
+    var yaml: Yaml = .{ .source = source };
+    errdefer yaml.deinit(gpa);
+    try yaml.load(gpa);
+    return yaml;
+}
+
+test "simple" {
+    const Simple = struct {
+        names: []const []const u8,
+        numbers: []const i16,
+        nested: struct {
+            some: []const u8,
+            wick: []const u8,
+            ok: bool,
+        },
+        finally: [4]f16,
+        isyaml: bool,
+        hasBoolean: bool,
+
+        pub fn eql(self: @This(), other: @This()) bool {
+            if (self.names.len != other.names.len) return false;
+            if (self.numbers.len != other.numbers.len) return false;
+            if (self.finally.len != other.finally.len) return false;
+
+            for (self.names, 0..) |lhs, i| {
+                if (!mem.eql(u8, lhs, other.names[i])) return false;
+            }
+
+            for (self.numbers, 0..) |lhs, i| {
+                if (lhs != other.numbers[i]) return false;
+            }
+
+            for (self.finally, 0..) |lhs, i| {
+                if (lhs != other.finally[i]) return false;
+            }
+
+            if (!mem.eql(u8, self.nested.some, other.nested.some)) return false;
+            if (!mem.eql(u8, self.nested.wick, other.nested.wick)) return false;
+
+            return true;
+        }
+    };
+
+    var parsed = try loadFromFile("test/simple.yaml");
+    defer parsed.deinit(gpa);
+
+    var arena = Arena.init(gpa);
+    defer arena.deinit();
+
+    const result = try parsed.parse(arena.allocator(), Simple);
+    const expected = Simple{
+        .names = &[_][]const u8{ "John Doe", "MacIntosh", "Jane Austin" },
+        .numbers = &[_]i16{ 10, -8, 6 },
+        .nested = .{
+            .some = "one",
+            .wick = "john doe",
+            .ok = true,
+        },
+        .isyaml = false,
+        .hasBoolean = false,
+        .finally = [_]f16{ 8.17, 19.78, 17, 21 },
+    };
+    try testing.expect(result.eql(expected));
+}
+
+const LibTbd = struct {
+    tbd_version: u3,
+    targets: []const []const u8,
+    uuids: []const struct {
+        target: []const u8,
+        value: []const u8,
+    },
+    install_name: []const u8,
+    current_version: union(enum) {
+        int: usize,
+        string: []const u8,
+    },
+    reexported_libraries: ?[]const struct {
+        targets: []const []const u8,
+        libraries: []const []const u8,
+    },
+    parent_umbrella: ?[]const struct {
+        targets: []const []const u8,
+        umbrella: []const u8,
+    },
+    exports: []const struct {
+        targets: []const []const u8,
+        symbols: []const []const u8,
+    },
+
+    pub fn eql(self: LibTbd, other: LibTbd) bool {
+        if (self.tbd_version != other.tbd_version) return false;
+        if (self.targets.len != other.targets.len) return false;
+
+        for (self.targets, 0..) |target, i| {
+            if (!mem.eql(u8, target, other.targets[i])) return false;
+        }
+
+        if (!mem.eql(u8, self.install_name, other.install_name)) return false;
+
+        switch (self.current_version) {
+            .string => |string| {
+                if (other.current_version != .string) return false;
+                if (!mem.eql(u8, string, other.current_version.string)) return false;
+            },
+            .int => |int| {
+                if (other.current_version != .int) return false;
+                if (int != other.current_version.int) return false;
+            },
+        }
+
+        if (self.reexported_libraries) |reexported_libraries| {
+            const o_reexported_libraries = other.reexported_libraries orelse return false;
+
+            if (reexported_libraries.len != o_reexported_libraries.len) return false;
+
+            for (reexported_libraries, 0..) |reexport, i| {
+                const o_reexport = o_reexported_libraries[i];
+                if (reexport.targets.len != o_reexport.targets.len) return false;
+                if (reexport.libraries.len != o_reexport.libraries.len) return false;
+
+                for (reexport.targets, 0..) |target, j| {
+                    const o_target = o_reexport.targets[j];
+                    if (!mem.eql(u8, target, o_target)) return false;
+                }
+
+                for (reexport.libraries, 0..) |library, j| {
+                    const o_library = o_reexport.libraries[j];
+                    if (!mem.eql(u8, library, o_library)) return false;
+                }
+            }
+        }
+
+        if (self.parent_umbrella) |parent_umbrella| {
+            const o_parent_umbrella = other.parent_umbrella orelse return false;
+
+            if (parent_umbrella.len != o_parent_umbrella.len) return false;
+
+            for (parent_umbrella, 0..) |pumbrella, i| {
+                const o_pumbrella = o_parent_umbrella[i];
+                if (pumbrella.targets.len != o_pumbrella.targets.len) return false;
+
+                for (pumbrella.targets, 0..) |target, j| {
+                    const o_target = o_pumbrella.targets[j];
+                    if (!mem.eql(u8, target, o_target)) return false;
+                }
+
+                if (!mem.eql(u8, pumbrella.umbrella, o_pumbrella.umbrella)) return false;
+            }
+        }
+
+        if (self.exports.len != other.exports.len) return false;
+
+        for (self.exports, 0..) |exp, i| {
+            const o_exp = other.exports[i];
+            if (exp.targets.len != o_exp.targets.len) return false;
+            if (exp.symbols.len != o_exp.symbols.len) return false;
+
+            for (exp.targets, 0..) |target, j| {
+                const o_target = o_exp.targets[j];
+                if (!mem.eql(u8, target, o_target)) return false;
+            }
+
+            for (exp.symbols, 0..) |symbol, j| {
+                const o_symbol = o_exp.symbols[j];
+                if (!mem.eql(u8, symbol, o_symbol)) return false;
+            }
+        }
+
+        return true;
+    }
+};
+
+test "single lib tbd" {
+    var parsed = try loadFromFile("test/single_lib.tbd");
+    defer parsed.deinit(gpa);
+
+    var arena = Arena.init(gpa);
+    defer arena.deinit();
+
+    const result = try parsed.parse(arena.allocator(), LibTbd);
+    const expected = LibTbd{
+        .tbd_version = 4,
+        .targets = &[_][]const u8{
+            "x86_64-macos",
+            "x86_64-maccatalyst",
+            "arm64-macos",
+            "arm64-maccatalyst",
+            "arm64e-macos",
+            "arm64e-maccatalyst",
+        },
+        .uuids = &.{
+            .{ .target = "x86_64-macos", .value = "F86CC732-D5E4-30B5-AA7D-167DF5EC2708" },
+            .{ .target = "x86_64-maccatalyst", .value = "F86CC732-D5E4-30B5-AA7D-167DF5EC2708" },
+            .{ .target = "arm64-macos", .value = "00000000-0000-0000-0000-000000000000" },
+            .{ .target = "arm64-maccatalyst", .value = "00000000-0000-0000-0000-000000000000" },
+            .{ .target = "arm64e-macos", .value = "A17E8744-051E-356E-8619-66F2A6E89AD4" },
+            .{ .target = "arm64e-maccatalyst", .value = "A17E8744-051E-356E-8619-66F2A6E89AD4" },
+        },
+        .install_name = "/usr/lib/libSystem.B.dylib",
+        .current_version = .{ .string = "1292.60.1" },
+        .reexported_libraries = &.{
+            .{
+                .targets = &.{
+                    "x86_64-macos",
+                    "x86_64-maccatalyst",
+                    "arm64-macos",
+                    "arm64-maccatalyst",
+                    "arm64e-macos",
+                    "arm64e-maccatalyst",
+                },
+                .libraries = &.{
+                    "/usr/lib/system/libcache.dylib",       "/usr/lib/system/libcommonCrypto.dylib",
+                    "/usr/lib/system/libcompiler_rt.dylib", "/usr/lib/system/libcopyfile.dylib",
+                    "/usr/lib/system/libxpc.dylib",
+                },
+            },
+        },
+        .exports = &.{
+            .{
+                .targets = &.{
+                    "x86_64-maccatalyst",
+                    "x86_64-macos",
+                },
+                .symbols = &.{
+                    "R8289209$_close", "R8289209$_fork", "R8289209$_fsync", "R8289209$_getattrlist",
+                    "R8289209$_write",
+                },
+            },
+            .{
+                .targets = &.{
+                    "x86_64-maccatalyst",
+                    "x86_64-macos",
+                    "arm64e-maccatalyst",
+                    "arm64e-macos",
+                    "arm64-macos",
+                    "arm64-maccatalyst",
+                },
+                .symbols = &.{
+                    "___crashreporter_info__",   "_libSystem_atfork_child", "_libSystem_atfork_parent",
+                    "_libSystem_atfork_prepare", "_mach_init_routine",
+                },
+            },
+        },
+        .parent_umbrella = null,
+    };
+    try testing.expect(result.eql(expected));
+}
+
+test "multi lib tbd" {
+    var parsed = try loadFromFile("test/multi_lib.tbd");
+    defer parsed.deinit(gpa);
+
+    var arena = Arena.init(gpa);
+    defer arena.deinit();
+
+    const result = try parsed.parse(arena.allocator(), []LibTbd);
+    const expected = &[_]LibTbd{
+        .{
+            .tbd_version = 4,
+            .targets = &[_][]const u8{"x86_64-macos"},
+            .uuids = &.{
+                .{ .target = "x86_64-macos", .value = "F86CC732-D5E4-30B5-AA7D-167DF5EC2708" },
+            },
+            .install_name = "/usr/lib/libSystem.B.dylib",
+            .current_version = .{ .string = "1292.60.1" },
+            .reexported_libraries = &.{
+                .{
+                    .targets = &.{"x86_64-macos"},
+                    .libraries = &.{"/usr/lib/system/libcache.dylib"},
+                },
+            },
+            .exports = &.{
+                .{
+                    .targets = &.{"x86_64-macos"},
+                    .symbols = &.{ "R8289209$_close", "R8289209$_fork" },
+                },
+                .{
+                    .targets = &.{"x86_64-macos"},
+                    .symbols = &.{ "___crashreporter_info__", "_libSystem_atfork_child" },
+                },
+            },
+            .parent_umbrella = null,
+        },
+        .{
+            .tbd_version = 4,
+            .targets = &[_][]const u8{"x86_64-macos"},
+            .uuids = &.{
+                .{ .target = "x86_64-macos", .value = "2F7F7303-DB23-359E-85CD-8B2F93223E2A" },
+            },
+            .install_name = "/usr/lib/system/libcache.dylib",
+            .current_version = .{ .int = 83 },
+            .parent_umbrella = &.{
+                .{
+                    .targets = &.{"x86_64-macos"},
+                    .umbrella = "System",
+                },
+            },
+            .exports = &.{
+                .{
+                    .targets = &.{"x86_64-macos"},
+                    .symbols = &.{ "_cache_create", "_cache_destroy" },
+                },
+            },
+            .reexported_libraries = null,
+        },
+    };
+
+    for (result, 0..) |lib, i| {
+        try testing.expect(lib.eql(expected[i]));
+    }
+}


### PR DESCRIPTION
OpenAPI and Swagger specs are often published as YAML, but the generator only accepted JSON despite allowing YAML file extensions. This adds YAML support by normalizing YAML input to JSON before the existing detection, parsing, conversion, and code generation pipeline runs.

## Summary

- Adds a YAML-to-JSON loader with normalization for common OpenAPI YAML forms, including quoted response-code keys, path keys with braces, block scalars, and scalar booleans/nulls/numeric schema constraints.
- Wires `.yaml` and `.yml` generation through the existing JSON-based pipeline for OpenAPI 3.x and Swagger 2.0.
- Exposes YAML helpers from the library API and documents CLI/library usage.
- Vendors a Zig 0.16-compatible `zig-yaml` parser build so the dependency is reproducible.
- Adds regression tests covering v2/v3 YAML parsing and unified conversion.

## Validation

- `zig fmt --check src\yaml_loader.zig src\tests\yaml_loader_tests.zig build.zig build.zig.zon vendor\zig-yaml\build.zig`
- `zig build -Doptimize=Debug`
- `zig build test`
- Generated clients from existing v2 and v3 petstore YAML samples
- `zig run generated\main.zig`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * YAML support now enabled across the tool and library (JSON+YAML instead of JSON-only)
  * CLI `--input` flag now accepts YAML files
  * Library now provides YAML-specific functions for version detection and document parsing for OpenAPI and Swagger specs

* **Documentation**
  * README updated to reflect YAML support with new usage examples and API reference entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->