### PR TITLE
Add --models-only option

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -13,6 +13,7 @@ pub const CliArgs = struct {
     output_path: ?[]const u8 = null,
     base_url: ?[]const u8 = null,
     resource_wrappers: ResourceWrapperMode = .paths,
+    models_only: bool = false,
 };
 
 pub const ParsedArgs = struct {
@@ -36,6 +37,7 @@ pub fn parse(args: []const [:0]const u8) !ParsedArgs {
     var output_path: ?[]const u8 = null;
     var base_url: ?[]const u8 = null;
     var resource_wrappers: ResourceWrapperMode = .paths;
+    var models_only = false;
 
     var i: usize = 2;
     while (i < args.len) : (i += 1) {
@@ -77,6 +79,8 @@ pub fn parse(args: []const [:0]const u8) !ParsedArgs {
                 std.debug.print("\nError: invalid resource wrapper mode '{s}'\n", .{args[i]});
                 return error.InvalidArguments;
             };
+        } else if (std.mem.eql(u8, arg, "--models-only")) {
+            models_only = true;
         }
     }
 
@@ -92,6 +96,7 @@ pub fn parse(args: []const [:0]const u8) !ParsedArgs {
             .output_path = output_path,
             .base_url = base_url,
             .resource_wrappers = resource_wrappers,
+            .models_only = models_only,
         },
     };
 }
@@ -118,11 +123,41 @@ fn printUsage() void {
         \\                              (default: server URL from OpenAPI Specification)
         \\   --resource-wrappers <mode> Generate resource wrappers: none, tags, paths, hybrid.
         \\                              (default: paths)
+        \\   --models-only              Generate only Zig models, skipping the API client.
         \\
         \\ EXAMPLES:
         \\   openapi2zig generate -i ./openapi/petstore.json -o api.zig
+        \\   openapi2zig generate -i ./openapi/petstore.json -o models.zig --models-only
         \\   openapi2zig generate -i https://petstore3.swagger.io/api/v3/openapi.json -o api.zig
         \\
         \\
     , .{ version_info.VERSION, version_info.GIT_COMMIT });
+}
+
+test "parse generate supports models-only flag" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--models-only",
+    };
+
+    const parsed = try parse(&argv);
+
+    try std.testing.expect(parsed.args.models_only);
+    try std.testing.expectEqualStrings("openapi.json", parsed.args.input_path);
+}
+
+test "parse generate defaults to complete output" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+    };
+
+    const parsed = try parse(&argv);
+
+    try std.testing.expect(!parsed.args.models_only);
 }

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -110,13 +110,18 @@ fn generateCodeFromUnifiedDocument(allocator: std.mem.Allocator, io: std.Io, uni
     const generated_models = try model_generator.generate(unified_doc);
     defer allocator.free(generated_models);
 
-    var api_generator = UnifiedApiGenerator.init(allocator, args);
-    defer api_generator.deinit();
-    const generated_api = try api_generator.generate(unified_doc);
-    defer allocator.free(generated_api);
+    const generated_code = if (args.models_only)
+        generated_models
+    else blk: {
+        var api_generator = UnifiedApiGenerator.init(allocator, args);
+        defer api_generator.deinit();
+        const generated_api = try api_generator.generate(unified_doc);
+        defer allocator.free(generated_api);
 
-    const generated_code = try std.mem.join(allocator, "\n", &.{ generated_models, generated_api });
-    defer allocator.free(generated_code);
+        const joined_code = try std.mem.join(allocator, "\n", &.{ generated_models, generated_api });
+        break :blk joined_code;
+    };
+    defer if (!args.models_only) allocator.free(generated_code);
 
     const output_path = args.output_path orelse default_output_file;
     const cwd = std.Io.Dir.cwd();

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -234,6 +234,11 @@ pub fn generateApi(allocator: std.mem.Allocator, unified_doc: UnifiedDocument, a
 /// - String containing complete generated Zig code
 pub fn generateCode(allocator: std.mem.Allocator, unified_doc: UnifiedDocument, args: CliArgs) ![]const u8 {
     const models_code = try generateModels(allocator, unified_doc);
+    errdefer allocator.free(models_code);
+
+    if (args.models_only) {
+        return models_code;
+    }
     defer allocator.free(models_code);
 
     const api_code = try generateApi(allocator, unified_doc, args);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11,6 +11,7 @@ const model_typing_tests = @import("tests/model_typing_tests.zig");
 const binary_payload_tests = @import("tests/binary_payload_tests.zig");
 const media_type = @import("media_type.zig");
 const generator = @import("generator.zig");
+const cli = @import("cli.zig");
 comptime {
     _ = openapi_v3_tests;
     _ = openapi_v31_tests;
@@ -25,4 +26,5 @@ comptime {
     _ = binary_payload_tests;
     _ = media_type;
     _ = generator;
+    _ = cli;
 }


### PR DESCRIPTION
OpenAPI can be also useful to define a single schema for software models. The schema can then be used to autogenerate native types for multiple programming langauges, in which case, emitting a full client may be redundant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--models-only` CLI option to generate only models.
  * Updated help text with the new option and an example usage.

* **Bug Fixes**
  * Ensured output is handled correctly when model-only generation is enabled.

* **Tests**
  * Added coverage for parsing the new option and its default disabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->