### PR TITLE
Optional schema numeric bound parsing

### DIFF
--- a/src/models/json_helpers.zig
+++ b/src/models/json_helpers.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+const json = std.json;
+
+pub fn optionalFloat(value: ?json.Value) ?f64 {
+    const val = value orelse return null;
+    return switch (val) {
+        .integer => |i| @as(f64, @floatFromInt(i)),
+        .float => |f| f,
+        .number_string => |s| std.fmt.parseFloat(f64, s) catch null,
+        else => null,
+    };
+}

--- a/src/models/v3.0/schema.zig
+++ b/src/models/v3.0/schema.zig
@@ -1,17 +1,8 @@
 const std = @import("std");
 const json = std.json;
+const json_helpers = @import("../json_helpers.zig");
 const Reference = @import("reference.zig").Reference;
 const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
-
-fn optionalFloat(value: ?json.Value) ?f64 {
-    const val = value orelse return null;
-    return switch (val) {
-        .integer => |i| @as(f64, @floatFromInt(i)),
-        .float => |f| f,
-        .number_string => |s| std.fmt.parseFloat(f64, s) catch null,
-        else => null,
-    };
-}
 
 pub const XML = struct {
     name: ?[]const u8 = null,
@@ -192,10 +183,10 @@ pub const Schema = struct {
         }
         return Schema{
             .title = if (obj.get("title")) |val| try allocator.dupe(u8, val.string) else null,
-            .multipleOf = optionalFloat(obj.get("multipleOf")),
-            .maximum = optionalFloat(obj.get("maximum")),
+            .multipleOf = json_helpers.optionalFloat(obj.get("multipleOf")),
+            .maximum = json_helpers.optionalFloat(obj.get("maximum")),
             .exclusiveMaximum = if (obj.get("exclusiveMaximum")) |val| val.bool else null,
-            .minimum = optionalFloat(obj.get("minimum")),
+            .minimum = json_helpers.optionalFloat(obj.get("minimum")),
             .exclusiveMinimum = if (obj.get("exclusiveMinimum")) |val| val.bool else null,
             .maxLength = if (obj.get("maxLength")) |val| val.integer else null,
             .minLength = if (obj.get("minLength")) |val| val.integer else null,

--- a/src/models/v3.0/schema.zig
+++ b/src/models/v3.0/schema.zig
@@ -3,6 +3,16 @@ const json = std.json;
 const Reference = @import("reference.zig").Reference;
 const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
 
+fn optionalFloat(value: ?json.Value) ?f64 {
+    const val = value orelse return null;
+    return switch (val) {
+        .integer => |i| @as(f64, @floatFromInt(i)),
+        .float => |f| f,
+        .number_string => |s| std.fmt.parseFloat(f64, s) catch null,
+        else => null,
+    };
+}
+
 pub const XML = struct {
     name: ?[]const u8 = null,
     namespace: ?[]const u8 = null,
@@ -182,10 +192,10 @@ pub const Schema = struct {
         }
         return Schema{
             .title = if (obj.get("title")) |val| try allocator.dupe(u8, val.string) else null,
-            .multipleOf = if (obj.get("multipleOf")) |val| val.float else null,
-            .maximum = if (obj.get("maximum")) |val| val.float else null,
+            .multipleOf = optionalFloat(obj.get("multipleOf")),
+            .maximum = optionalFloat(obj.get("maximum")),
             .exclusiveMaximum = if (obj.get("exclusiveMaximum")) |val| val.bool else null,
-            .minimum = if (obj.get("minimum")) |val| val.float else null,
+            .minimum = optionalFloat(obj.get("minimum")),
             .exclusiveMinimum = if (obj.get("exclusiveMinimum")) |val| val.bool else null,
             .maxLength = if (obj.get("maxLength")) |val| val.integer else null,
             .minLength = if (obj.get("minLength")) |val| val.integer else null,

--- a/src/models/v3.1/schema.zig
+++ b/src/models/v3.1/schema.zig
@@ -1,17 +1,8 @@
 const std = @import("std");
 const json = std.json;
+const json_helpers = @import("../json_helpers.zig");
 const Reference = @import("reference.zig").Reference;
 const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
-
-fn optionalFloat(value: ?json.Value) ?f64 {
-    const val = value orelse return null;
-    return switch (val) {
-        .integer => |i| @as(f64, @floatFromInt(i)),
-        .float => |f| f,
-        .number_string => |s| std.fmt.parseFloat(f64, s) catch null,
-        else => null,
-    };
-}
 
 fn optionalInteger(value: ?json.Value) ?i64 {
     const val = value orelse return null;
@@ -249,10 +240,10 @@ pub const Schema = struct {
 
         return Schema{
             .title = if (obj.get("title")) |val| try allocator.dupe(u8, val.string) else null,
-            .multipleOf = optionalFloat(obj.get("multipleOf")),
-            .maximum = optionalFloat(obj.get("maximum")),
+            .multipleOf = json_helpers.optionalFloat(obj.get("multipleOf")),
+            .maximum = json_helpers.optionalFloat(obj.get("maximum")),
             .exclusiveMaximum = optionalBool(obj.get("exclusiveMaximum")),
-            .minimum = optionalFloat(obj.get("minimum")),
+            .minimum = json_helpers.optionalFloat(obj.get("minimum")),
             .exclusiveMinimum = optionalBool(obj.get("exclusiveMinimum")),
             .maxLength = optionalInteger(obj.get("maxLength")),
             .minLength = optionalInteger(obj.get("minLength")),

--- a/src/models/v3.2/schema.zig
+++ b/src/models/v3.2/schema.zig
@@ -3,6 +3,16 @@ const json = std.json;
 const Reference = @import("reference.zig").Reference;
 const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
 
+fn optionalFloat(value: ?json.Value) ?f64 {
+    const val = value orelse return null;
+    return switch (val) {
+        .integer => |i| @as(f64, @floatFromInt(i)),
+        .float => |f| f,
+        .number_string => |s| std.fmt.parseFloat(f64, s) catch null,
+        else => null,
+    };
+}
+
 pub const XML = struct {
     name: ?[]const u8 = null,
     namespace: ?[]const u8 = null,
@@ -206,10 +216,10 @@ pub const Schema = struct {
 
         return Schema{
             .title = if (obj.get("title")) |val| try allocator.dupe(u8, val.string) else null,
-            .multipleOf = if (obj.get("multipleOf")) |val| val.float else null,
-            .maximum = if (obj.get("maximum")) |val| val.float else null,
+            .multipleOf = optionalFloat(obj.get("multipleOf")),
+            .maximum = optionalFloat(obj.get("maximum")),
             .exclusiveMaximum = if (obj.get("exclusiveMaximum")) |val| val.bool else null,
-            .minimum = if (obj.get("minimum")) |val| val.float else null,
+            .minimum = optionalFloat(obj.get("minimum")),
             .exclusiveMinimum = if (obj.get("exclusiveMinimum")) |val| val.bool else null,
             .maxLength = if (obj.get("maxLength")) |val| val.integer else null,
             .minLength = if (obj.get("minLength")) |val| val.integer else null,

--- a/src/models/v3.2/schema.zig
+++ b/src/models/v3.2/schema.zig
@@ -1,17 +1,8 @@
 const std = @import("std");
 const json = std.json;
+const json_helpers = @import("../json_helpers.zig");
 const Reference = @import("reference.zig").Reference;
 const ExternalDocumentation = @import("externaldocs.zig").ExternalDocumentation;
-
-fn optionalFloat(value: ?json.Value) ?f64 {
-    const val = value orelse return null;
-    return switch (val) {
-        .integer => |i| @as(f64, @floatFromInt(i)),
-        .float => |f| f,
-        .number_string => |s| std.fmt.parseFloat(f64, s) catch null,
-        else => null,
-    };
-}
 
 pub const XML = struct {
     name: ?[]const u8 = null,
@@ -216,10 +207,10 @@ pub const Schema = struct {
 
         return Schema{
             .title = if (obj.get("title")) |val| try allocator.dupe(u8, val.string) else null,
-            .multipleOf = optionalFloat(obj.get("multipleOf")),
-            .maximum = optionalFloat(obj.get("maximum")),
+            .multipleOf = json_helpers.optionalFloat(obj.get("multipleOf")),
+            .maximum = json_helpers.optionalFloat(obj.get("maximum")),
             .exclusiveMaximum = if (obj.get("exclusiveMaximum")) |val| val.bool else null,
-            .minimum = optionalFloat(obj.get("minimum")),
+            .minimum = json_helpers.optionalFloat(obj.get("minimum")),
             .exclusiveMinimum = if (obj.get("exclusiveMinimum")) |val| val.bool else null,
             .maxLength = if (obj.get("maxLength")) |val| val.integer else null,
             .minLength = if (obj.get("minLength")) |val| val.integer else null,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9,6 +9,7 @@ const yaml_loader_tests = @import("tests/yaml_loader_tests.zig");
 const resource_wrapper_tests = @import("tests/resource_wrapper_tests.zig");
 const model_typing_tests = @import("tests/model_typing_tests.zig");
 const binary_payload_tests = @import("tests/binary_payload_tests.zig");
+const schema_bounds_parsing_tests = @import("tests/schema_bounds_parsing_tests.zig");
 const media_type = @import("media_type.zig");
 const generator = @import("generator.zig");
 comptime {
@@ -23,6 +24,7 @@ comptime {
     _ = resource_wrapper_tests;
     _ = model_typing_tests;
     _ = binary_payload_tests;
+    _ = schema_bounds_parsing_tests;
     _ = media_type;
     _ = generator;
 }

--- a/src/tests/schema_bounds_parsing_tests.zig
+++ b/src/tests/schema_bounds_parsing_tests.zig
@@ -265,6 +265,72 @@ test "v3.2 schema parses negative numeric bounds" {
     try std.testing.expectEqual(@as(f64, -10.0), schema.minimum.?);
 }
 
+test "v3.0 schema parses overflowing integer multipleOf via number_string" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": 999999999999999999999}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf != null);
+}
+
+test "v3.0 schema parses overflowing integer maximum via number_string" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"maximum\": 999999999999999999999}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.maximum != null);
+}
+
+test "v3.0 schema parses overflowing integer minimum via number_string" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"minimum\": 999999999999999999999}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.minimum != null);
+}
+
+test "v3.2 schema parses overflowing integer multipleOf via number_string" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": 999999999999999999999}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf != null);
+}
+
+test "v3.2 schema parses overflowing integer maximum via number_string" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"maximum\": 999999999999999999999}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.maximum != null);
+}
+
+test "v3.2 schema parses overflowing integer minimum via number_string" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"minimum\": 999999999999999999999}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.minimum != null);
+}
+
 test "v3.0 schema parses negative numeric bounds" {
     var gpa = test_utils.createTestAllocator();
     const allocator = gpa.allocator();

--- a/src/tests/schema_bounds_parsing_tests.zig
+++ b/src/tests/schema_bounds_parsing_tests.zig
@@ -1,0 +1,279 @@
+const std = @import("std");
+const models = @import("../models.zig");
+const test_utils = @import("test_utils.zig");
+
+fn parseJsonValue(allocator: std.mem.Allocator, json_str: []const u8) !std.json.Parsed(std.json.Value) {
+    return try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+}
+
+test "v3.0 schema parses integer multipleOf as float" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": 5}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf != null);
+    try std.testing.expectEqual(@as(f64, 5.0), schema.multipleOf.?);
+}
+
+test "v3.0 schema parses integer maximum as float" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"maximum\": 100}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.maximum != null);
+    try std.testing.expectEqual(@as(f64, 100.0), schema.maximum.?);
+}
+
+test "v3.0 schema parses integer minimum as float" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"minimum\": 1}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.minimum != null);
+    try std.testing.expectEqual(@as(f64, 1.0), schema.minimum.?);
+}
+
+test "v3.0 schema parses float multipleOf" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": 2.5}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf != null);
+    try std.testing.expectEqual(@as(f64, 2.5), schema.multipleOf.?);
+}
+
+test "v3.0 schema parses float maximum" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"maximum\": 99.9}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.maximum != null);
+    try std.testing.expectEqual(@as(f64, 99.9), schema.maximum.?);
+}
+
+test "v3.0 schema parses float minimum" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"minimum\": 0.5}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.minimum != null);
+    try std.testing.expectEqual(@as(f64, 0.5), schema.minimum.?);
+}
+
+test "v3.0 schema missing numeric bounds are null" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"type\": \"string\"}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf == null);
+    try std.testing.expect(schema.maximum == null);
+    try std.testing.expect(schema.minimum == null);
+}
+
+test "v3.0 schema invalid string multipleOf is null" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": \"not-a-number\"}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf == null);
+}
+
+test "v3.0 schema retains exclusiveMaximum/exclusiveMinimum as bool" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"exclusiveMaximum\": true, \"exclusiveMinimum\": false}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.exclusiveMaximum != null);
+    try std.testing.expect(schema.exclusiveMaximum.?);
+    try std.testing.expect(schema.exclusiveMinimum != null);
+    try std.testing.expect(!schema.exclusiveMinimum.?);
+}
+
+test "v3.0 schema parses all numeric bounds together" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": 10, \"maximum\": 200, \"minimum\": 5}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expectEqual(@as(f64, 10.0), schema.multipleOf.?);
+    try std.testing.expectEqual(@as(f64, 200.0), schema.maximum.?);
+    try std.testing.expectEqual(@as(f64, 5.0), schema.minimum.?);
+}
+
+test "v3.2 schema parses integer multipleOf as float" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": 5}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf != null);
+    try std.testing.expectEqual(@as(f64, 5.0), schema.multipleOf.?);
+}
+
+test "v3.2 schema parses integer maximum as float" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"maximum\": 100}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.maximum != null);
+    try std.testing.expectEqual(@as(f64, 100.0), schema.maximum.?);
+}
+
+test "v3.2 schema parses integer minimum as float" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"minimum\": 1}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.minimum != null);
+    try std.testing.expectEqual(@as(f64, 1.0), schema.minimum.?);
+}
+
+test "v3.2 schema parses float multipleOf" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": 2.5}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf != null);
+    try std.testing.expectEqual(@as(f64, 2.5), schema.multipleOf.?);
+}
+
+test "v3.2 schema parses float maximum" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"maximum\": 99.9}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.maximum != null);
+    try std.testing.expectEqual(@as(f64, 99.9), schema.maximum.?);
+}
+
+test "v3.2 schema parses float minimum" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"minimum\": 0.5}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.minimum != null);
+    try std.testing.expectEqual(@as(f64, 0.5), schema.minimum.?);
+}
+
+test "v3.2 schema missing numeric bounds are null" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"type\": \"string\"}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf == null);
+    try std.testing.expect(schema.maximum == null);
+    try std.testing.expect(schema.minimum == null);
+}
+
+test "v3.2 schema invalid string multipleOf is null" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": \"not-a-number\"}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.multipleOf == null);
+}
+
+test "v3.2 schema retains exclusiveMaximum/exclusiveMinimum as bool" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"exclusiveMaximum\": true, \"exclusiveMinimum\": false}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expect(schema.exclusiveMaximum != null);
+    try std.testing.expect(schema.exclusiveMaximum.?);
+    try std.testing.expect(schema.exclusiveMinimum != null);
+    try std.testing.expect(!schema.exclusiveMinimum.?);
+}
+
+test "v3.2 schema parses all numeric bounds together" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": 10, \"maximum\": 200, \"minimum\": 5}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expectEqual(@as(f64, 10.0), schema.multipleOf.?);
+    try std.testing.expectEqual(@as(f64, 200.0), schema.maximum.?);
+    try std.testing.expectEqual(@as(f64, 5.0), schema.minimum.?);
+}
+
+test "v3.2 schema parses negative numeric bounds" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": -2, \"maximum\": -1, \"minimum\": -10}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v32.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expectEqual(@as(f64, -2.0), schema.multipleOf.?);
+    try std.testing.expectEqual(@as(f64, -1.0), schema.maximum.?);
+    try std.testing.expectEqual(@as(f64, -10.0), schema.minimum.?);
+}
+
+test "v3.0 schema parses negative numeric bounds" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    const source = "{\"multipleOf\": -2, \"maximum\": -1, \"minimum\": -10}";
+    var parsed = try parseJsonValue(allocator, source);
+    defer parsed.deinit();
+    var schema = try models.v3.Schema.parseFromJson(allocator, parsed.value);
+    defer schema.deinit(allocator);
+    try std.testing.expectEqual(@as(f64, -2.0), schema.multipleOf.?);
+    try std.testing.expectEqual(@as(f64, -1.0), schema.maximum.?);
+    try std.testing.expectEqual(@as(f64, -10.0), schema.minimum.?);
+}


### PR DESCRIPTION
Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of schema numeric limits (`multipleOf`, `maximum`, `minimum`) to correctly accept integers, decimals, and numeric-string inputs.
  * Unsupported or missing numeric bound values are now handled gracefully (without errors), while `exclusiveMaximum`/`exclusiveMinimum` boolean flags continue to be preserved.

* **Tests**
  * Added/expanded schema bound parsing test coverage across supported schema versions, including positive, negative, missing, invalid, and overflowing-number scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->