### PR TITLE
Add CancellationToken support for SSE streaming endpoints

### DIFF
--- a/generated/compile_generated.zig
+++ b/generated/compile_generated.zig
@@ -40,6 +40,7 @@ test "generated SSE parser handles comments CRLF multiline and done" {
             "data: [DONE]\n\n" ++
             "data: should-not-dispatch\n\n",
         &callback,
+        null,
     );
     try std.testing.expectEqual(@as(usize, 1), callback.count);
 
@@ -55,6 +56,7 @@ test "generated SSE parser handles comments CRLF multiline and done" {
             "data: b\n" ++
             "\n",
         &callback,
+        null,
     );
     try std.testing.expectEqual(@as(usize, 3), callback.count);
 }
@@ -68,7 +70,7 @@ test "generated SSE parser bounds line and event size" {
     const long_line = try std.testing.allocator.alloc(u8, max_sse_line_size + 1);
     defer std.testing.allocator.free(long_line);
     @memset(long_line, 'x');
-    try std.testing.expectError(error.SseLineTooLong, v3.parseSseBytes(std.testing.allocator, long_line, &callback));
+    try std.testing.expectError(error.SseLineTooLong, v3.parseSseBytes(std.testing.allocator, long_line, &callback, null));
 
     var input: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer input.deinit();
@@ -84,7 +86,7 @@ test "generated SSE parser bounds line and event size" {
     }
     try input.writer.writeAll("\n");
 
-    try std.testing.expectError(error.SseEventTooLong, v3.parseSseBytes(std.testing.allocator, input.written(), &callback));
+    try std.testing.expectError(error.SseEventTooLong, v3.parseSseBytes(std.testing.allocator, input.written(), &callback, null));
 }
 
 const TypedEvent = struct {
@@ -108,6 +110,7 @@ test "generated SSE parser can parse typed events" {
             "data: {\"x\":2}\n\n" ++
             "data: [DONE]\n\n",
         &callback,
+        null,
     );
     try std.testing.expectEqual(@as(i64, 3), callback.seen);
 }
@@ -151,6 +154,28 @@ test "generated ApiResult parses success and keeps error body" {
             try std.testing.expect(parse_error.error_name.len > 0);
         },
     }
+}
+
+test "generated CancellationToken cancels SSE parsing" {
+    var token = v3.CancellationToken.init();
+    token.cancel();
+
+    var callback: SseCallback = .{};
+    try std.testing.expectError(
+        error.Cancelled,
+        v3.parseSseBytes(std.testing.allocator, "data: {\"x\":1}\n\n", &callback, &token),
+    );
+}
+
+test "generated CancellationToken cancels typed SSE parsing" {
+    var token = v3.CancellationToken.init();
+    token.cancel();
+
+    var callback: TypedSseTestCallback = .{};
+    try std.testing.expectError(
+        error.Cancelled,
+        v3.parseSseBytesTyped(TypedEvent, std.testing.allocator, "data: {\"x\":1}\n\n", &callback, &token),
+    );
 }
 
 test "generated endpoint parsing is loose" {

--- a/generated/generated_v2.zig
+++ b/generated/generated_v2.zig
@@ -234,15 +234,37 @@ pub fn postJsonResult(comptime T: type, client: *Client, path: []const u8, paylo
     return parseRawResponse(T, try postJsonRaw(client, path, payload));
 }
 
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool),
+
+    pub fn init() CancellationToken {
+        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .seq_cst);
+    }
+
+    pub fn isCancelled(self: *CancellationToken) bool {
+        return self.cancelled.load(.seq_cst);
+    }
+};
+
+fn checkCancellation(token: ?*CancellationToken) !void {
+    if (token) |t| {
+        if (t.isCancelled()) return error.Cancelled;
+    }
+}
+
 const max_sse_line_size = 256 * 1024;
 const max_sse_event_size = 1024 * 1024;
 
-pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var reader: std.Io.Reader = .fixed(bytes);
-    try parseSseReader(allocator, &reader, callback);
+    try parseSseReader(allocator, &reader, callback, cancellation_token);
 }
 
-pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var line_buf: std.Io.Writer.Allocating = .init(allocator);
     defer line_buf.deinit();
 
@@ -250,6 +272,7 @@ pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, call
     defer event_data.deinit();
 
     while (true) {
+        try checkCancellation(cancellation_token);
         line_buf.clearRetainingCapacity();
 
         _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -318,16 +341,16 @@ fn TypedSseCallback(comptime T: type, comptime Callback: type) type {
     };
 }
 
-pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseBytes(allocator, bytes, &typed_callback);
+    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
 }
 
-pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseReader(allocator, reader, &typed_callback);
+    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
 }
 
 fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -348,13 +371,13 @@ fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![
     return try out.toOwnedSlice();
 }
 
-fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-    try streamJson(client, path, requestBody, &typed_callback);
+    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
 }
 
-fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const allocator = client.allocator;
     const payload = try stringifyStreamRequest(allocator, requestBody);
     defer allocator.free(payload);
@@ -367,6 +390,7 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
     defer allocator.free(url);
     const uri = try std.Uri.parse(url);
+    try checkCancellation(cancellation_token);
 
     var req = try client.http.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
@@ -380,13 +404,14 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     try body.writer.writeAll(payload);
     try body.end();
     try req.connection.?.flush();
+    try checkCancellation(cancellation_token);
 
     var response = try req.receiveHead(&.{});
     if (response.head.status.class() != .success) return error.ResponseError;
 
     var transfer_buffer: [8 * 1024]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
-    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
         error.ReadFailed => return response.bodyErr() orelse err,
         else => return err,
     };

--- a/generated/generated_v2_yaml.zig
+++ b/generated/generated_v2_yaml.zig
@@ -234,15 +234,37 @@ pub fn postJsonResult(comptime T: type, client: *Client, path: []const u8, paylo
     return parseRawResponse(T, try postJsonRaw(client, path, payload));
 }
 
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool),
+
+    pub fn init() CancellationToken {
+        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .seq_cst);
+    }
+
+    pub fn isCancelled(self: *CancellationToken) bool {
+        return self.cancelled.load(.seq_cst);
+    }
+};
+
+fn checkCancellation(token: ?*CancellationToken) !void {
+    if (token) |t| {
+        if (t.isCancelled()) return error.Cancelled;
+    }
+}
+
 const max_sse_line_size = 256 * 1024;
 const max_sse_event_size = 1024 * 1024;
 
-pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var reader: std.Io.Reader = .fixed(bytes);
-    try parseSseReader(allocator, &reader, callback);
+    try parseSseReader(allocator, &reader, callback, cancellation_token);
 }
 
-pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var line_buf: std.Io.Writer.Allocating = .init(allocator);
     defer line_buf.deinit();
 
@@ -250,6 +272,7 @@ pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, call
     defer event_data.deinit();
 
     while (true) {
+        try checkCancellation(cancellation_token);
         line_buf.clearRetainingCapacity();
 
         _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -318,16 +341,16 @@ fn TypedSseCallback(comptime T: type, comptime Callback: type) type {
     };
 }
 
-pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseBytes(allocator, bytes, &typed_callback);
+    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
 }
 
-pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseReader(allocator, reader, &typed_callback);
+    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
 }
 
 fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -348,13 +371,13 @@ fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![
     return try out.toOwnedSlice();
 }
 
-fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-    try streamJson(client, path, requestBody, &typed_callback);
+    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
 }
 
-fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const allocator = client.allocator;
     const payload = try stringifyStreamRequest(allocator, requestBody);
     defer allocator.free(payload);
@@ -367,6 +390,7 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
     defer allocator.free(url);
     const uri = try std.Uri.parse(url);
+    try checkCancellation(cancellation_token);
 
     var req = try client.http.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
@@ -380,13 +404,14 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     try body.writer.writeAll(payload);
     try body.end();
     try req.connection.?.flush();
+    try checkCancellation(cancellation_token);
 
     var response = try req.receiveHead(&.{});
     if (response.head.status.class() != .success) return error.ResponseError;
 
     var transfer_buffer: [8 * 1024]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
-    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
         error.ReadFailed => return response.bodyErr() orelse err,
         else => return err,
     };

--- a/generated/generated_v3.zig
+++ b/generated/generated_v3.zig
@@ -247,15 +247,37 @@ pub fn postJsonResult(comptime T: type, client: *Client, path: []const u8, paylo
     return parseRawResponse(T, try postJsonRaw(client, path, payload));
 }
 
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool),
+
+    pub fn init() CancellationToken {
+        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .seq_cst);
+    }
+
+    pub fn isCancelled(self: *CancellationToken) bool {
+        return self.cancelled.load(.seq_cst);
+    }
+};
+
+fn checkCancellation(token: ?*CancellationToken) !void {
+    if (token) |t| {
+        if (t.isCancelled()) return error.Cancelled;
+    }
+}
+
 const max_sse_line_size = 256 * 1024;
 const max_sse_event_size = 1024 * 1024;
 
-pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var reader: std.Io.Reader = .fixed(bytes);
-    try parseSseReader(allocator, &reader, callback);
+    try parseSseReader(allocator, &reader, callback, cancellation_token);
 }
 
-pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var line_buf: std.Io.Writer.Allocating = .init(allocator);
     defer line_buf.deinit();
 
@@ -263,6 +285,7 @@ pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, call
     defer event_data.deinit();
 
     while (true) {
+        try checkCancellation(cancellation_token);
         line_buf.clearRetainingCapacity();
 
         _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -331,16 +354,16 @@ fn TypedSseCallback(comptime T: type, comptime Callback: type) type {
     };
 }
 
-pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseBytes(allocator, bytes, &typed_callback);
+    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
 }
 
-pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseReader(allocator, reader, &typed_callback);
+    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
 }
 
 fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -361,13 +384,13 @@ fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![
     return try out.toOwnedSlice();
 }
 
-fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-    try streamJson(client, path, requestBody, &typed_callback);
+    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
 }
 
-fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const allocator = client.allocator;
     const payload = try stringifyStreamRequest(allocator, requestBody);
     defer allocator.free(payload);
@@ -380,6 +403,7 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
     defer allocator.free(url);
     const uri = try std.Uri.parse(url);
+    try checkCancellation(cancellation_token);
 
     var req = try client.http.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
@@ -393,13 +417,14 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     try body.writer.writeAll(payload);
     try body.end();
     try req.connection.?.flush();
+    try checkCancellation(cancellation_token);
 
     var response = try req.receiveHead(&.{});
     if (response.head.status.class() != .success) return error.ResponseError;
 
     var transfer_buffer: [8 * 1024]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
-    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
         error.ReadFailed => return response.bodyErr() orelse err,
         else => return err,
     };

--- a/generated/generated_v31.zig
+++ b/generated/generated_v31.zig
@@ -195,15 +195,37 @@ pub fn postJsonResult(comptime T: type, client: *Client, path: []const u8, paylo
     return parseRawResponse(T, try postJsonRaw(client, path, payload));
 }
 
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool),
+
+    pub fn init() CancellationToken {
+        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .seq_cst);
+    }
+
+    pub fn isCancelled(self: *CancellationToken) bool {
+        return self.cancelled.load(.seq_cst);
+    }
+};
+
+fn checkCancellation(token: ?*CancellationToken) !void {
+    if (token) |t| {
+        if (t.isCancelled()) return error.Cancelled;
+    }
+}
+
 const max_sse_line_size = 256 * 1024;
 const max_sse_event_size = 1024 * 1024;
 
-pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var reader: std.Io.Reader = .fixed(bytes);
-    try parseSseReader(allocator, &reader, callback);
+    try parseSseReader(allocator, &reader, callback, cancellation_token);
 }
 
-pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var line_buf: std.Io.Writer.Allocating = .init(allocator);
     defer line_buf.deinit();
 
@@ -211,6 +233,7 @@ pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, call
     defer event_data.deinit();
 
     while (true) {
+        try checkCancellation(cancellation_token);
         line_buf.clearRetainingCapacity();
 
         _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -279,16 +302,16 @@ fn TypedSseCallback(comptime T: type, comptime Callback: type) type {
     };
 }
 
-pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseBytes(allocator, bytes, &typed_callback);
+    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
 }
 
-pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseReader(allocator, reader, &typed_callback);
+    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
 }
 
 fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -309,13 +332,13 @@ fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![
     return try out.toOwnedSlice();
 }
 
-fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-    try streamJson(client, path, requestBody, &typed_callback);
+    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
 }
 
-fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const allocator = client.allocator;
     const payload = try stringifyStreamRequest(allocator, requestBody);
     defer allocator.free(payload);
@@ -328,6 +351,7 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
     defer allocator.free(url);
     const uri = try std.Uri.parse(url);
+    try checkCancellation(cancellation_token);
 
     var req = try client.http.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
@@ -341,13 +365,14 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     try body.writer.writeAll(payload);
     try body.end();
     try req.connection.?.flush();
