### PR TITLE
Add PerTag methods for operations without an operationId

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ openapi2zig generate -i openapi/v3.0/petstore.json -o api.zig --multiple-clients
 openapi2zig generate -i openapi/v3.0/petstore.json -o api.zig --multiple-clients PerEndpoint
 ```
 
-With `PerTag`, operations are grouped into one struct per tag (untagged operations land in `DefaultClient`), each with an `init(client: *Client)` constructor and methods that delegate to the flat API functions:
+With `PerTag`, operations are grouped into one struct per tag (untagged operations land in `DefaultClient`), each with an `init(client: *Client)` constructor and methods that delegate to the flat API functions. Operations without an `operationId` still get a tag-client method, named from the HTTP method + path (e.g. a `GET /orphan` becomes `getOrphan`), which delegates to the flat fallback function:
 
 ```zig
 var client = api.Client.init(allocator, io, "");

--- a/src/generators/unified/api_generator.zig
+++ b/src/generators/unified/api_generator.zig
@@ -1220,7 +1220,6 @@ pub const UnifiedApiGenerator = struct {
         }
 
         for (operations.items) |op_ref| {
-            if (op_ref.operation.operationId == null) continue;
             const struct_name = try self.tagClientNameAlloc(op_ref.operation);
             errdefer self.allocator.free(struct_name);
 
@@ -1308,7 +1307,7 @@ pub const UnifiedApiGenerator = struct {
             }
 
             for (group.methods.items) |op_ref| {
-                const method_name = try self.uniqueTagClientMethodNameAlloc(op_ref.operation.operationId.?, used_method_names);
+                const method_name = try self.uniqueTagClientMethodNameAlloc(op_ref, used_method_names);
                 used_method_names.put(method_name, {}) catch {
                     self.allocator.free(method_name);
                     return error.OutOfMemory;
@@ -1519,8 +1518,11 @@ pub const UnifiedApiGenerator = struct {
         return std.mem.eql(u8, name, "init") or std.mem.eql(u8, name, "client") or std.mem.eql(u8, name, "deinit");
     }
 
-    fn uniqueTagClientMethodNameAlloc(self: *UnifiedApiGenerator, operation_id: []const u8, used_names: std.StringHashMap(void)) ![]const u8 {
-        var candidate = try self.tagClientMethodNameAlloc(operation_id);
+    fn uniqueTagClientMethodNameAlloc(self: *UnifiedApiGenerator, op_ref: OperationRef, used_names: std.StringHashMap(void)) ![]const u8 {
+        var candidate = if (op_ref.operation.operationId) |op_id|
+            try self.tagClientMethodNameAlloc(op_id)
+        else
+            try self.tagClientFallbackMethodNameAlloc(op_ref);
         errdefer self.allocator.free(candidate);
         while (isReservedTagClientMethod(candidate) or used_names.contains(candidate)) {
             const suffixed = try std.fmt.allocPrint(self.allocator, "{s}_", .{candidate});
@@ -1528,6 +1530,14 @@ pub const UnifiedApiGenerator = struct {
             candidate = suffixed;
         }
         return candidate;
+    }
+
+    fn tagClientFallbackMethodNameAlloc(self: *UnifiedApiGenerator, op_ref: OperationRef) ![]const u8 {
+        const pascal = try self.endpointFallbackNameAlloc(op_ref.method, op_ref.path);
+        defer self.allocator.free(pascal);
+        const method = try self.allocator.dupe(u8, pascal);
+        if (method.len > 0) method[0] = std.ascii.toLower(method[0]);
+        return method;
     }
 
     fn tagClientNameAlloc(self: *UnifiedApiGenerator, operation: Operation) ![]const u8 {
@@ -1548,16 +1558,20 @@ pub const UnifiedApiGenerator = struct {
 
     fn generateTagClientMethod(self: *UnifiedApiGenerator, struct_name: []const u8, method_name: []const u8, op_ref: OperationRef) !void {
         const operation = op_ref.operation;
-        const operation_id = operation.operationId orelse return;
+        const op_id = operation.operationId;
         const has_return = self.hasReturnValue(op_ref.method, operation);
 
         // When the method name matches the operation id, the unqualified
         // delegation call inside the method would be an ambiguous reference to
         // the file-scope flat function. Route through the `_` aliases emitted
-        // by generateTagClients instead.
-        const prospective_name = try self.tagClientMethodNameAlloc(operation_id);
-        defer self.allocator.free(prospective_name);
-        const needs_alias = std.mem.eql(u8, prospective_name, operation_id);
+        // by generateTagClients instead. Operations without an operationId
+        // delegate to the raw @"operation{path}" flat fallback, which never
+        // matches the derived method name, so no alias is needed.
+        const needs_alias = if (op_id) |id| blk: {
+            const prospective_name = try self.tagClientMethodNameAlloc(id);
+            defer self.allocator.free(prospective_name);
+            break :blk std.mem.eql(u8, prospective_name, id);
+        } else false;
 
         try self.buffer.appendSlice(self.allocator, "    pub fn ");
         try self.buffer.appendSlice(self.allocator, method_name);
@@ -1573,82 +1587,90 @@ pub const UnifiedApiGenerator = struct {
         }
         try self.buffer.appendSlice(self.allocator, "        return ");
         if (needs_alias) try self.buffer.appendSlice(self.allocator, "_");
-        try self.appendIdentifier(operation_id);
+        if (op_id) |id| {
+            try self.appendIdentifier(id);
+        } else {
+            try self.buffer.appendSlice(self.allocator, "@\"operation");
+            try self.buffer.appendSlice(self.allocator, op_ref.path[1..]);
+            try self.buffer.appendSlice(self.allocator, "\"");
+        }
         try self.appendTagClientCallArguments(operation);
         try self.buffer.appendSlice(self.allocator, ";\n");
         try self.buffer.appendSlice(self.allocator, "    }\n\n");
 
-        const raw_method_name = try std.fmt.allocPrint(self.allocator, "{s}Raw", .{method_name});
-        defer self.allocator.free(raw_method_name);
-        const raw_operation_name = try std.fmt.allocPrint(self.allocator, "{s}Raw", .{operation_id});
-        defer self.allocator.free(raw_operation_name);
-
-        try self.buffer.appendSlice(self.allocator, "    pub fn ");
-        try self.buffer.appendSlice(self.allocator, raw_method_name);
-        try self.buffer.appendSlice(self.allocator, "(self: *");
-        try self.buffer.appendSlice(self.allocator, struct_name);
-        try self.appendFlatOperationParameters(operation);
-        try self.buffer.appendSlice(self.allocator, ") !RawResponse {\n");
-        try self.buffer.appendSlice(self.allocator, "        return ");
-        if (needs_alias) try self.buffer.appendSlice(self.allocator, "_");
-        try self.appendIdentifier(raw_operation_name);
-        try self.appendTagClientCallArguments(operation);
-        try self.buffer.appendSlice(self.allocator, ";\n");
-        try self.buffer.appendSlice(self.allocator, "    }\n\n");
-
-        if (has_return) {
-            const result_method_name = try std.fmt.allocPrint(self.allocator, "{s}Result", .{method_name});
-            defer self.allocator.free(result_method_name);
-            const result_operation_name = try std.fmt.allocPrint(self.allocator, "{s}Result", .{operation_id});
-            defer self.allocator.free(result_operation_name);
+        if (op_id) |id| {
+            const raw_method_name = try std.fmt.allocPrint(self.allocator, "{s}Raw", .{method_name});
+            defer self.allocator.free(raw_method_name);
+            const raw_operation_name = try std.fmt.allocPrint(self.allocator, "{s}Raw", .{id});
+            defer self.allocator.free(raw_operation_name);
 
             try self.buffer.appendSlice(self.allocator, "    pub fn ");
-            try self.buffer.appendSlice(self.allocator, result_method_name);
+            try self.buffer.appendSlice(self.allocator, raw_method_name);
             try self.buffer.appendSlice(self.allocator, "(self: *");
             try self.buffer.appendSlice(self.allocator, struct_name);
             try self.appendFlatOperationParameters(operation);
-            try self.buffer.appendSlice(self.allocator, ") !ApiResult(");
-            try self.appendReturnType(op_ref.method, operation);
-            try self.buffer.appendSlice(self.allocator, ") {\n");
+            try self.buffer.appendSlice(self.allocator, ") !RawResponse {\n");
             try self.buffer.appendSlice(self.allocator, "        return ");
             if (needs_alias) try self.buffer.appendSlice(self.allocator, "_");
-            try self.appendIdentifier(result_operation_name);
+            try self.appendIdentifier(raw_operation_name);
             try self.appendTagClientCallArguments(operation);
             try self.buffer.appendSlice(self.allocator, ";\n");
             try self.buffer.appendSlice(self.allocator, "    }\n\n");
-        }
 
-        if (operation.streaming and std.mem.eql(u8, op_ref.method, "POST")) {
-            const stream_method_name = try std.fmt.allocPrint(self.allocator, "{s}Streaming", .{method_name});
-            defer self.allocator.free(stream_method_name);
-            const stream_operation_name = try std.fmt.allocPrint(self.allocator, "{s}Streaming", .{operation_id});
-            defer self.allocator.free(stream_operation_name);
+            if (has_return) {
+                const result_method_name = try std.fmt.allocPrint(self.allocator, "{s}Result", .{method_name});
+                defer self.allocator.free(result_method_name);
+                const result_operation_name = try std.fmt.allocPrint(self.allocator, "{s}Result", .{id});
+                defer self.allocator.free(result_operation_name);
 
-            try self.buffer.appendSlice(self.allocator, "    pub fn ");
-            try self.buffer.appendSlice(self.allocator, stream_method_name);
-            try self.buffer.appendSlice(self.allocator, "(self: *");
-            try self.buffer.appendSlice(self.allocator, struct_name);
-            try self.buffer.appendSlice(self.allocator, ", requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
-            try self.buffer.appendSlice(self.allocator, "        return ");
-            if (needs_alias) try self.buffer.appendSlice(self.allocator, "_");
-            try self.appendIdentifier(stream_operation_name);
-            try self.buffer.appendSlice(self.allocator, "(self.client, requestBody, callback, cancellation_token);\n");
-            try self.buffer.appendSlice(self.allocator, "    }\n\n");
+                try self.buffer.appendSlice(self.allocator, "    pub fn ");
+                try self.buffer.appendSlice(self.allocator, result_method_name);
+                try self.buffer.appendSlice(self.allocator, "(self: *");
+                try self.buffer.appendSlice(self.allocator, struct_name);
+                try self.appendFlatOperationParameters(operation);
+                try self.buffer.appendSlice(self.allocator, ") !ApiResult(");
+                try self.appendReturnType(op_ref.method, operation);
+                try self.buffer.appendSlice(self.allocator, ") {\n");
+                try self.buffer.appendSlice(self.allocator, "        return ");
+                if (needs_alias) try self.buffer.appendSlice(self.allocator, "_");
+                try self.appendIdentifier(result_operation_name);
+                try self.appendTagClientCallArguments(operation);
+                try self.buffer.appendSlice(self.allocator, ";\n");
+                try self.buffer.appendSlice(self.allocator, "    }\n\n");
+            }
 
-            const stream_events_method_name = try std.fmt.allocPrint(self.allocator, "{s}StreamEvents", .{method_name});
-            defer self.allocator.free(stream_events_method_name);
-            const stream_events_operation_name = try std.fmt.allocPrint(self.allocator, "{s}StreamingEvents", .{operation_id});
-            defer self.allocator.free(stream_events_operation_name);
+            if (operation.streaming and std.mem.eql(u8, op_ref.method, "POST")) {
+                const stream_method_name = try std.fmt.allocPrint(self.allocator, "{s}Streaming", .{method_name});
+                defer self.allocator.free(stream_method_name);
+                const stream_operation_name = try std.fmt.allocPrint(self.allocator, "{s}Streaming", .{id});
+                defer self.allocator.free(stream_operation_name);
 
-            try self.buffer.appendSlice(self.allocator, "    pub fn ");
-            try self.buffer.appendSlice(self.allocator, stream_events_method_name);
-            try self.buffer.appendSlice(self.allocator, "(comptime Event: type, self: *");
-            try self.buffer.appendSlice(self.allocator, struct_name);
-            try self.buffer.appendSlice(self.allocator, ", requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
-            try self.buffer.appendSlice(self.allocator, "        return ");
-            try self.appendIdentifier(stream_events_operation_name);
-            try self.buffer.appendSlice(self.allocator, "(Event, self.client, requestBody, callback, cancellation_token);\n");
-            try self.buffer.appendSlice(self.allocator, "    }\n\n");
+                try self.buffer.appendSlice(self.allocator, "    pub fn ");
+                try self.buffer.appendSlice(self.allocator, stream_method_name);
+                try self.buffer.appendSlice(self.allocator, "(self: *");
+                try self.buffer.appendSlice(self.allocator, struct_name);
+                try self.buffer.appendSlice(self.allocator, ", requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
+                try self.buffer.appendSlice(self.allocator, "        return ");
+                if (needs_alias) try self.buffer.appendSlice(self.allocator, "_");
+                try self.appendIdentifier(stream_operation_name);
+                try self.buffer.appendSlice(self.allocator, "(self.client, requestBody, callback, cancellation_token);\n");
+                try self.buffer.appendSlice(self.allocator, "    }\n\n");
+
+                const stream_events_method_name = try std.fmt.allocPrint(self.allocator, "{s}StreamEvents", .{method_name});
+                defer self.allocator.free(stream_events_method_name);
+                const stream_events_operation_name = try std.fmt.allocPrint(self.allocator, "{s}StreamingEvents", .{id});
+                defer self.allocator.free(stream_events_operation_name);
+
+                try self.buffer.appendSlice(self.allocator, "    pub fn ");
+                try self.buffer.appendSlice(self.allocator, stream_events_method_name);
+                try self.buffer.appendSlice(self.allocator, "(comptime Event: type, self: *");
+                try self.buffer.appendSlice(self.allocator, struct_name);
+                try self.buffer.appendSlice(self.allocator, ", requestBody: anytype, callback: anytype, cancellation_token: ?*CancellationToken) !void {\n");
+                try self.buffer.appendSlice(self.allocator, "        return ");
+                try self.appendIdentifier(stream_events_operation_name);
+                try self.buffer.appendSlice(self.allocator, "(Event, self.client, requestBody, callback, cancellation_token);\n");
+                try self.buffer.appendSlice(self.allocator, "    }\n\n");
+            }
         }
     }
 

--- a/src/tests/multiple_clients_tests.zig
+++ b/src/tests/multiple_clients_tests.zig
@@ -108,6 +108,14 @@ fn buildPerTagFixture(allocator: std.mem.Allocator) !common.UnifiedDocument {
     try paths.put(try allocator.dupe(u8, "/search"), .{
         .get = try opWithTags(allocator, "searchUntagged", false, false, true, null),
     });
+    // No operationId: tagged op lands in PetClient with a method+path derived name.
+    try paths.put(try allocator.dupe(u8, "/orphan"), .{
+        .get = try opWithTags(allocator, null, false, false, true, &.{"pet"}),
+    });
+    // No operationId and untagged: lands in DefaultClient with a method+path derived name.
+    try paths.put(try allocator.dupe(u8, "/root"), .{
+        .get = try opWithTags(allocator, null, false, false, true, null),
+    });
     // Streaming operation → {opId}Streaming / {opId}StreamEvents methods.
     var stream_op = try opWithTags(allocator, "streamPets", false, true, true, &.{"pet"});
     stream_op.streaming = true;
@@ -140,6 +148,14 @@ fn buildCollisionFixture(allocator: std.mem.Allocator) !common.UnifiedDocument {
     // Reserved method name: operationId "init" sanitizes to "init".
     try paths.put(try allocator.dupe(u8, "/init"), .{
         .post = try opWithTags(allocator, "init", false, true, true, &.{"pet"}),
+    });
+    // Fallback method name (no operationId) collides with an opId-derived
+    // method name: no-opId GET /pets/list → "getPetsList", opId "getPetsList" → "getPetsList".
+    try paths.put(try allocator.dupe(u8, "/other"), .{
+        .get = try opWithTags(allocator, "getPetsList", false, false, true, &.{"pet"}),
+    });
+    try paths.put(try allocator.dupe(u8, "/pets/list"), .{
+        .get = try opWithTags(allocator, null, false, false, true, &.{"pet"}),
     });
     // Tag "Pet" (uppercase) sanitizes to the same PetClient as tag "pet" and merges.
     try paths.put(try allocator.dupe(u8, "/users"), .{
@@ -274,6 +290,40 @@ test "multiple-clients PerTag groups operations into client structs" {
     try std.testing.expect(std.mem.indexOf(u8, code, "return streamPetsStreamingEvents(Event, self.client, requestBody, callback, cancellation_token);") != null);
 }
 
+test "multiple-clients PerTag derives methods for operations without an operationId" {
+    const allocator = std.testing.allocator;
+    var document = try buildPerTagFixture(allocator);
+    defer document.deinit(allocator);
+
+    var generator = UnifiedApiGenerator.init(allocator, .{
+        .input_path = "fixture.json",
+        .multiple_clients = .per_tag,
+    });
+    defer generator.deinit();
+
+    const code = try generator.generate(document);
+    defer allocator.free(code);
+
+    // Tagged operation without an operationId lands in PetClient under a
+    // method+path derived camelCase name, delegating to the flat fallback fn.
+    try std.testing.expect(std.mem.indexOf(u8, code, "pub fn getOrphan(self: *PetClient) !Owned(std.json.Value) {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "return @\"operationorphan\"(self.client);") != null);
+
+    // Untagged operation without an operationId lands in DefaultClient.
+    try std.testing.expect(std.mem.indexOf(u8, code, "pub fn getRoot(self: *DefaultClient) !Owned(std.json.Value) {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "return @\"operationroot\"(self.client);") != null);
+
+    // No Raw/Result flat functions exist for a fallback-named operation.
+    try std.testing.expect(std.mem.indexOf(u8, code, "pub fn getOrphanRaw(self: *PetClient") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "pub fn getOrphanResult(self: *PetClient") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "pub fn getRootRaw(self: *DefaultClient") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "pub fn getRootResult(self: *DefaultClient") == null);
+
+    // Fallback-named operations do not produce file-scope aliases.
+    try std.testing.expect(std.mem.indexOf(u8, code, "const _getOrphan = ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "const _getRoot = ") == null);
+}
+
 test "multiple-clients PerTag dedupes struct names, reserved methods, and method collisions" {
     const allocator = std.testing.allocator;
     var document = try buildCollisionFixture(allocator);
@@ -314,4 +364,13 @@ test "multiple-clients PerTag dedupes struct names, reserved methods, and method
     try std.testing.expect(std.mem.indexOf(u8, code, "pub fn listUsers(self: *PetClient") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "return _listUsers(self.client);") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "const _listUsers = listUsers;") != null);
+
+    // Fallback method name collides with an opId-derived name: the second one
+    // (ordered by path+method) gets the underscore suffix. The no-opId op
+    // (/pets/list sorts after /other) delegates through the raw fallback fn.
+    try std.testing.expect(std.mem.indexOf(u8, code, "pub fn getPetsList(self: *PetClient) !Owned(std.json.Value) {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "return _getPetsList(self.client);") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "pub fn getPetsList_(self: *PetClient) !Owned(std.json.Value) {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "return @\"operationpets/list\"(self.client);") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "const _getPetsList = getPetsList;") != null);
 }


### PR DESCRIPTION
## Summary

Ports the no-operationId fallback handling from the `multiple-clients` branch onto `multiple-clients-flag`, closing the PerTag correctness gap identified in review: operations without an `operationId` were previously dropped from the generated tag clients, violating the PRD rule that every operation is assigned to exactly one tag client.

## Changes

- `src/generators/unified/api_generator.zig`
  - `generateTagClients` no longer skips operations with a missing `operationId`.
  - New `tagClientFallbackMethodNameAlloc` derives a camelCase method name from HTTP method + path (reusing `endpointFallbackNameAlloc`), e.g. a `GET /orphan` becomes `getOrphan` - consistent with the PerEndpoint fallback convention.
  - `generateTagClientMethod` emits the main method for fallback-named operations, delegating to the flat `@"operation{path}"` function; `Raw`/`Result`/`Streaming` methods are emitted only when an `operationId` exists (those flat functions do not exist otherwise).
- `src/tests/multiple_clients_tests.zig` - new tests covering tagged (`PetClient`) and untagged (`DefaultClient`) no-opId operations, absence of `Raw`/`Result`/aliases for fallback-named methods, and collision dedupe between fallback and opId-derived method names.
- `README.md` - documents the method+path fallback naming.

## Validation

- `zig build test` - all pass
- `zig build -Doptimize=ReleaseSafe` / `ReleaseFast` - pass
- Smoke tests: `v3.0/*` across `PerTag` and `PerEndpoint` - 79 pass, 0 fail
- Petstore golden output unchanged (no no-opId operations in that spec)
