### PR TITLE
Change upgrade from option to command in CLI args

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -117,9 +117,11 @@ fn parseResourceWrapperMode(value: []const u8) ?ResourceWrapperMode {
 fn printUsage() void {
     std.debug.print(
         \\
+        \\ openapi2zig - OpenAPI/Swagger to Zig code generator
+        \\ version: {s} ({s})
+        \\
         \\ Usage: openapi2zig generate [options]
-        \\        openapi2zig --upgrade
-        \\ Version: {s} ({s})
+        \\        openapi2zig upgrade
         \\
         \\ Options:
         \\   -i, --input <PATH_OR_URL>  OpenAPI/Swagger spec (file path or http/https URL)
@@ -130,13 +132,11 @@ fn printUsage() void {
         \\   --resource-wrappers <mode> Generate resource wrappers: none, tags, paths, hybrid.
         \\                              (default: paths)
         \\   --models-only              Generate only Zig models, skipping the API client.
-        \\   --upgrade                  Upgrade to the latest version.
         \\
         \\ EXAMPLES:
         \\   openapi2zig generate -i ./openapi/petstore.json -o api.zig
         \\   openapi2zig generate -i ./openapi/petstore.json -o models.zig --models-only
         \\   openapi2zig generate -i https://petstore3.swagger.io/api/v3/openapi.json -o api.zig
-        \\
         \\
     , .{ version_info.VERSION, version_info.GIT_COMMIT });
 }
@@ -169,10 +169,10 @@ test "parse generate defaults to complete output" {
     try std.testing.expect(!parsed.args.models_only);
 }
 
-test "parse --upgrade flag" {
+test "parse upgrade" {
     const argv = [_][:0]const u8{
         "openapi2zig",
-        "--upgrade",
+        "upgrade",
     };
 
     const parsed = try parse(&argv);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -19,6 +19,7 @@ pub const CliArgs = struct {
 pub const ParsedArgs = struct {
     args: CliArgs,
     upgrade: bool = false,
+    help: bool = false,
 };
 
 pub fn parse(args: []const [:0]const u8) !ParsedArgs {
@@ -29,16 +30,12 @@ pub fn parse(args: []const [:0]const u8) !ParsedArgs {
         };
     }
 
-    if (args.len < 4) {
+    if (args.len < 4 or (args.len >= 1 and !std.mem.eql(u8, args[1], "generate"))) {
         printUsage();
-        std.debug.print("\nError: OpenAPI spec path or URL required\n", .{});
-        return error.InvalidArguments;
-    }
-
-    if (!std.mem.eql(u8, args[1], "generate")) {
-        printUsage();
-        std.debug.print("\nError: unknown subcommand '{s}'\n", .{args[1]});
-        return error.InvalidArguments;
+        return .{
+            .help = true,
+            .args = .{ .input_path = "" },
+        };
     }
 
     var input_path: ?[]const u8 = null;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -23,7 +23,7 @@ pub const ParsedArgs = struct {
 };
 
 pub fn parse(args: []const [:0]const u8) !ParsedArgs {
-    if (args.len >= 2 and std.mem.eql(u8, args[1], "--upgrade")) {
+    if (args.len >= 2 and std.mem.eql(u8, args[1], "upgrade")) {
         return .{
             .upgrade = true,
             .args = .{ .input_path = "" },

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,9 @@ pub fn main(init: std.process.Init) !void {
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     const parsed_args = cli.parse(args) catch std.process.exit(1);
+    if (parsed_args.help) {
+        return;
+    }
 
     if (parsed_args.upgrade) {
         upgrade.run(allocator, io, init.environ_map) catch |err| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,10 +14,7 @@ pub fn main(init: std.process.Init) !void {
     }
 
     if (parsed_args.upgrade) {
-        upgrade.run(allocator, io, init.environ_map) catch |err| {
-            std.debug.print("Upgrade failed: {}\n", .{err});
-            return err;
-        };
+        upgrade.run(allocator, io, init.environ_map) catch return;
         return;
     }
 

--- a/src/upgrade.zig
+++ b/src/upgrade.zig
@@ -221,24 +221,28 @@ fn replaceBinary(allocator: std.mem.Allocator, io: std.Io, new_binary_path: []co
         const cleanup_cmd = try std.fmt.allocPrint(allocator, "Start-Sleep 2; Remove-Item -Force '{s}'", .{old_path});
         defer allocator.free(cleanup_cmd);
 
-        _ = std.process.run(std.heap.page_allocator, io, .{
+        if (std.process.run(allocator, io, .{
             .argv = &[_][]const u8{ "powershell", "-NoProfile", "-Command", cleanup_cmd },
-        }) catch {};
+        })) |cleanup_result| {
+            allocator.free(cleanup_result.stdout);
+            allocator.free(cleanup_result.stderr);
+        } else |_| {}
     } else {
         try copyFile(allocator, io, new_binary_path, exe_path);
     }
 }
 
 fn copyFile(allocator: std.mem.Allocator, io: std.Io, src: []const u8, dst: []const u8) !void {
-    if (builtin.os.tag == .windows) {
-        _ = try std.process.run(allocator, io, .{
+    const result = if (builtin.os.tag == .windows)
+        try std.process.run(allocator, io, .{
             .argv = &[_][]const u8{ "cmd", "/c", "copy", "/y", src, dst },
-        });
-    } else {
-        _ = try std.process.run(allocator, io, .{
+        })
+    else
+        try std.process.run(allocator, io, .{
             .argv = &[_][]const u8{ "cp", "-f", src, dst },
         });
-    }
+    allocator.free(result.stdout);
+    allocator.free(result.stderr);
 }
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io, environ_map: *std.process.Environ.Map) !void {

--- a/src/upgrade.zig
+++ b/src/upgrade.zig
@@ -58,6 +58,26 @@ fn stripVPrefix(version: []const u8) []const u8 {
     return version;
 }
 
+const Version = struct {
+    major: u32,
+    minor: u32,
+    patch: u32,
+
+    fn parse(s: []const u8) !Version {
+        var it = std.mem.splitScalar(u8, s, '.');
+        const major = try std.fmt.parseInt(u32, it.next() orelse return error.InvalidVersion, 10);
+        const minor = try std.fmt.parseInt(u32, it.next() orelse return error.InvalidVersion, 10);
+        const patch = try std.fmt.parseInt(u32, it.next() orelse return error.InvalidVersion, 10);
+        return .{ .major = major, .minor = minor, .patch = patch };
+    }
+
+    fn newerThan(self: Version, other: Version) bool {
+        if (self.major != other.major) return self.major > other.major;
+        if (self.minor != other.minor) return self.minor > other.minor;
+        return self.patch > other.patch;
+    }
+};
+
 fn archiveName(allocator: std.mem.Allocator, p: Platform) ![]const u8 {
     const ext = if (isWindows(p)) ".zip" else ".tar.gz";
     return std.fmt.allocPrint(allocator, "openapi2zig-{s}{s}", .{ platformString(p), ext });
@@ -221,11 +241,20 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, environ_map: *std.process.E
     defer allocator.free(latest_version);
 
     const current = version_info.VERSION;
-    const latest_trimmed = if (std.mem.startsWith(u8, latest_version, "v")) latest_version[1..] else latest_version;
+    const latest_trimmed = stripVPrefix(latest_version);
 
     std.debug.print("  Latest version: {s}\n", .{latest_version});
 
-    if (std.mem.eql(u8, current, latest_trimmed)) {
+    const current_version = Version.parse(current) catch {
+        std.debug.print("  Could not parse current version: {s}\n", .{current});
+        return;
+    };
+    const latest_parsed = Version.parse(latest_trimmed) catch {
+        std.debug.print("  Could not parse latest version: {s}\n", .{latest_trimmed});
+        return;
+    };
+
+    if (!latest_parsed.newerThan(current_version)) {
         std.debug.print("  Already up to date.\n", .{});
         return;
     }

--- a/src/upgrade.zig
+++ b/src/upgrade.zig
@@ -277,7 +277,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, environ_map: *std.process.E
     defer allocator.free(archive_path);
 
     std.debug.print("  Extracting...\n", .{});
-    try extractArchive(allocator, io, archive_path, tmp_dir_path, platform);
+    try extractArchive(allocator, io, archive_path, tmp_sub, platform);
 
     const binary_name = if (isWindows(platform)) "openapi2zig.exe" else "openapi2zig";
     const new_binary = try std.fs.path.join(allocator, &.{ tmp_dir_path, sub_dir_name, binary_name });

--- a/src/upgrade.zig
+++ b/src/upgrade.zig
@@ -150,7 +150,7 @@ fn downloadArchive(allocator: std.mem.Allocator, io: std.Io, version: []const u8
 
     try req.sendBodiless();
 
-    var redirect_buf: [1024]u8 = undefined;
+    var redirect_buf: [8192]u8 = undefined;
     var response = try req.receiveHead(&redirect_buf);
 
     if (response.head.status != .ok) return error.UpgradeFailed;

--- a/src/upgrade.zig
+++ b/src/upgrade.zig
@@ -53,6 +53,11 @@ fn isLinux(p: Platform) bool {
     };
 }
 
+fn stripVPrefix(version: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, version, "v")) return version[1..];
+    return version;
+}
+
 fn archiveName(allocator: std.mem.Allocator, p: Platform) ![]const u8 {
     const ext = if (isWindows(p)) ".zip" else ".tar.gz";
     return std.fmt.allocPrint(allocator, "openapi2zig-{s}{s}", .{ platformString(p), ext });

--- a/src/upgrade.zig
+++ b/src/upgrade.zig
@@ -110,22 +110,37 @@ fn fetchLatestVersion(allocator: std.mem.Allocator, io: std.Io) ![]const u8 {
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
 
-    if (result.term != .exited or result.term.exited != 0) return error.UpgradeFailed;
+    if (result.term != .exited or result.term.exited != 0) {
+        std.debug.print("  Version check command failed: term={}, stderr={s}\n", .{ result.term, result.stderr });
+        return error.UpgradeFailed;
+    }
 
     const trimmed = std.mem.trim(u8, result.stdout, " \t\r\n");
-    if (trimmed.len == 0) return error.UpgradeFailed;
+    if (trimmed.len == 0) {
+        std.debug.print("  Empty response from version check\n", .{});
+        return error.UpgradeFailed;
+    }
 
     if (builtin.os.tag != .windows) {
         const parsed = try std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{ .ignore_unknown_fields = true });
         defer parsed.deinit();
         const root = switch (parsed.value) {
             .object => |obj| obj,
-            else => return error.UpgradeFailed,
+            else => {
+                std.debug.print("  Unexpected JSON root type\n", .{});
+                return error.UpgradeFailed;
+            },
         };
-        const tag_value = root.get("tag_name") orelse return error.UpgradeFailed;
+        const tag_value = root.get("tag_name") orelse {
+            std.debug.print("  Missing 'tag_name' in release response\n", .{});
+            return error.UpgradeFailed;
+        };
         const version = switch (tag_value) {
             .string => |s| s,
-            else => return error.UpgradeFailed,
+            else => {
+                std.debug.print("  'tag_name' is not a string\n", .{});
+                return error.UpgradeFailed;
+            },
         };
         return allocator.dupe(u8, version);
     }


### PR DESCRIPTION
This PR addresses issues in the upgrade subcommand flow, including parsing the correct flag, cleaning up duplicate error messages, and fixing allocator usage for process output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `upgrade` as a positional subcommand, and updated help/usage examples accordingly.

* **Bug Fixes**
  * Upgrade decisions now use semantic version comparison (including optional `v`-prefixed tags) to avoid unnecessary upgrades.
  * Hardened “latest release” lookup and download handling by validating responses and required fields.
  * Improved archive extraction and binary replacement flow, including safer handling of command outputs.

* **Chores**
  * Reduced noisy output by suppressing upgrade error messages and handling `--help` early exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->