+    try checkCancellation(cancellation_token);
 
     var response = try req.receiveHead(&.{});
     if (response.head.status.class() != .success) return error.ResponseError;
 
     var transfer_buffer: [8 * 1024]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
-    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
         error.ReadFailed => return response.bodyErr() orelse err,
         else => return err,
     };

--- a/generated/generated_v31_yaml.zig
+++ b/generated/generated_v31_yaml.zig
@@ -195,15 +195,37 @@ pub fn postJsonResult(comptime T: type, client: *Client, path: []const u8, paylo
     return parseRawResponse(T, try postJsonRaw(client, path, payload));
 }
 
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool),
+
+    pub fn init() CancellationToken {
+        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .seq_cst);
+    }
+
+    pub fn isCancelled(self: *CancellationToken) bool {
+        return self.cancelled.load(.seq_cst);
+    }
+};
+
+fn checkCancellation(token: ?*CancellationToken) !void {
+    if (token) |t| {
+        if (t.isCancelled()) return error.Cancelled;
+    }
+}
+
 const max_sse_line_size = 256 * 1024;
 const max_sse_event_size = 1024 * 1024;
 
-pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var reader: std.Io.Reader = .fixed(bytes);
-    try parseSseReader(allocator, &reader, callback);
+    try parseSseReader(allocator, &reader, callback, cancellation_token);
 }
 
-pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var line_buf: std.Io.Writer.Allocating = .init(allocator);
     defer line_buf.deinit();
 
@@ -211,6 +233,7 @@ pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, call
     defer event_data.deinit();
 
     while (true) {
+        try checkCancellation(cancellation_token);
         line_buf.clearRetainingCapacity();
 
         _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -279,16 +302,16 @@ fn TypedSseCallback(comptime T: type, comptime Callback: type) type {
     };
 }
 
-pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseBytes(allocator, bytes, &typed_callback);
+    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
 }
 
-pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseReader(allocator, reader, &typed_callback);
+    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
 }
 
 fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -309,13 +332,13 @@ fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![
     return try out.toOwnedSlice();
 }
 
-fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-    try streamJson(client, path, requestBody, &typed_callback);
+    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
 }
 
-fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const allocator = client.allocator;
     const payload = try stringifyStreamRequest(allocator, requestBody);
     defer allocator.free(payload);
@@ -328,6 +351,7 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
     defer allocator.free(url);
     const uri = try std.Uri.parse(url);
+    try checkCancellation(cancellation_token);
 
     var req = try client.http.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
@@ -341,13 +365,14 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     try body.writer.writeAll(payload);
     try body.end();
     try req.connection.?.flush();
+    try checkCancellation(cancellation_token);
 
     var response = try req.receiveHead(&.{});
     if (response.head.status.class() != .success) return error.ResponseError;
 
     var transfer_buffer: [8 * 1024]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
-    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
         error.ReadFailed => return response.bodyErr() orelse err,
         else => return err,
     };

--- a/generated/generated_v32.zig
+++ b/generated/generated_v32.zig
@@ -234,15 +234,37 @@ pub fn postJsonResult(comptime T: type, client: *Client, path: []const u8, paylo
     return parseRawResponse(T, try postJsonRaw(client, path, payload));
 }
 
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool),
+
+    pub fn init() CancellationToken {
+        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .seq_cst);
+    }
+
+    pub fn isCancelled(self: *CancellationToken) bool {
+        return self.cancelled.load(.seq_cst);
+    }
+};
+
+fn checkCancellation(token: ?*CancellationToken) !void {
+    if (token) |t| {
+        if (t.isCancelled()) return error.Cancelled;
+    }
+}
+
 const max_sse_line_size = 256 * 1024;
 const max_sse_event_size = 1024 * 1024;
 
-pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var reader: std.Io.Reader = .fixed(bytes);
-    try parseSseReader(allocator, &reader, callback);
+    try parseSseReader(allocator, &reader, callback, cancellation_token);
 }
 
-pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var line_buf: std.Io.Writer.Allocating = .init(allocator);
     defer line_buf.deinit();
 
@@ -250,6 +272,7 @@ pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, call
     defer event_data.deinit();
 
     while (true) {
+        try checkCancellation(cancellation_token);
         line_buf.clearRetainingCapacity();
 
         _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -318,16 +341,16 @@ fn TypedSseCallback(comptime T: type, comptime Callback: type) type {
     };
 }
 
-pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseBytes(allocator, bytes, &typed_callback);
+    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
 }
 
-pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseReader(allocator, reader, &typed_callback);
+    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
 }
 
 fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -348,13 +371,13 @@ fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![
     return try out.toOwnedSlice();
 }
 
-fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-    try streamJson(client, path, requestBody, &typed_callback);
+    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
 }
 
-fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const allocator = client.allocator;
     const payload = try stringifyStreamRequest(allocator, requestBody);
     defer allocator.free(payload);
@@ -367,6 +390,7 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
     defer allocator.free(url);
     const uri = try std.Uri.parse(url);
+    try checkCancellation(cancellation_token);
 
     var req = try client.http.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
@@ -380,13 +404,14 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     try body.writer.writeAll(payload);
     try body.end();
     try req.connection.?.flush();
+    try checkCancellation(cancellation_token);
 
     var response = try req.receiveHead(&.{});
     if (response.head.status.class() != .success) return error.ResponseError;
 
     var transfer_buffer: [8 * 1024]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
-    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
         error.ReadFailed => return response.bodyErr() orelse err,
         else => return err,
     };

--- a/generated/generated_v3_yaml.zig
+++ b/generated/generated_v3_yaml.zig
@@ -247,15 +247,37 @@ pub fn postJsonResult(comptime T: type, client: *Client, path: []const u8, paylo
     return parseRawResponse(T, try postJsonRaw(client, path, payload));
 }
 
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool),
+
+    pub fn init() CancellationToken {
+        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .seq_cst);
+    }
+
+    pub fn isCancelled(self: *CancellationToken) bool {
+        return self.cancelled.load(.seq_cst);
+    }
+};
+
+fn checkCancellation(token: ?*CancellationToken) !void {
+    if (token) |t| {
+        if (t.isCancelled()) return error.Cancelled;
+    }
+}
+
 const max_sse_line_size = 256 * 1024;
 const max_sse_event_size = 1024 * 1024;
 
-pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var reader: std.Io.Reader = .fixed(bytes);
-    try parseSseReader(allocator, &reader, callback);
+    try parseSseReader(allocator, &reader, callback, cancellation_token);
 }
 
-pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var line_buf: std.Io.Writer.Allocating = .init(allocator);
     defer line_buf.deinit();
 
@@ -263,6 +285,7 @@ pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, call
     defer event_data.deinit();
 
     while (true) {
+        try checkCancellation(cancellation_token);
         line_buf.clearRetainingCapacity();
 
         _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -331,16 +354,16 @@ fn TypedSseCallback(comptime T: type, comptime Callback: type) type {
     };
 }
 
-pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseBytes(allocator, bytes, &typed_callback);
+    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
 }
 
-pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseReader(allocator, reader, &typed_callback);
+    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
 }
 
 fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -361,13 +384,13 @@ fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![
     return try out.toOwnedSlice();
 }
 
-fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-    try streamJson(client, path, requestBody, &typed_callback);
+    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
 }
 
-fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const allocator = client.allocator;
     const payload = try stringifyStreamRequest(allocator, requestBody);
     defer allocator.free(payload);
@@ -380,6 +403,7 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
     defer allocator.free(url);
     const uri = try std.Uri.parse(url);
+    try checkCancellation(cancellation_token);
 
     var req = try client.http.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
@@ -393,13 +417,14 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     try body.writer.writeAll(payload);
     try body.end();
     try req.connection.?.flush();
+    try checkCancellation(cancellation_token);
 
     var response = try req.receiveHead(&.{});
     if (response.head.status.class() != .success) return error.ResponseError;
 
     var transfer_buffer: [8 * 1024]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
-    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
         error.ReadFailed => return response.bodyErr() orelse err,
         else => return err,
     };

--- a/generated/lmstudio.zig
+++ b/generated/lmstudio.zig
@@ -33,7 +33,46 @@ pub const DownloadModelResponse = struct {
     started_at: ?[]const u8 = null,
 };
 
-pub const ChatOutputItem = std.json.Value;
+pub const ChatOutputItem = union(enum) {
+    message: MessageOutput,
+    tool_call: ToolCallOutput,
+    reasoning: ReasoningOutput,
+    invalid_tool_call: InvalidToolCallOutput,
+    raw: std.json.Value,
+
+    pub fn jsonParse(allocator: std.mem.Allocator, source: anytype, options: std.json.ParseOptions) !@This() {
+        const value = try std.json.innerParse(std.json.Value, allocator, source, options);
+        return jsonParseFromValue(allocator, value, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, options: std.json.ParseOptions) !@This() {
+        if (source != .object) return error.UnexpectedToken;        const discriminator = source.object.get("type") orelse return .{ .raw = source };
+        if (discriminator != .string) return .{ .raw = source };
+        if (std.mem.eql(u8, discriminator.string, "message")) {
+            return .{ .message = try std.json.parseFromValueLeaky(MessageOutput, allocator, source, options) };
+        }
+        if (std.mem.eql(u8, discriminator.string, "tool_call")) {
+            return .{ .tool_call = try std.json.parseFromValueLeaky(ToolCallOutput, allocator, source, options) };
+        }
+        if (std.mem.eql(u8, discriminator.string, "reasoning")) {
+            return .{ .reasoning = try std.json.parseFromValueLeaky(ReasoningOutput, allocator, source, options) };
+        }
+        if (std.mem.eql(u8, discriminator.string, "invalid_tool_call")) {
+            return .{ .invalid_tool_call = try std.json.parseFromValueLeaky(InvalidToolCallOutput, allocator, source, options) };
+        }
+
+        return .{ .raw = source };
+    }
+
+    pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) !void {
+        switch (self) {            .message => |value| try jw.write(value),
+            .tool_call => |value| try jw.write(value),
+            .reasoning => |value| try jw.write(value),
+            .invalid_tool_call => |value| try jw.write(value),
+            .raw => |value| try jw.write(value),
+        }
+    }
+};
 
 pub const LoadedInstance = struct {
     id: []const u8,
@@ -131,8 +170,73 @@ pub const DownloadModelRequest = struct {
     model: []const u8,
 };
 
+pub const ChatRequestIntegrationsItemVariant0 = []const u8;
+
+pub const ChatRequestIntegrationsItem = union(enum) {
+    string: []const u8,
+    plugin_integration: PluginIntegration,
+    ephemeral_mcp_integration: EphemeralMcpIntegration,
+    raw: std.json.Value,
+
+    pub fn jsonParse(allocator: std.mem.Allocator, source: anytype, options: std.json.ParseOptions) !@This() {
+        const value = try std.json.innerParse(std.json.Value, allocator, source, options);
+        return jsonParseFromValue(allocator, value, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, options: std.json.ParseOptions) !@This() {        if (std.json.parseFromValueLeaky([]const u8, allocator, source, options)) |value| {
+            return .{ .string = value };
+        } else |_| {}
+        if (std.json.parseFromValueLeaky(PluginIntegration, allocator, source, options)) |value| {
+            return .{ .plugin_integration = value };
+        } else |_| {}
+        if (std.json.parseFromValueLeaky(EphemeralMcpIntegration, allocator, source, options)) |value| {
+            return .{ .ephemeral_mcp_integration = value };
+        } else |_| {}
+        return .{ .raw = source };
+    }
+
+    pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) !void {
+        switch (self) {            .string => |value| try jw.write(value),
+            .plugin_integration => |value| try jw.write(value),
+            .ephemeral_mcp_integration => |value| try jw.write(value),
+            .raw => |value| try jw.write(value),
+        }
+    }
+};
+
+pub const ChatRequestInputVariant0 = []const u8;
+
+pub const ChatRequestInputVariant1 = []const ChatInputItem;
+
+pub const ChatRequestInput = union(enum) {
+    string: []const u8,
+    chat_input_item_items: []const ChatInputItem,
+    raw: std.json.Value,
+
+    pub fn jsonParse(allocator: std.mem.Allocator, source: anytype, options: std.json.ParseOptions) !@This() {
+        const value = try std.json.innerParse(std.json.Value, allocator, source, options);
+        return jsonParseFromValue(allocator, value, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, options: std.json.ParseOptions) !@This() {        if (std.json.parseFromValueLeaky([]const u8, allocator, source, options)) |value| {
+            return .{ .string = value };
+        } else |_| {}
+        if (std.json.parseFromValueLeaky([]const ChatInputItem, allocator, source, options)) |value| {
+            return .{ .chat_input_item_items = value };
+        } else |_| {}
+        return .{ .raw = source };
+    }
+
+    pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) !void {
+        switch (self) {            .string => |value| try jw.write(value),
+            .chat_input_item_items => |value| try jw.write(value),
+            .raw => |value| try jw.write(value),
+        }
+    }
+};
+
 pub const ChatRequest = struct {
-    integrations: ?[]const std.json.Value = null,
+    integrations: ?[]const ChatRequestIntegrationsItem = null,
     reasoning: ?[]const u8 = null,
     temperature: ?f64 = null,
     max_output_tokens: ?i64 = null,
@@ -145,7 +249,7 @@ pub const ChatRequest = struct {
     top_k: ?i64 = null,
     min_p: ?f64 = null,
     previous_response_id: ?[]const u8 = null,
-    input: std.json.Value,
+    input: ChatRequestInput,
     system_prompt: ?[]const u8 = null,
 };
 
@@ -185,11 +289,38 @@ pub const InvalidToolCallOutput = struct {
     @"type": []const u8,
 };
 
+pub const LoadModelResponseLoadConfig = union(enum) {
+    llm_load_config: LlmLoadConfig,
+    embedding_load_config: EmbeddingLoadConfig,
+    raw: std.json.Value,
+
+    pub fn jsonParse(allocator: std.mem.Allocator, source: anytype, options: std.json.ParseOptions) !@This() {
+        const value = try std.json.innerParse(std.json.Value, allocator, source, options);
+        return jsonParseFromValue(allocator, value, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, options: std.json.ParseOptions) !@This() {        if (std.json.parseFromValueLeaky(LlmLoadConfig, allocator, source, options)) |value| {
+            return .{ .llm_load_config = value };
+        } else |_| {}
+        if (std.json.parseFromValueLeaky(EmbeddingLoadConfig, allocator, source, options)) |value| {
+            return .{ .embedding_load_config = value };
+        } else |_| {}
+        return .{ .raw = source };
+    }
+
+    pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) !void {
+        switch (self) {            .llm_load_config => |value| try jw.write(value),
+            .embedding_load_config => |value| try jw.write(value),
+            .raw => |value| try jw.write(value),
+        }
+    }
+};
+
 pub const LoadModelResponse = struct {
     load_time_seconds: f64,
     status: []const u8,
     instance_id: []const u8,
-    load_config: ?std.json.Value = null,
+    load_config: ?LoadModelResponseLoadConfig = null,
     @"type": []const u8,
 };
 
@@ -199,7 +330,36 @@ pub const ProviderInfo = struct {
     server_label: ?[]const u8 = null,
 };
 
-pub const ChatInputItem = std.json.Value;
+pub const ChatInputItem = union(enum) {
+    message: TextInput,
+    image: ImageInput,
+    raw: std.json.Value,
+
+    pub fn jsonParse(allocator: std.mem.Allocator, source: anytype, options: std.json.ParseOptions) !@This() {
+        const value = try std.json.innerParse(std.json.Value, allocator, source, options);
+        return jsonParseFromValue(allocator, value, options);
+    }
+
+    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, options: std.json.ParseOptions) !@This() {
+        if (source != .object) return error.UnexpectedToken;        const discriminator = source.object.get("type") orelse return .{ .raw = source };
+        if (discriminator != .string) return .{ .raw = source };
+        if (std.mem.eql(u8, discriminator.string, "message")) {
+            return .{ .message = try std.json.parseFromValueLeaky(TextInput, allocator, source, options) };
+        }
+        if (std.mem.eql(u8, discriminator.string, "image")) {
+            return .{ .image = try std.json.parseFromValueLeaky(ImageInput, allocator, source, options) };
+        }
+
+        return .{ .raw = source };
+    }
+
+    pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) !void {
+        switch (self) {            .message => |value| try jw.write(value),
+            .image => |value| try jw.write(value),
+            .raw => |value| try jw.write(value),
+        }
+    }
+};
 
 pub const EphemeralMcpIntegration = struct {
     server_url: []const u8,
@@ -276,7 +436,7 @@ pub const Client = struct {
     io: std.Io,
     http: std.http.Client,
     api_key: []const u8,
-    base_url: []const u8 = "",
+    base_url: []const u8 = "http://localhost:1234",
     organization: ?[]const u8 = null,
     project: ?[]const u8 = null,
     default_headers: []const std.http.Header = &.{},
@@ -402,15 +562,37 @@ pub fn postJsonResult(comptime T: type, client: *Client, path: []const u8, paylo
     return parseRawResponse(T, try postJsonRaw(client, path, payload));
 }
 
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool),
+
+    pub fn init() CancellationToken {
+        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .seq_cst);
+    }
+
+    pub fn isCancelled(self: *CancellationToken) bool {
+        return self.cancelled.load(.seq_cst);
+    }
+};
+
+fn checkCancellation(token: ?*CancellationToken) !void {
+    if (token) |t| {
+        if (t.isCancelled()) return error.Cancelled;
+    }
+}
+
 const max_sse_line_size = 256 * 1024;
 const max_sse_event_size = 1024 * 1024;
 
-pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var reader: std.Io.Reader = .fixed(bytes);
-    try parseSseReader(allocator, &reader, callback);
+    try parseSseReader(allocator, &reader, callback, cancellation_token);
 }
 
-pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     var line_buf: std.Io.Writer.Allocating = .init(allocator);
     defer line_buf.deinit();
 
@@ -418,6 +600,7 @@ pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, call
     defer event_data.deinit();
 
     while (true) {
+        try checkCancellation(cancellation_token);
         line_buf.clearRetainingCapacity();
 
         _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -486,16 +669,16 @@ fn TypedSseCallback(comptime T: type, comptime Callback: type) type {
     };
 }
 
-pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseBytes(allocator, bytes, &typed_callback);
+    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
 }
 
-pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-    try parseSseReader(allocator, reader, &typed_callback);
+    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
 }
 
 fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -516,13 +699,13 @@ fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![
     return try out.toOwnedSlice();
 }
 
-fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const Callback = @TypeOf(callback.*);
     var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-    try streamJson(client, path, requestBody, &typed_callback);
+    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
 }
 
-fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
     const allocator = client.allocator;
     const payload = try stringifyStreamRequest(allocator, requestBody);
     defer allocator.free(payload);
@@ -535,6 +718,7 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
     defer allocator.free(url);
     const uri = try std.Uri.parse(url);
+    try checkCancellation(cancellation_token);
 
     var req = try client.http.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
@@ -548,13 +732,14 @@ fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback:
     try body.writer.writeAll(payload);
     try body.end();
     try req.connection.?.flush();
+    try checkCancellation(cancellation_token);
 
     var response = try req.receiveHead(&.{});
     if (response.head.status.class() != .success) return error.ResponseError;
 
     var transfer_buffer: [8 * 1024]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
-    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
         error.ReadFailed => return response.bodyErr() orelse err,
         else => return err,
     };
@@ -815,12 +1000,12 @@ pub fn chatResult(client: *Client, requestBody: ChatRequest) !ApiResult(ChatResp
     return parseRawResponse(ChatResponse, try chatRaw(client, requestBody));
 }
 
-pub fn chatStreaming(client: *Client, requestBody: anytype, callback: anytype) !void {
-    return streamJson(client, "/api/v1/chat", requestBody, callback);
+pub fn chatStreaming(client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
+    return streamJson(client, "/api/v1/chat", requestBody, callback, cancellation_token);
 }
 
-pub fn chatStreamingEvents(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype) !void {
-    return streamJsonTyped(Event, client, "/api/v1/chat", requestBody, callback);
+pub fn chatStreamingEvents(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
+    return streamJsonTyped(Event, client, "/api/v1/chat", requestBody, callback, cancellation_token);
 }
 
 const _chat = chat;
@@ -835,11 +1020,11 @@ pub const resources = struct {
             pub fn chat_Result(client: *Client, requestBody: ChatRequest) !ApiResult(ChatResponse) {
                 return _chatResult(client, requestBody);
             }
-            pub fn stream(client: *Client, requestBody: anytype, callback: anytype) !void {
-                return chatStreaming(client, requestBody, callback);
+            pub fn chatStream(client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
+                return chatStreaming(client, requestBody, callback, cancellation_token);
             }
-            pub fn streamEvents(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype) !void {
-                return chatStreamingEvents(Event, client, requestBody, callback);
+            pub fn chatStreamEvents(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
+                return chatStreamingEvents(Event, client, requestBody, callback, cancellation_token);
             }
         };
         pub const models = struct {

--- a/generated/lmstudio_example.zig
+++ b/generated/lmstudio_example.zig
@@ -47,7 +47,7 @@ pub fn main(init: std.process.Init) !void {
 
     const request = lmstudio.ChatRequest{
         .model = model.key,
-        .input = parsed_input.value,
+        .input = .{ .raw = parsed_input.value },
     };
 
     const StreamHandler = struct {
@@ -102,11 +102,11 @@ pub fn main(init: std.process.Init) !void {
     std.debug.print("\nStarting a second stream and cancelling it after 2 seconds...\n", .{});
     var cancel_token = lmstudio.CancellationToken.init();
     const cancel_thread = try std.Thread.spawn(.{}, struct {
-        fn run(cancellation_token: *lmstudio.CancellationToken) !void {
-            std.time.sleep(2 * std.time.ns_per_s);
+        fn run(cancellation_token: *lmstudio.CancellationToken, thread_io: std.Io) !void {
+            try std.Io.sleep(thread_io, .fromSeconds(2), .real);
             cancellation_token.cancel();
         }
-    }.run, .{&cancel_token});
+    }.run, .{ &cancel_token, io });
     defer cancel_thread.join();
 
     var handler2 = StreamHandler{ .allocator = allocator, .in_reasoning = false };

--- a/generated/lmstudio_example.zig
+++ b/generated/lmstudio_example.zig
@@ -90,26 +90,13 @@ pub fn main(init: std.process.Init) !void {
 
     var handler = StreamHandler{ .allocator = allocator, .in_reasoning = false };
     std.debug.print("Chat response:\n\n", .{});
-    lmstudio.chatStreaming(&client, request, &handler) catch |err| {
+
+    // Pass a CancellationToken to allow cancelling the stream from another thread.
+    // Calling token.cancel() will make the next SSE read return error.Cancelled.
+    var token = lmstudio.CancellationToken.init();
+    lmstudio.chatStreaming(&client, request, &handler, &token) catch |err| {
         std.debug.print("\n\nStream error: {any}\n", .{err});
         return;
     };
     std.debug.print("\n\nDone.\n", .{});
-}
-
-test "lmstudio cancellation token cancels SSE parsing" {
-    const allocator = std.testing.allocator;
-
-    var token = lmstudio.CancellationToken.init();
-    token.cancel();
-
-    const Callback = struct {
-        pub fn event(_: *@This(), _: []const u8) !void {}
-    };
-    var callback: Callback = .{};
-
-    try std.testing.expectError(
-        error.Cancelled,
-        lmstudio.parseSseBytes(allocator, "data: {\"x\":1}\n\n", &callback, &token),
-    );
 }

--- a/generated/lmstudio_example.zig
+++ b/generated/lmstudio_example.zig
@@ -96,3 +96,20 @@ pub fn main(init: std.process.Init) !void {
     };
     std.debug.print("\n\nDone.\n", .{});
 }
+
+test "lmstudio cancellation token cancels SSE parsing" {
+    const allocator = std.testing.allocator;
+
+    var token = lmstudio.CancellationToken.init();
+    token.cancel();
+
+    const Callback = struct {
+        pub fn event(_: *@This(), _: []const u8) !void {}
+    };
+    var callback: Callback = .{};
+
+    try std.testing.expectError(
+        error.Cancelled,
+        lmstudio.parseSseBytes(allocator, "data: {\"x\":1}\n\n", &callback, &token),
+    );
+}

--- a/generated/lmstudio_example.zig
+++ b/generated/lmstudio_example.zig
@@ -91,12 +91,26 @@ pub fn main(init: std.process.Init) !void {
     var handler = StreamHandler{ .allocator = allocator, .in_reasoning = false };
     std.debug.print("Chat response:\n\n", .{});
 
-    // Pass a CancellationToken to allow cancelling the stream from another thread.
-    // Calling token.cancel() will make the next SSE read return error.Cancelled.
-    var token = lmstudio.CancellationToken.init();
-    lmstudio.chatStreaming(&client, request, &handler, &token) catch |err| {
+    // First stream: run to completion without cancellation.
+    lmstudio.chatStreaming(&client, request, &handler, null) catch |err| {
         std.debug.print("\n\nStream error: {any}\n", .{err});
         return;
     };
     std.debug.print("\n\nDone.\n", .{});
+
+    // Second stream: cancel after a few seconds to demonstrate CancellationToken usage.
+    std.debug.print("\nStarting a second stream and cancelling it after 2 seconds...\n", .{});
+    var cancel_token = lmstudio.CancellationToken.init();
+    const cancel_thread = try std.Thread.spawn(.{}, struct {
+        fn run(cancellation_token: *lmstudio.CancellationToken) !void {
+            std.time.sleep(2 * std.time.ns_per_s);
+            cancellation_token.cancel();
+        }
+    }.run, .{&cancel_token});
+    defer cancel_thread.join();
+
+    var handler2 = StreamHandler{ .allocator = allocator, .in_reasoning = false };
+    lmstudio.chatStreaming(&client, request, &handler2, &cancel_token) catch |err| {
+        std.debug.print("Second stream cancelled as expected: {any}\n", .{err});
+    };
 }

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -855,18 +855,18 @@ pub const UnifiedApiGenerator = struct {
     fn generateStreamFunction(self: *UnifiedApiGenerator, name: []const u8, path: []const u8) !void {
         try self.buffer.appendSlice(self.allocator, "pub fn ");
         try self.buffer.appendSlice(self.allocator, name);
-        try self.buffer.appendSlice(self.allocator, "(client: *Client, requestBody: anytype, callback: anytype) !void {\n");
+        try self.buffer.appendSlice(self.allocator, "(client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
         try self.buffer.appendSlice(self.allocator, "    return streamJson(client, \"");
         try self.buffer.appendSlice(self.allocator, path);
-        try self.buffer.appendSlice(self.allocator, "\", requestBody, callback);\n");
+        try self.buffer.appendSlice(self.allocator, "\", requestBody, callback, cancellation_token);\n");
         try self.buffer.appendSlice(self.allocator, "}\n\n");
 
         try self.buffer.appendSlice(self.allocator, "pub fn ");
         try self.buffer.appendSlice(self.allocator, name);
-        try self.buffer.appendSlice(self.allocator, "Events(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype) !void {\n");
+        try self.buffer.appendSlice(self.allocator, "Events(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
         try self.buffer.appendSlice(self.allocator, "    return streamJsonTyped(Event, client, \"");
         try self.buffer.appendSlice(self.allocator, path);
-        try self.buffer.appendSlice(self.allocator, "\", requestBody, callback);\n");
+        try self.buffer.appendSlice(self.allocator, "\", requestBody, callback, cancellation_token);\n");
         try self.buffer.appendSlice(self.allocator, "}\n\n");
     }
 

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -1016,8 +1016,12 @@ pub const UnifiedApiGenerator = struct {
                     try declarations.append(self.allocator, result_name);
                 }
                 if (wrapper.operation.streaming) {
-                    try declarations.append(self.allocator, "stream");
-                    try declarations.append(self.allocator, "streamEvents");
+                    const stream_decl_name = try std.fmt.allocPrint(self.allocator, "{s}Stream", .{wrapper.operation_id});
+                    try declarations.append(self.allocator, stream_decl_name);
+                    try allocated_declarations.append(self.allocator, stream_decl_name);
+                    const events_decl_name = try std.fmt.allocPrint(self.allocator, "{s}StreamEvents", .{wrapper.operation_id});
+                    try declarations.append(self.allocator, events_decl_name);
+                    try allocated_declarations.append(self.allocator, events_decl_name);
                 }
             }
         }
@@ -1113,9 +1117,15 @@ pub const UnifiedApiGenerator = struct {
     }
 
     fn generateResourceStreamMethods(self: *UnifiedApiGenerator, wrapper: ResourceWrapper, stream_name: []const u8, indent: usize) !void {
-        _ = wrapper;
+        const stream_method_name = try std.fmt.allocPrint(self.allocator, "{s}Stream", .{wrapper.operation_id});
+        defer self.allocator.free(stream_method_name);
+        const events_method_name = try std.fmt.allocPrint(self.allocator, "{s}StreamEvents", .{wrapper.operation_id});
+        defer self.allocator.free(events_method_name);
+
         try self.appendIndent(indent);
-        try self.buffer.appendSlice(self.allocator, "pub fn stream(client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
+        try self.buffer.appendSlice(self.allocator, "pub fn ");
+        try self.buffer.appendSlice(self.allocator, stream_method_name);
+        try self.buffer.appendSlice(self.allocator, "(client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
         try self.appendIndent(indent + 1);
         try self.buffer.appendSlice(self.allocator, "return ");
         try self.buffer.appendSlice(self.allocator, stream_name);
@@ -1124,7 +1134,9 @@ pub const UnifiedApiGenerator = struct {
         try self.buffer.appendSlice(self.allocator, "}\n");
 
         try self.appendIndent(indent);
-        try self.buffer.appendSlice(self.allocator, "pub fn streamEvents(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
+        try self.buffer.appendSlice(self.allocator, "pub fn ");
+        try self.buffer.appendSlice(self.allocator, events_method_name);
+        try self.buffer.appendSlice(self.allocator, "(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
         try self.appendIndent(indent + 1);
         try self.buffer.appendSlice(self.allocator, "return ");
         try self.buffer.appendSlice(self.allocator, stream_name);

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -1115,20 +1115,20 @@ pub const UnifiedApiGenerator = struct {
     fn generateResourceStreamMethods(self: *UnifiedApiGenerator, wrapper: ResourceWrapper, stream_name: []const u8, indent: usize) !void {
         _ = wrapper;
         try self.appendIndent(indent);
-        try self.buffer.appendSlice(self.allocator, "pub fn stream(client: *Client, requestBody: anytype, callback: anytype) !void {\n");
+        try self.buffer.appendSlice(self.allocator, "pub fn stream(client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
         try self.appendIndent(indent + 1);
         try self.buffer.appendSlice(self.allocator, "return ");
         try self.buffer.appendSlice(self.allocator, stream_name);
-        try self.buffer.appendSlice(self.allocator, "(client, requestBody, callback);\n");
+        try self.buffer.appendSlice(self.allocator, "(client, requestBody, callback, cancellation_token);\n");
         try self.appendIndent(indent);
         try self.buffer.appendSlice(self.allocator, "}\n");
 
         try self.appendIndent(indent);
-        try self.buffer.appendSlice(self.allocator, "pub fn streamEvents(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype) !void {\n");
+        try self.buffer.appendSlice(self.allocator, "pub fn streamEvents(comptime Event: type, client: *Client, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
         try self.appendIndent(indent + 1);
         try self.buffer.appendSlice(self.allocator, "return ");
         try self.buffer.appendSlice(self.allocator, stream_name);
-        try self.buffer.appendSlice(self.allocator, "Events(Event, client, requestBody, callback);\n");
+        try self.buffer.appendSlice(self.allocator, "Events(Event, client, requestBody, callback, cancellation_token);\n");
         try self.appendIndent(indent);
         try self.buffer.appendSlice(self.allocator, "}\n");
     }

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -348,6 +348,28 @@ pub const UnifiedApiGenerator = struct {
             \\    return parseRawResponse(T, try postJsonRaw(client, path, payload));
             \\}
             \\
+            \\pub const CancellationToken = struct {
+            \\    cancelled: std.atomic.Value(bool),
+            \\
+            \\    pub fn init() CancellationToken {
+            \\        return .{ .cancelled = std.atomic.Value(bool).init(false) };
+            \\    }
+            \\
+            \\    pub fn cancel(self: *CancellationToken) void {
+            \\        self.cancelled.store(true, .seq_cst);
+            \\    }
+            \\
+            \\    pub fn isCancelled(self: *CancellationToken) bool {
+            \\        return self.cancelled.load(.seq_cst);
+            \\    }
+            \\};
+            \\
+            \\fn checkCancellation(token: ?*CancellationToken) !void {
+            \\    if (token) |t| {
+            \\        if (t.isCancelled()) return error.Cancelled;
+            \\    }
+            \\}
+            \\
             \\const max_sse_line_size = 256 * 1024;
             \\const max_sse_event_size = 1024 * 1024;
             \\

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -373,12 +373,12 @@ pub const UnifiedApiGenerator = struct {
             \\const max_sse_line_size = 256 * 1024;
             \\const max_sse_event_size = 1024 * 1024;
             \\
-            \\pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+            \\pub fn parseSseBytes(allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
             \\    var reader: std.Io.Reader = .fixed(bytes);
-            \\    try parseSseReader(allocator, &reader, callback);
+            \\    try parseSseReader(allocator, &reader, callback, cancellation_token);
             \\}
             \\
-            \\pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+            \\pub fn parseSseReader(allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
             \\    var line_buf: std.Io.Writer.Allocating = .init(allocator);
             \\    defer line_buf.deinit();
             \\
@@ -386,6 +386,7 @@ pub const UnifiedApiGenerator = struct {
             \\    defer event_data.deinit();
             \\
             \\    while (true) {
+            \\        try checkCancellation(cancellation_token);
             \\        line_buf.clearRetainingCapacity();
             \\
             \\        _ = reader.streamDelimiterLimit(&line_buf.writer, '\n', .limited(max_sse_line_size)) catch |err| switch (err) {
@@ -454,16 +455,16 @@ pub const UnifiedApiGenerator = struct {
             \\    };
             \\}
             \\
-            \\pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype) !void {
+            \\pub fn parseSseBytesTyped(comptime T: type, allocator: std.mem.Allocator, bytes: []const u8, callback: anytype, cancellation_token: ?*CancellationToken) !void {
             \\    const Callback = @TypeOf(callback.*);
             \\    var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-            \\    try parseSseBytes(allocator, bytes, &typed_callback);
+            \\    try parseSseBytes(allocator, bytes, &typed_callback, cancellation_token);
             \\}
             \\
-            \\pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype) !void {
+            \\pub fn parseSseReaderTyped(comptime T: type, allocator: std.mem.Allocator, reader: *std.Io.Reader, callback: anytype, cancellation_token: ?*CancellationToken) !void {
             \\    const Callback = @TypeOf(callback.*);
             \\    var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = allocator, .callback = callback };
-            \\    try parseSseReader(allocator, reader, &typed_callback);
+            \\    try parseSseReader(allocator, reader, &typed_callback, cancellation_token);
             \\}
             \\
             \\fn stringifyStreamRequest(allocator: std.mem.Allocator, requestBody: anytype) ![]u8 {
@@ -484,13 +485,13 @@ pub const UnifiedApiGenerator = struct {
             \\    return try out.toOwnedSlice();
             \\}
             \\
-            \\fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+            \\fn streamJsonTyped(comptime T: type, client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
             \\    const Callback = @TypeOf(callback.*);
             \\    var typed_callback: TypedSseCallback(T, Callback) = .{ .allocator = client.allocator, .callback = callback };
-            \\    try streamJson(client, path, requestBody, &typed_callback);
+            \\    try streamJson(client, path, requestBody, &typed_callback, cancellation_token);
             \\}
             \\
-            \\fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype) !void {
+            \\fn streamJson(client: *Client, path: []const u8, requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {
             \\    const allocator = client.allocator;
             \\    const payload = try stringifyStreamRequest(allocator, requestBody);
             \\    defer allocator.free(payload);
@@ -503,6 +504,7 @@ pub const UnifiedApiGenerator = struct {
             \\    const url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ client.base_url, path });
             \\    defer allocator.free(url);
             \\    const uri = try std.Uri.parse(url);
+            \\    try checkCancellation(cancellation_token);
             \\
             \\    var req = try client.http.request(.POST, uri, .{
             \\        .redirect_behavior = .unhandled,
@@ -516,13 +518,14 @@ pub const UnifiedApiGenerator = struct {
             \\    try body.writer.writeAll(payload);
             \\    try body.end();
             \\    try req.connection.?.flush();
+            \\    try checkCancellation(cancellation_token);
             \\
             \\    var response = try req.receiveHead(&.{});
             \\    if (response.head.status.class() != .success) return error.ResponseError;
             \\
             \\    var transfer_buffer: [8 * 1024]u8 = undefined;
             \\    const reader = response.reader(&transfer_buffer);
-            \\    parseSseReader(allocator, reader, callback) catch |err| switch (err) {
+            \\    parseSseReader(allocator, reader, callback, cancellation_token) catch |err| switch (err) {
             \\        error.ReadFailed => return response.bodyErr() orelse err,
             \\        else => return err,
             \\    };


### PR DESCRIPTION
This PR adds C#-style cancellation support to generated Zig HTTP clients for server-sent-event (SSE) / streaming endpoints.

## Changes
- Generate a lightweight CancellationToken type backed by std.atomic.Value(bool).
- Generate rror.Cancelled for cooperative cancellation.
- Add optional ?*CancellationToken parameters to SSE helpers (parseSseReader, parseSseBytes, typed variants), streaming helpers (streamJson, streamJsonTyped), generated operation streaming wrappers, and resource-level streaming methods.
- Check cancellation before initiating a stream and between SSE event reads.
- Fix a coupled bug where resource-level streaming methods were always named stream/streamEvents, causing duplicate member errors when a tag had multiple streaming operations (e.g., OpenAI udio). They now use operation-specific names like createSpeechStream/createSpeechStreamEvents.
- Regenerate sample clients and update lmstudio_example.zig to demonstrate cancelling a stream after 2 seconds.
- Add cancellation tests in generated/compile_generated.zig.

## Validation
- zig build test passes.
- Debug, ReleaseFast, ReleaseSafe, ReleaseSmall builds pass.
- Cross-compilation to x86_64-windows, x86_64-macos, and aarch64-linux passes.
- Smoke tests: 140/140 pass.
- zig run generated/lmstudio_example.zig verified against a running LM Studio instance.