### PR TITLE
Sanitize reserved property names

### DIFF
--- a/generated/anthropic.zig
+++ b/generated/anthropic.zig
@@ -34,13 +34,13 @@ pub const BetaManagedAgentsGetMemoryStoreResponse = union(enum) {
 
 pub const BetaManagedAgentsAgentReference = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     version: i64,
 };
 
 pub const BetaManagedAgentsModelOverloadedError = struct {
     retry_status: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -48,7 +48,7 @@ pub const BetaManagedAgentsSpanOutcomeEvaluationStartEvent = struct {
     processed_at: std.json.Value,
     iteration: i64,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     outcome_id: []const u8,
 };
 
@@ -58,13 +58,13 @@ pub const BetaResponsePageLocationCitation = struct {
     start_page_number: i64,
     document_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
 pub const BetaManagedAgentsErrorResponse = struct {
     @"error": BetaManagedAgentsError,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMCPToolsetDefaultConfig = struct {
@@ -78,7 +78,7 @@ pub const ResponsePageLocationCitation = struct {
     start_page_number: i64,
     document_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
@@ -90,7 +90,7 @@ pub const ThinkingTypes = struct {
 pub const BetaUserLocation = struct {
     city: ?[]const u8 = null,
     country: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     region: ?[]const u8 = null,
     timezone: ?[]const u8 = null,
 };
@@ -98,7 +98,7 @@ pub const BetaUserLocation = struct {
 pub const BetaWebhookSessionStatusRescheduledEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -106,13 +106,13 @@ pub const AnthropicBeta = []const u8;
 
 pub const BetaFileImageSource = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseBashCodeExecutionResultBlock = struct {
     content: []const ResponseBashCodeExecutionOutputBlock,
     return_code: i64,
-    type: []const u8,
+    @"type": []const u8,
     stderr: []const u8,
     stdout: []const u8,
 };
@@ -154,11 +154,11 @@ pub const BetaManagedAgentsAgentTool = union(enum) {
 };
 
 pub const BetaManagedAgentsUnrestrictedCredentialNetworkingParams = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsTextRubricParams = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -174,7 +174,7 @@ pub const BetaManagedAgentsUpdateVaultRequestBody = struct {
 
 pub const URLPDFSource = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSearchResultCitations = struct {
@@ -184,7 +184,7 @@ pub const BetaManagedAgentsSearchResultCitations = struct {
 pub const BetaManagedAgentsUserToolConfirmationResult = []const u8;
 
 pub const BetaManagedAgentsAlwaysAllowPolicy = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsInputEvent = union(enum) {
@@ -246,18 +246,18 @@ pub const BetaManagedAgentsInputEvent = union(enum) {
 pub const BetaWebhookSessionRunningEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaManagedAgentsBase64ImageSource = struct {
     media_type: []const u8,
     data: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsOrganizationDisabledDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const MessageBatchIndividualRequestParams = struct {
@@ -267,7 +267,7 @@ pub const MessageBatchIndividualRequestParams = struct {
 
 pub const RequestToolReferenceBlock = struct {
     tool_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     cache_control: ?std.json.Value = null,
 };
 
@@ -419,12 +419,12 @@ pub const BetaRequestWebSearchResultBlock = struct {
     page_age: ?[]const u8 = null,
     encrypted_content: []const u8,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
 };
 
 pub const BetaManagedAgentsDeploymentUserMessageEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaManagedAgentsUserContentBlock,
 };
 
@@ -432,7 +432,7 @@ pub const BetaManagedAgentsAgentThreadMessageSentEvent = struct {
     processed_at: std.json.Value,
     to_session_thread_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     to_agent_name: ?[]const u8 = null,
     content: []const BetaManagedAgentsUserContentBlock,
 };
@@ -471,7 +471,7 @@ pub const BetaResponseCodeExecutionToolResultBlockContent = union(enum) {
 
 pub const BetaResponseCodeExecutionToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseCodeExecutionToolResultBlockContent,
 };
 
@@ -492,7 +492,7 @@ pub const BetaUsage = struct {
 pub const BetaWebhookSessionCreatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -501,7 +501,7 @@ pub const ResponseToolUseBlock = struct {
     id: []const u8,
     input: std.json.Value,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsDeploymentStatus = []const u8;
@@ -509,7 +509,7 @@ pub const BetaManagedAgentsDeploymentStatus = []const u8;
 pub const BetaWebhookVaultArchivedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -520,13 +520,13 @@ pub const MemoryTool_20250818 = struct {
     allowed_callers: ?[]const AllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestCodeExecutionResultBlock = struct {
     content: []const RequestCodeExecutionOutputBlock,
     return_code: i64,
-    type: []const u8,
+    @"type": []const u8,
     stderr: []const u8,
     stdout: []const u8,
 };
@@ -630,24 +630,24 @@ pub const BetaManagedAgentsMcpOauthCreateParams = struct {
     access_token: []const u8,
     expires_at: ?[]const u8 = null,
     refresh: ?BetaManagedAgentsMcpOauthCreateParamsRefresh = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCustomTool = struct {
     description: []const u8,
     input_schema: BetaManagedAgentsCustomToolInputSchema,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaEnrollmentUrl = struct {
     url: []const u8,
     expires_at: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsVaultArchivedDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseCodeExecutionToolResultBlockContent = union(enum) {
@@ -684,7 +684,7 @@ pub const ResponseCodeExecutionToolResultBlockContent = union(enum) {
 
 pub const ResponseCodeExecutionToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ResponseCodeExecutionToolResultBlockContent,
 };
 
@@ -701,12 +701,12 @@ pub const WebFetchTool_20260318 = struct {
     blocked_domains: ?[]const []const u8 = null,
     citations: ?RequestCitationsConfig = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaFileScope = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsScheduleParams = union(enum) {
@@ -773,23 +773,23 @@ pub const BetaManagedAgentsCredentialAuth = union(enum) {
 
 pub const BetaDeleteSkillResponse = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ToolChoiceNone = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaOverloadedError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ToolSearchToolResultErrorCode = []const u8;
 
 pub const InputJsonContentBlockDelta = struct {
     partial_json: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateMessageParamsWithoutStreamToolsItem = union(enum) {
@@ -960,7 +960,7 @@ pub const BetaManagedAgentsCredentialRefreshStatus = []const u8;
 pub const RequestToolSearchToolResultError = struct {
     error_code: []const u8,
     error_message: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsListSessionThreads = struct {
@@ -971,13 +971,13 @@ pub const BetaManagedAgentsListSessionThreads = struct {
 pub const Base64ImageSource = struct {
     data: []const u8,
     media_type: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionThreadStatusRunningEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     agent_name: []const u8,
     session_thread_id: []const u8,
 };
@@ -985,7 +985,7 @@ pub const BetaManagedAgentsSessionThreadStatusRunningEvent = struct {
 pub const BetaManagedAgentsDeploymentUserDefineOutcomeEvent = struct {
     description: []const u8,
     rubric: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     max_iterations: ?i64 = null,
 };
 
@@ -1004,24 +1004,24 @@ pub const BetaCreateSkillResponse = struct {
     display_title: ?[]const u8,
     id: []const u8,
     latest_version: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
     updated_at: []const u8,
 };
 
 pub const BetaManagedAgentsVaultNotFoundRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const BetaDreamMemoryStoreOutput = struct {
-    type: []const u8,
+    @"type": []const u8,
     memory_store_id: []const u8,
 };
 
 pub const BetaWebhookSessionThreadIdledEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
     session_thread_id: []const u8,
 };
@@ -1064,7 +1064,7 @@ pub const BetaManagedAgentsActor = union(enum) {
 
 pub const BetaManagedAgentsFileRubricParams = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaSpeed = []const u8;
@@ -1102,7 +1102,7 @@ pub const RequestWebSearchToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
     caller: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     content: RequestWebSearchToolResultBlockContent,
 };
 
@@ -1130,26 +1130,26 @@ pub const MessageBatch = struct {
     archived_at: ?[]const u8,
     ended_at: ?[]const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     results_url: ?[]const u8,
     processing_status: []const u8,
 };
 
 pub const BetaManagedAgentsAgentArchivedDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestToolSearchToolResultError = struct {
     error_code: []const u8,
     error_message: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCodeExecutionTool_20250825 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const BetaAllowedCaller = null,
     name: []const u8,
 };
@@ -1157,21 +1157,21 @@ pub const BetaCodeExecutionTool_20250825 = struct {
 pub const BetaManagedAgentsURLMCPServerParams = struct {
     url: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaInputTokensTrigger = struct {
     value: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsRetryStatusRetrying = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseToolSearchToolSearchResultBlock = struct {
     tool_references: []const BetaResponseToolReferenceBlock,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebSearchTool_20260209 = struct {
@@ -1184,7 +1184,7 @@ pub const BetaWebSearchTool_20260209 = struct {
     user_location: ?BetaUserLocation = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CacheCreation = struct {
@@ -1194,7 +1194,7 @@ pub const CacheCreation = struct {
 
 pub const JsonOutputFormat = struct {
     schema: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsRefreshHttpResponse = struct {
@@ -1209,7 +1209,7 @@ pub const RequestPageLocationCitation = struct {
     document_index: i64,
     start_page_number: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
@@ -1294,7 +1294,7 @@ pub const BetaMessageDeltaEvent = struct {
     delta: BetaMessageDelta,
     context_management: ?BetaResponseContextManagement,
     usage: BetaMessageDeltaUsage,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSkill = union(enum) {
@@ -1329,13 +1329,13 @@ pub const BetaManagedAgentsSkill = union(enum) {
 };
 
 pub const BetaManagedAgentsManualDeploymentPausedReason = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestBashCodeExecutionResultBlock = struct {
     content: []const BetaRequestBashCodeExecutionOutputBlock,
     return_code: i64,
-    type: []const u8,
+    @"type": []const u8,
     stderr: []const u8,
     stdout: []const u8,
 };
@@ -1343,7 +1343,7 @@ pub const BetaRequestBashCodeExecutionResultBlock = struct {
 pub const BetaManagedAgentsEventDeltaEvent = struct {
     event_id: []const u8,
     delta: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSendSessionEvents = struct {
@@ -1352,24 +1352,24 @@ pub const BetaManagedAgentsSendSessionEvents = struct {
 
 pub const ThinkingConfigAdaptive = struct {
     display: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookDeploymentRunStartedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaFileDocumentSource = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCustomSkill = struct {
     version: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     skill_id: []const u8,
 };
 
@@ -1382,7 +1382,7 @@ pub const BetaManagedAgentsSessionUpdatedEventAgent = struct {
     system: []const u8,
     model: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     mcp_servers: []const BetaManagedAgentsMCPServer,
 };
@@ -1391,13 +1391,13 @@ pub const BetaManagedAgentsSessionUpdatedEvent = struct {
     processed_at: std.json.Value,
     metadata: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     title: ?[]const u8 = null,
     agent: ?BetaManagedAgentsSessionUpdatedEventAgent = null,
 };
 
 pub const BetaManagedAgentsSessionEndTurn = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseContentBlockLocationCitation = struct {
@@ -1406,7 +1406,7 @@ pub const BetaResponseContentBlockLocationCitation = struct {
     document_index: i64,
     start_block_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
@@ -1415,7 +1415,7 @@ pub const BetaToolSearchToolResultErrorCode = []const u8;
 pub const BetaResponseToolSearchToolResultError = struct {
     error_code: []const u8,
     error_message: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsRefreshObjectHttpResponse = struct {
@@ -1465,7 +1465,7 @@ pub const BetaResponseBashCodeExecutionToolResultBlockContent = union(enum) {
 
 pub const BetaResponseBashCodeExecutionToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseBashCodeExecutionToolResultBlockContent,
 };
 
@@ -1477,7 +1477,7 @@ pub const BetaManagedAgentsSessionThreadAgent = struct {
     system: []const u8,
     model: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     mcp_servers: []const BetaManagedAgentsMCPServer,
 };
@@ -1489,11 +1489,11 @@ pub const BetaTextEditor_20250124 = struct {
     allowed_callers: ?[]const BetaAllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaUnrestrictedNetwork = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaContainer = struct {
@@ -1507,7 +1507,7 @@ pub const BetaManagedAgentsAgentToolResultEvent = struct {
     processed_at: std.json.Value,
     is_error: ?bool = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ?[]const BetaManagedAgentsToolResultContentBlock = null,
 };
 
@@ -1552,7 +1552,7 @@ pub const BetaRequestTextEditorCodeExecutionViewResultBlock = struct {
     file_type: []const u8,
     num_lines: ?i64 = null,
     start_line: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -1591,7 +1591,7 @@ pub const BetaManagedAgentsListSessionThreadEvents = struct {
 
 pub const BetaDeleteSkillVersionResponse = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaMessage = struct {
@@ -1604,7 +1604,7 @@ pub const BetaMessage = struct {
     usage: BetaUsage,
     model: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     stop_sequence: ?[]const u8,
     content: []const BetaContentBlock,
 };
@@ -1613,7 +1613,7 @@ pub const BetaToolSearchToolBM25_20251119 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const BetaAllowedCaller = null,
     name: []const u8,
 };
@@ -1634,7 +1634,7 @@ pub const MessageBatchIndividualResponse = struct {
 
 pub const ErroredResult = struct {
     @"error": ErrorResponse,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebFetchTool_20260209 = struct {
@@ -1648,7 +1648,7 @@ pub const WebFetchTool_20260209 = struct {
     citations: ?RequestCitationsConfig = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateMessageBatchParams = struct {
@@ -1660,17 +1660,17 @@ pub const BetaSelfHostedWorkHeartbeatResponse = struct {
     last_heartbeat: []const u8,
     ttl_seconds: i64,
     state: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMemoryPrefix = struct {
     path: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestBashCodeExecutionToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaDiagnosticsParam = struct {
@@ -1714,32 +1714,32 @@ pub const EffortCapability = struct {
 
 pub const BetaManagedAgentsTokenEndpointAuthBasicParam = struct {
     client_secret: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const SucceededResult = struct {
     message: Message,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestSearchResultBlock = struct {
     source: []const u8,
     cache_control: ?std.json.Value = null,
     citations: ?BetaRequestCitationsConfig = null,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
     content: []const BetaRequestTextBlock,
 };
 
 pub const BetaResponseContainerUploadBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionThreadStatus = []const u8;
 
 pub const BetaManagedAgentsAlwaysAskPolicy = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaTunnel = struct {
@@ -1747,14 +1747,14 @@ pub const BetaTunnel = struct {
     display_name: []const u8,
     archived_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     domain: []const u8,
 };
 
 pub const ToolChoiceTool = struct {
     disable_parallel_tool_use: ?bool = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaMCPToolDefaultConfig = struct {
@@ -1764,7 +1764,7 @@ pub const BetaMCPToolDefaultConfig = struct {
 
 pub const BetaTunnelToken = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     tunnel_token: []const u8,
 };
 
@@ -1772,7 +1772,7 @@ pub const BetaWebhookVaultCredentialDeletedEventData = struct {
     organization_id: []const u8,
     vault_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -1806,7 +1806,7 @@ pub const BetaRequestToolSearchToolResultBlockContent = union(enum) {
 pub const BetaRequestToolSearchToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaRequestToolSearchToolResultBlockContent,
 };
 
@@ -1823,16 +1823,16 @@ pub const BetaWebFetchTool_20260318 = struct {
     blocked_domains: ?[]const []const u8 = null,
     citations: ?BetaRequestCitationsConfig = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaThinkingTurns = struct {
     value: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsVaultNotFoundDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseSearchResultLocationCitation = struct {
@@ -1842,14 +1842,14 @@ pub const ResponseSearchResultLocationCitation = struct {
     start_block_index: i64,
     cited_text: []const u8,
     title: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestMCPToolUseBlock = struct {
     cache_control: ?std.json.Value = null,
     server_name: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: std.json.Value,
     name: []const u8,
 };
@@ -1857,7 +1857,7 @@ pub const BetaRequestMCPToolUseBlock = struct {
 pub const BetaWebhookAgentDeletedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -2006,12 +2006,12 @@ pub const BetaManagedAgentsTriggerContext = union(enum) {
 
 pub const BetaRequestBashCodeExecutionOutputBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsFileResourceConfig = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     mount_path: ?[]const u8 = null,
 };
 
@@ -2047,12 +2047,12 @@ pub const BetaManagedAgentsMCPServer = union(enum) {
 };
 
 pub const BetaManagedAgentsUnknownDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseAdvisorToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CompletionRequest = struct {
@@ -2070,7 +2070,7 @@ pub const CompletionRequest = struct {
 pub const MessageDeltaEvent = struct {
     delta: MessageDelta,
     usage: MessageDeltaUsage,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsEnvironmentVariableUpdateParamsInjectionLocation = struct {
@@ -2080,7 +2080,7 @@ pub const BetaManagedAgentsEnvironmentVariableUpdateParamsInjectionLocation = st
 
 pub const BetaManagedAgentsEnvironmentVariableUpdateParams = struct {
     injection_location: ?BetaManagedAgentsEnvironmentVariableUpdateParamsInjectionLocation = null,
-    type: []const u8,
+    @"type": []const u8,
     networking: ?std.json.Value = null,
     secret_value: ?[]const u8 = null,
 };
@@ -2088,14 +2088,14 @@ pub const BetaManagedAgentsEnvironmentVariableUpdateParams = struct {
 pub const BetaWebhookAgentArchivedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaWebhookAgentCreatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -2104,26 +2104,26 @@ pub const BetaAllowedCaller = []const u8;
 pub const BetaRequestCodeExecutionResultBlock = struct {
     content: []const BetaRequestCodeExecutionOutputBlock,
     return_code: i64,
-    type: []const u8,
+    @"type": []const u8,
     stderr: []const u8,
     stdout: []const u8,
 };
 
 pub const BetaManagedAgentsMultiagentCoordinatorParams = struct {
     agents: []const BetaManagedAgentsMultiagentRosterEntryParams,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionStatusTerminatedEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaAdvisorToolResultErrorCode = []const u8;
 
 pub const BetaManagedAgentsFileNotFoundDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseAdvisorToolResultBlockContent = union(enum) {
@@ -2160,7 +2160,7 @@ pub const BetaResponseAdvisorToolResultBlockContent = union(enum) {
 
 pub const BetaResponseAdvisorToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseAdvisorToolResultBlockContent,
 };
 
@@ -2360,7 +2360,7 @@ pub const BetaCountMessageTokensParams = struct {
 pub const RequestTextBlock = struct {
     text: []const u8,
     citations: ?[]const std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     cache_control: ?std.json.Value = null,
 };
 
@@ -2413,13 +2413,13 @@ pub const RequestTextEditorCodeExecutionToolResultBlockContent = union(enum) {
 pub const RequestTextEditorCodeExecutionToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: RequestTextEditorCodeExecutionToolResultBlockContent,
 };
 
 pub const RequestImageBlock = struct {
     source: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     cache_control: ?std.json.Value = null,
 };
 
@@ -2430,17 +2430,17 @@ pub const BetaBashTool_20250124 = struct {
     allowed_callers: ?[]const BetaAllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCacheMissMessagesChanged = struct {
     cache_missed_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaInputTokensClearAtLeast = struct {
     value: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCapabilitySupport = struct {
@@ -2449,7 +2449,7 @@ pub const BetaCapabilitySupport = struct {
 
 pub const BetaToolChoiceAny = struct {
     disable_parallel_tool_use: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebFetchTool_20260209 = struct {
@@ -2463,12 +2463,12 @@ pub const BetaWebFetchTool_20260209 = struct {
     citations: ?BetaRequestCitationsConfig = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestAdvisorRedactedResultBlock = struct {
     encrypted_content: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     stop_reason: ?[]const u8 = null,
 };
 
@@ -2489,7 +2489,7 @@ pub const ThinkingCapability = struct {
 pub const BetaRequestTextEditorCodeExecutionToolResultError = struct {
     error_code: []const u8,
     error_message: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebFetchTool_20260309 = struct {
@@ -2503,33 +2503,33 @@ pub const WebFetchTool_20260309 = struct {
     citations: ?RequestCitationsConfig = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     use_cache: ?bool = null,
 };
 
 pub const CacheControlEphemeral = struct {
     ttl: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsUserMessageEventParams = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaManagedAgentsUserContentBlock,
 };
 
 pub const BillingError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaErroredResult = struct {
     @"error": BetaErrorResponse,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsBillingError = struct {
     retry_status: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -2541,7 +2541,7 @@ pub const BetaThinkingCapability = struct {
 pub const ResponseWebFetchResultBlock = struct {
     retrieved_at: ?[]const u8,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ResponseDocumentBlock,
 };
 
@@ -2553,13 +2553,13 @@ pub const BetaOutputConfig = struct {
 
 pub const BetaContentBlockStopEvent = struct {
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaTokenTaskBudget = struct {
     remaining: ?i64 = null,
     total: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const EffortLevel = []const u8;
@@ -2572,12 +2572,12 @@ pub const BetaManagedAgentsMcptoolsetParamsDefaultConfig = struct {
 pub const BetaManagedAgentsMCPToolsetParams = struct {
     default_config: ?BetaManagedAgentsMcptoolsetParamsDefaultConfig = null,
     mcp_server_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     configs: ?[]const BetaManagedAgentsMCPToolConfigParams = null,
 };
 
 pub const BetaManagedAgentsTokenEndpointAuthPostResponse = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsPrecondition = union(enum) {
@@ -2610,7 +2610,7 @@ pub const CodeExecutionTool_20250522 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const AllowedCaller = null,
     name: []const u8,
 };
@@ -2622,12 +2622,12 @@ pub const RequestSearchResultLocationCitation = struct {
     start_block_index: i64,
     cited_text: []const u8,
     title: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsDeletedCredential = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsGetSessionResource = union(enum) {
@@ -2667,24 +2667,24 @@ pub const BetaManagedAgentsGetSessionResource = union(enum) {
 };
 
 pub const ServerToolCaller = struct {
-    type: []const u8,
+    @"type": []const u8,
     tool_id: []const u8,
 };
 
 pub const BetaManagedAgentsDeleteSessionResource = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestThinkingBlock = struct {
     thinking: []const u8,
     signature: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseToolReferenceBlock = struct {
     tool_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaDream = struct {
@@ -2700,16 +2700,16 @@ pub const BetaDream = struct {
     session_id: []const u8,
     archived_at: []const u8,
     ended_at: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSelfHostedResourcesUnsupportedDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaSkillParams = struct {
     version: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     skill_id: []const u8,
 };
 
@@ -2726,29 +2726,29 @@ pub const BetaMessageDeltaUsage = struct {
 pub const InputSchema = struct {
     properties: ?std.json.Value = null,
     required: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseClearToolUses20250919Edit = struct {
     cleared_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
     cleared_tool_uses: i64,
 };
 
 pub const BetaManagedAgentsEventDeltaEventContentDeltaContent = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsEventDeltaEvent_ContentDelta = struct {
-    type: []const u8,
+    @"type": []const u8,
     index: ?i64 = null,
     content: BetaManagedAgentsEventDeltaEventContentDeltaContent,
 };
 
 pub const BetaURLImageSource = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebFetchToolResultErrorCode = []const u8;
@@ -2759,20 +2759,20 @@ pub const BetaRequestFallbackHopInfo = struct {
 
 pub const BetaRequestMidConvSystemBlock = struct {
     cache_control: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     content: []const std.json.Value,
 };
 
 pub const BetaManagedAgentsMemoryStoreResourceConfig = struct {
     instructions: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     memory_store_id: []const u8,
     access: ?std.json.Value = null,
 };
 
 pub const BetaManagedAgentsModelRequestFailedError = struct {
     retry_status: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -2814,7 +2814,7 @@ pub const BetaManagedAgentsCredentialUpdateAuth = union(enum) {
 
 pub const BetaManagedAgentsAgentParams = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     version: ?i64 = null,
 };
 
@@ -2830,14 +2830,14 @@ pub const BetaManagedAgentsListSessionResources = struct {
 
 pub const BetaInputJsonContentBlockDelta = struct {
     partial_json: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseWebSearchResultBlock = struct {
     page_age: ?[]const u8,
     encrypted_content: []const u8,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
 };
 
@@ -2851,18 +2851,18 @@ pub const BetaManagedAgentsSessionThread = struct {
     agent: BetaManagedAgentsSessionThreadAgent,
     usage: BetaManagedAgentsSessionThreadUsage,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     updated_at: std.json.Value,
 };
 
 pub const BetaResponseToolReferenceBlock = struct {
     tool_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsTokenEndpointAuthPostParam = struct {
     client_secret: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseToolSearchToolResultBlockContent = union(enum) {
@@ -2894,7 +2894,7 @@ pub const ResponseToolSearchToolResultBlockContent = union(enum) {
 
 pub const ResponseToolSearchToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ResponseToolSearchToolResultBlockContent,
 };
 
@@ -2908,19 +2908,19 @@ pub const BetaManagedAgentsAgentMcpToolResultEvent = struct {
     processed_at: std.json.Value,
     is_error: ?bool = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ?[]const BetaManagedAgentsToolResultContentBlock = null,
 };
 
 pub const BetaManagedAgentsEnvironmentNotFoundDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestTextEditorCodeExecutionStrReplaceResultBlock = struct {
     old_lines: ?i64 = null,
     new_lines: ?i64 = null,
     old_start: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
     lines: ?[]const []const u8 = null,
     new_start: ?i64 = null,
 };
@@ -2931,20 +2931,20 @@ pub const BetaRefusalStopDetails = struct {
     fallback_credit_token: ?[]const u8,
     fallback_has_prefill_claim: ?bool,
     recommended_model: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestBashCodeExecutionResultBlock = struct {
     content: []const RequestBashCodeExecutionOutputBlock,
     return_code: i64,
-    type: []const u8,
+    @"type": []const u8,
     stderr: []const u8,
     stdout: []const u8,
 };
 
 pub const BetaCloudConfigParams = struct {
     packages: ?BetaPackagesParams = null,
-    type: []const u8,
+    @"type": []const u8,
     networking: ?std.json.Value = null,
 };
 
@@ -2964,7 +2964,7 @@ pub const BetaFallbackMessageIterationUsage = struct {
     model: []const u8,
     output_tokens: i64,
     cache_creation_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
     cache_creation: ?BetaCacheCreation,
 };
 
@@ -2979,7 +2979,7 @@ pub const BetaResponseServerToolUseBlock = struct {
     id: []const u8,
     input: std.json.Value,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BashCodeExecutionToolResultErrorCode = []const u8;
@@ -2991,12 +2991,12 @@ pub const BetaBody_create_skill_v1_skills_post = struct {
 
 pub const InvalidRequestError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseCodeExecutionToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaEffortLevel = []const u8;
@@ -3031,7 +3031,7 @@ pub const BetaResponseWebFetchToolResultBlockContent = union(enum) {
 pub const BetaResponseWebFetchToolResultBlock = struct {
     tool_use_id: []const u8,
     caller: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseWebFetchToolResultBlockContent,
 };
 
@@ -3067,7 +3067,7 @@ pub const BetaResponseWebSearchToolResultBlockContent = union(enum) {
 pub const BetaResponseWebSearchToolResultBlock = struct {
     tool_use_id: []const u8,
     caller: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseWebSearchToolResultBlockContent,
 };
 
@@ -3077,7 +3077,7 @@ pub const BetaAdvisorMessageIterationUsage = struct {
     model: []const u8,
     output_tokens: i64,
     cache_creation_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
     cache_creation: ?BetaCacheCreation,
 };
 
@@ -3087,18 +3087,18 @@ pub const OutputConfig = struct {
 };
 
 pub const BetaManagedAgentsMemoryPreconditionFailedError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: ?[]const u8 = null,
 };
 
 pub const ResponseTextBlock = struct {
     text: []const u8,
     citations: ?[]const std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMemoryStoreArchivedDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CountMessageTokensParamsToolsItem = union(enum) {
@@ -3258,13 +3258,13 @@ pub const CountMessageTokensParams = struct {
 pub const BetaThinkingDisplayMode = []const u8;
 
 pub const BetaManagedAgentsSkillNotFoundRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const BetaManagedAgentsTokenEndpointAuthPostUpdateParam = struct {
     client_secret: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaServerToolUsage = struct {
@@ -3284,7 +3284,7 @@ pub const BetaLimitedNetwork = struct {
     allowed_hosts: []const []const u8,
     allow_mcp_servers: bool,
     allow_package_managers: bool,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateMessageParamsToolsItem = union(enum) {
@@ -3464,7 +3464,7 @@ pub const BetaManagedAgentsListMemoryStoresResponse = struct {
 };
 
 pub const BetaManagedAgentsMultiagentSelfParams = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestTextEditorCodeExecutionToolResultBlockContent = union(enum) {
@@ -3507,7 +3507,7 @@ pub const BetaRequestTextEditorCodeExecutionToolResultBlockContent = union(enum)
 pub const BetaRequestTextEditorCodeExecutionToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaRequestTextEditorCodeExecutionToolResultBlockContent,
 };
 
@@ -3570,7 +3570,7 @@ pub const BetaManagedAgentsEventParams = union(enum) {
 pub const BetaManagedAgentsStaticBearerCreateParams = struct {
     mcp_server_url: []const u8,
     token: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const Tool = struct {
@@ -3582,14 +3582,14 @@ pub const Tool = struct {
     description: ?[]const u8 = null,
     input_schema: InputSchema,
     name: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     eager_input_streaming: ?bool = null,
 };
 
 pub const BetaContentBlockDeltaEvent = struct {
     delta: std.json.Value,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaModelInfo = struct {
@@ -3600,7 +3600,7 @@ pub const BetaModelInfo = struct {
     display_name: []const u8,
     allowed_fallback_models: ?[]const []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BashTool_20250124 = struct {
@@ -3610,13 +3610,13 @@ pub const BashTool_20250124 = struct {
     allowed_callers: ?[]const AllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ThinkingDisplayMode = []const u8;
 
 pub const BetaExpiredResult = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaListUserProfilesResponse = struct {
@@ -3659,7 +3659,7 @@ pub const BetaManagedAgentsMemoryListItem = union(enum) {
 
 pub const BetaRequestToolSearchToolSearchResultBlock = struct {
     tool_references: []const BetaRequestToolReferenceBlock,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebFetchTool_20250910 = struct {
@@ -3673,13 +3673,13 @@ pub const WebFetchTool_20250910 = struct {
     citations: ?RequestCitationsConfig = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseFallbackBlock = struct {
     from: BetaResponseFallbackHopInfo,
     to: BetaResponseFallbackHopInfo,
-    type: []const u8,
+    @"type": []const u8,
     trigger: BetaFallbackRefusalTrigger,
 };
 
@@ -3716,32 +3716,32 @@ pub const BetaManagedAgentsCreateMemoryParams = struct {
 
 pub const BetaManagedAgentsDeletedMemory = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMultiagentCoordinator = struct {
     agents: []const BetaManagedAgentsAgentReference,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookSessionRequiresActionEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaWebhookSessionThreadCreatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
     session_thread_id: []const u8,
 };
 
 pub const BetaTextContentBlockDelta = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaMemoryTool_20250818_ViewCommand = struct {
@@ -3756,19 +3756,19 @@ pub const BetaDreamModelConfig = struct {
 };
 
 pub const BetaManagedAgentsMemoryStoreArchivedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const BetaDreamError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const BetaBase64PDFSource = struct {
     data: []const u8,
     media_type: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaToolChoice = union(enum) {
@@ -3857,14 +3857,14 @@ pub const BetaManagedAgentsAgentWithOverridesParams = struct {
     system: ?[]const u8 = null,
     model: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     mcp_servers: ?[]const BetaManagedAgentsMCPServerParams = null,
 };
 
 pub const BetaRequestCompactionBlock = struct {
     cache_control: ?std.json.Value = null,
     encrypted_content: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     content: ?[]const u8 = null,
 };
 
@@ -3907,13 +3907,13 @@ pub const BetaManagedAgentsSessionStatusIdleEventStopReason = union(enum) {
 pub const BetaManagedAgentsSessionStatusIdleEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     stop_reason: BetaManagedAgentsSessionStatusIdleEventStopReason,
 };
 
 pub const ResponseBashCodeExecutionToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseWebSearchResultLocationCitation = struct {
@@ -3921,7 +3921,7 @@ pub const BetaResponseWebSearchResultLocationCitation = struct {
     encrypted_index: []const u8,
     cited_text: []const u8,
     title: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const Metadata = struct {
@@ -3929,12 +3929,12 @@ pub const Metadata = struct {
 };
 
 pub const BetaSelfHostedConfigParams = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaPermissionError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSpeed = []const u8;
@@ -3946,14 +3946,14 @@ pub const BetaContextManagementResponse = struct {
 pub const BetaManagedAgentsSessionThreadStatusRescheduledEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     agent_name: []const u8,
     session_thread_id: []const u8,
 };
 
 pub const BetaManagedAgentsEventStartEvent_AgentMessagePreview = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSpanModelUsage = struct {
@@ -3968,7 +3968,7 @@ pub const BetaToolSearchToolRegex_20251119 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const BetaAllowedCaller = null,
     name: []const u8,
 };
@@ -3976,7 +3976,7 @@ pub const BetaToolSearchToolRegex_20251119 = struct {
 pub const BetaManagedAgentsUserInterruptEvent = struct {
     processed_at: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     session_thread_id: ?[]const u8 = null,
 };
 
@@ -4015,7 +4015,7 @@ pub const BetaRequestToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
     is_error: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     content: ?BetaRequestToolResultBlockContent = null,
 };
 
@@ -4025,13 +4025,13 @@ pub const BetaManagedAgentsVault = struct {
     archived_at: std.json.Value,
     metadata: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     updated_at: []const u8,
 };
 
 pub const BetaCacheMissSystemChanged = struct {
     cache_missed_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaInputContentBlock = union(enum) {
@@ -4162,7 +4162,7 @@ pub const BetaInputContentBlock = union(enum) {
 };
 
 pub const BetaManagedAgentsDeploymentSystemMessageEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaManagedAgentsSystemContentBlock,
 };
 
@@ -4176,7 +4176,7 @@ pub const BetaManagedAgentsGitHubRepositoryResource = struct {
     checkout: ?BetaManagedAgentsRepositoryCheckout = null,
     url: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     mount_path: []const u8,
     updated_at: []const u8,
 };
@@ -4186,31 +4186,31 @@ pub const BetaManagedAgentsMemoryVersionOperation = []const u8;
 pub const BetaWebhookSessionThreadTerminatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
     session_thread_id: []const u8,
 };
 
 pub const ThinkingContentBlockDelta = struct {
     thinking: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestTextBlock = struct {
     text: []const u8,
     citations: ?[]const std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     cache_control: ?std.json.Value = null,
 };
 
 pub const BetaManagedAgentsTextBlock = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionMultiagentCoordinator = struct {
     agents: []const BetaManagedAgentsSessionThreadAgent,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsRubric = union(enum) {
@@ -4245,7 +4245,7 @@ pub const BetaManagedAgentsRubric = union(enum) {
 };
 
 pub const BetaManagedAgentsAgentArchivedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -4262,7 +4262,7 @@ pub const BetaBashTool_20241022 = struct {
     allowed_callers: ?[]const BetaAllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaDiagnostics = struct {
@@ -4283,14 +4283,14 @@ pub const BetaManagedAgentsAgent = struct {
     archived_at: std.json.Value,
     metadata: std.json.Value,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     mcp_servers: []const BetaManagedAgentsMCPServer,
 };
 
 pub const BetaManagedAgentsAgentThinkingEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaClearThinking20251015KeepVariant0 = std.json.Value;
@@ -4325,7 +4325,7 @@ pub const BetaClearThinking20251015Keep = union(enum) {
 };
 
 pub const BetaClearThinking20251015 = struct {
-    type: []const u8,
+    @"type": []const u8,
     keep: ?BetaClearThinking20251015Keep = null,
 };
 
@@ -4336,7 +4336,7 @@ pub const BetaPackages = struct {
     cargo: []const []const u8,
     pip: []const []const u8,
     gem: []const []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const BetaWebSearchTool_20250305 = struct {
@@ -4349,28 +4349,28 @@ pub const BetaWebSearchTool_20250305 = struct {
     user_location: ?BetaUserLocation = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ExpiredResult = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseTextEditorCodeExecutionToolResultError = struct {
     error_code: []const u8,
     error_message: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ThinkingConfigEnabled = struct {
     display: ?[]const u8 = null,
     budget_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseTextEditorCodeExecutionCreateResultBlock = struct {
     is_file_update: bool,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsRetryStatus = union(enum) {
@@ -4417,7 +4417,7 @@ pub const BetaManagedAgentsListAgentVersions = struct {
 pub const BetaWebhookSessionDeletedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -4493,7 +4493,7 @@ pub const ResponseCharLocationCitation = struct {
     document_index: i64,
     end_char_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     start_char_index: i64,
 };
 
@@ -4501,19 +4501,19 @@ pub const ResponseWebSearchResultBlock = struct {
     page_age: ?[]const u8,
     encrypted_content: []const u8,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
 };
 
 pub const BetaContentBlockStartEvent = struct {
     content_block: std.json.Value,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaAPIError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaContextManagementCapability = struct {
@@ -4529,7 +4529,7 @@ pub const BetaCreateTunnelCertificateRequestBody = struct {
 
 pub const BetaManagedAgentsFileDocumentSource = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCodeExecutionToolResultErrorCode = []const u8;
@@ -4541,7 +4541,7 @@ pub const BetaTunnelCertificate = struct {
     fingerprint: []const u8,
     archived_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestSearchResultLocationCitation = struct {
@@ -4551,12 +4551,12 @@ pub const BetaRequestSearchResultLocationCitation = struct {
     start_block_index: i64,
     cited_text: []const u8,
     title: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsLimitedCredentialNetworkingParams = struct {
     allowed_hosts: []const []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCreateAgentParams = struct {
@@ -4573,13 +4573,13 @@ pub const BetaManagedAgentsCreateAgentParams = struct {
 
 pub const BetaManagedAgentsImageBlock = struct {
     source: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsGitHubRepositoryResourceConfig = struct {
     url: []const u8,
     checkout: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     mount_path: ?[]const u8 = null,
 };
 
@@ -4587,7 +4587,7 @@ pub const BetaManagedAgentsAgentCustomToolUseEvent = struct {
     input: std.json.Value,
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     session_thread_id: ?[]const u8 = null,
 };
@@ -4639,18 +4639,18 @@ pub const BetaRequestCodeExecutionToolResultBlockContent = union(enum) {
 pub const BetaRequestCodeExecutionToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaRequestCodeExecutionToolResultBlockContent,
 };
 
 pub const BetaManagedAgentsSessionResourceNotFoundRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const BetaResponseAdvisorResultBlock = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     stop_reason: ?[]const u8,
 };
 
@@ -4664,11 +4664,11 @@ pub const WebSearchTool_20250305 = struct {
     user_location: ?UserLocation = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionRateLimitedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -4678,7 +4678,7 @@ pub const BetaManagedAgentsFileResource = struct {
     created_at: []const u8,
     file_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     mount_path: []const u8,
     updated_at: []const u8,
 };
@@ -4686,7 +4686,7 @@ pub const BetaManagedAgentsFileResource = struct {
 pub const BetaManagedAgentsSystemMessageEvent = struct {
     processed_at: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaManagedAgentsSystemContentBlock,
 };
 
@@ -4697,13 +4697,13 @@ pub const BetaMemoryTool_20250818 = struct {
     allowed_callers: ?[]const BetaAllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseTextEditorCodeExecutionToolResultError = struct {
     error_code: []const u8,
     error_message: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaJsonValue = std.json.Value;
@@ -4711,13 +4711,13 @@ pub const BetaJsonValue = std.json.Value;
 pub const BetaManagedAgentsPlainTextDocumentSource = struct {
     media_type: []const u8,
     data: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseCodeExecutionResultBlock = struct {
     content: []const BetaResponseCodeExecutionOutputBlock,
     return_code: i64,
-    type: []const u8,
+    @"type": []const u8,
     stderr: []const u8,
     stdout: []const u8,
 };
@@ -4736,13 +4736,13 @@ pub const BetaManagedAgentsSessionThreadUsage = struct {
 
 pub const RequestMidConvSystemBlock = struct {
     cache_control: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     content: []const std.json.Value,
 };
 
 pub const BetaSkill = struct {
     version: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     skill_id: []const u8,
 };
 
@@ -4752,7 +4752,7 @@ pub const BetaMetadata = struct {
 
 pub const BetaResponseCodeExecutionToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebSearchTool_20260209 = struct {
@@ -4765,14 +4765,14 @@ pub const WebSearchTool_20260209 = struct {
     user_location: ?UserLocation = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCodeExecutionTool_20260120 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const BetaAllowedCaller = null,
     name: []const u8,
 };
@@ -4806,7 +4806,7 @@ pub const BetaResponseToolSearchToolResultBlockContent = union(enum) {
 
 pub const BetaResponseToolSearchToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseToolSearchToolResultBlockContent,
 };
 
@@ -4875,7 +4875,7 @@ pub const BetaDreamInput = union(enum) {
 pub const Base64PDFSource = struct {
     data: []const u8,
     media_type: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TextEditor_20250124 = struct {
@@ -4885,7 +4885,7 @@ pub const TextEditor_20250124 = struct {
     allowed_callers: ?[]const AllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionResource = union(enum) {
@@ -4927,12 +4927,12 @@ pub const BetaManagedAgentsSessionResource = union(enum) {
 pub const BetaManagedAgentsCustomToolInputSchema = struct {
     properties: ?std.json.Value = null,
     required: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsEventStartEvent_AgentThinkingPreview = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsUserContentBlock = union(enum) {
@@ -4977,29 +4977,29 @@ pub const BetaMessageIterationUsage = struct {
     model: []const u8,
     output_tokens: i64,
     cache_creation_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
     cache_creation: ?BetaCacheCreation,
 };
 
 pub const BetaResponseClearThinking20251015Edit = struct {
     cleared_input_tokens: i64,
     cleared_thinking_turns: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMCPServerURLDefinition = struct {
     url: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsURLDocumentSource = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsTokenEndpointAuthBasicResponse = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestCounts = struct {
@@ -5013,7 +5013,7 @@ pub const BetaRequestCounts = struct {
 pub const BetaTextEditorCodeExecutionToolResultErrorCode = []const u8;
 
 pub const BetaManagedAgentsManualTriggerContext = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaMCPToolConfig = struct {
@@ -5023,23 +5023,23 @@ pub const BetaMCPToolConfig = struct {
 
 pub const BetaManagedAgentsStaticBearerAuthResponse = struct {
     mcp_server_url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAnthropicSkillParams = struct {
     version: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     skill_id: []const u8,
 };
 
 pub const BetaManagedAgentsSessionCreationRejectedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const BetaToolUsesTrigger = struct {
     value: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsInjectionLocationParams = struct {
@@ -5052,11 +5052,11 @@ pub const ResponseServerToolUseBlock = struct {
     id: []const u8,
     input: std.json.Value,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsWorkspaceArchivedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -5076,14 +5076,14 @@ pub const BetaManagedAgentsSpanOutcomeEvaluationEndEvent = struct {
     usage: BetaManagedAgentsSpanOutcomeEvaluationEndEventUsage,
     explanation: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     outcome_id: []const u8,
 };
 
 pub const BetaWebhookSessionPendingEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -5091,7 +5091,7 @@ pub const BetaWebhookVaultCredentialRefreshFailedEventData = struct {
     organization_id: []const u8,
     vault_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -5102,7 +5102,7 @@ pub const BetaPackagesParams = struct {
     cargo: ?[]const []const u8 = null,
     pip: ?[]const []const u8 = null,
     gem: ?[]const []const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const StopReason = []const u8;
@@ -5148,20 +5148,20 @@ pub const ResponseTextEditorCodeExecutionToolResultBlockContent = union(enum) {
 
 pub const ResponseTextEditorCodeExecutionToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ResponseTextEditorCodeExecutionToolResultBlockContent,
 };
 
 pub const BetaManagedAgentsMcpConnectionFailedError = struct {
     retry_status: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
     mcp_server_name: []const u8,
 };
 
 pub const RequestBashCodeExecutionOutputBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestContentBlockLocationCitation = struct {
@@ -5169,17 +5169,17 @@ pub const BetaRequestContentBlockLocationCitation = struct {
     start_block_index: i64,
     document_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
 pub const BetaAllThinkingTurns = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaJsonOutputFormat = struct {
     schema: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebSearchTool_20260318 = struct {
@@ -5193,13 +5193,13 @@ pub const WebSearchTool_20260318 = struct {
     user_location: ?UserLocation = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsUserMessageEvent = struct {
     processed_at: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaManagedAgentsUserContentBlock,
 };
 
@@ -5209,54 +5209,54 @@ pub const Betaapi__schemas__skills__Skill = struct {
     display_title: ?[]const u8,
     id: []const u8,
     latest_version: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
     updated_at: []const u8,
 };
 
 pub const PlainTextSource = struct {
     data: []const u8,
     media_type: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestToolReferenceBlock = struct {
     tool_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     cache_control: ?std.json.Value = null,
 };
 
 pub const RequestCodeExecutionOutputBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const NotFoundError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookSessionOutcomeEvaluationEndedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaThinkingConfigAdaptive = struct {
     display: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookAgentUpdatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaManagedAgentsErrorDeploymentPausedReason = struct {
     @"error": std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaThinkingTypes = struct {
@@ -5272,7 +5272,7 @@ pub const BetaGetSkillVersionResponse = struct {
     description: []const u8,
     id: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaContentBlock = union(enum) {
@@ -5386,19 +5386,19 @@ pub const BetaClearToolUses20250919 = struct {
     trigger: ?std.json.Value = null,
     exclude_tools: ?[]const []const u8 = null,
     clear_at_least: ?BetaInputTokensClearAtLeast = null,
-    type: []const u8,
+    @"type": []const u8,
     clear_tool_inputs: std.json.Value = null,
     keep: ?std.json.Value = null,
 };
 
 pub const BetaDreamSessionsInput = struct {
     session_ids: []const []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsDeploymentRunAgent = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     version: i64,
 };
 
@@ -5410,7 +5410,7 @@ pub const BetaManagedAgentsDeploymentRun = struct {
     trigger_context: std.json.Value,
     agent: BetaManagedAgentsDeploymentRunAgent,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaOutputTokensDetails = struct {
@@ -5420,7 +5420,7 @@ pub const BetaOutputTokensDetails = struct {
 pub const BetaResponseWebFetchResultBlock = struct {
     retrieved_at: ?[]const u8,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseDocumentBlock,
 };
 
@@ -5432,7 +5432,7 @@ pub const BetaMessageBatch = struct {
     archived_at: ?[]const u8,
     ended_at: ?[]const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     results_url: ?[]const u8,
     processing_status: []const u8,
 };
@@ -5440,18 +5440,18 @@ pub const BetaMessageBatch = struct {
 pub const RefusalStopDetails = struct {
     category: ?[]const u8,
     explanation: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMemoryPathConflictError = struct {
     conflicting_path: ?[]const u8 = null,
     conflicting_memory_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     message: ?[]const u8 = null,
 };
 
 pub const BetaCacheMissUnavailable = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsDeploymentInitialEvent = union(enum) {
@@ -5498,7 +5498,7 @@ pub const TextEditor_20250728 = struct {
     cache_control: ?std.json.Value = null,
     max_characters: ?i64 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaEnvironmentListResponse = struct {
@@ -5513,19 +5513,19 @@ pub const BetaManagedAgentsOutcomeEvaluationResource = struct {
     description: []const u8,
     outcome_id: []const u8,
     explanation: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookDeploymentUnpausedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const ResponseTextEditorCodeExecutionCreateResultBlock = struct {
     is_file_update: bool,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ErrorType = []const u8;
@@ -5533,31 +5533,31 @@ pub const ErrorType = []const u8;
 pub const BetaManagedAgentsAgentMessageEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaManagedAgentsTextBlock,
 };
 
 pub const WebFetchToolResultErrorCode = []const u8;
 
 pub const MessageStopEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookDeploymentPausedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const OverloadedError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsFileResourceParams = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     mount_path: ?[]const u8 = null,
 };
 
@@ -5624,7 +5624,7 @@ pub const BetaManagedAgentsEnvironmentVariableAuthResponseInjectionLocation = st
 
 pub const BetaManagedAgentsEnvironmentVariableAuthResponse = struct {
     injection_location: BetaManagedAgentsEnvironmentVariableAuthResponseInjectionLocation,
-    type: []const u8,
+    @"type": []const u8,
     secret_name: []const u8,
     networking: std.json.Value,
 };
@@ -5635,7 +5635,7 @@ pub const BetaManagedAgentsListAgents = struct {
 };
 
 pub const ServerToolCaller_20260120 = struct {
-    type: []const u8,
+    @"type": []const u8,
     tool_id: []const u8,
 };
 
@@ -5650,12 +5650,12 @@ pub const BetaResponseMCPToolUseBlock = struct {
     id: []const u8,
     input: std.json.Value,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaToolChoiceAuto = struct {
     disable_parallel_tool_use: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCreateMemoryStoreRequest = struct {
@@ -5667,7 +5667,7 @@ pub const BetaManagedAgentsCreateMemoryStoreRequest = struct {
 pub const BetaWebhookDeploymentDeletedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -5678,14 +5678,14 @@ pub const BetaListDreamsResponse = struct {
 
 pub const BetaManagedAgentsUserCustomToolResultEventParams = struct {
     is_error: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     custom_tool_use_id: []const u8,
     content: ?[]const BetaManagedAgentsToolResultContentBlock = null,
 };
 
 pub const BetaManagedAgentsBranchCheckout = struct {
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMcpOauthAuthResponseRefreshTokenEndpointAuth = union(enum) {
@@ -5736,18 +5736,18 @@ pub const BetaManagedAgentsMcpOauthAuthResponse = struct {
     mcp_server_url: []const u8,
     expires_at: ?[]const u8 = null,
     refresh: ?BetaManagedAgentsMcpOauthAuthResponseRefresh = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaBase64ImageSource = struct {
     data: []const u8,
     media_type: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaDeleteMessageBatchResponse = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentToolUseEvent = struct {
@@ -5755,7 +5755,7 @@ pub const BetaManagedAgentsAgentToolUseEvent = struct {
     session_thread_id: ?[]const u8 = null,
     evaluated_permission: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     input: std.json.Value,
 };
@@ -5765,7 +5765,7 @@ pub const BetaManagedAgentsUserCustomToolResultEvent = struct {
     session_thread_id: ?[]const u8 = null,
     is_error: ?bool = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     custom_tool_use_id: []const u8,
     content: ?[]const BetaManagedAgentsToolResultContentBlock = null,
 };
@@ -5781,7 +5781,7 @@ pub const BetaPublicEnvironmentCreateRequest = struct {
 pub const BetaRequestThinkingBlock = struct {
     thinking: []const u8,
     signature: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentToolset20260401_EditInput = struct {
@@ -5793,7 +5793,7 @@ pub const BetaManagedAgentsAgentToolset20260401_EditInput = struct {
 
 pub const BetaEnvironmentDeleteResponse = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseTextEditorCodeExecutionToolResultBlockContent = union(enum) {
@@ -5835,18 +5835,18 @@ pub const BetaResponseTextEditorCodeExecutionToolResultBlockContent = union(enum
 
 pub const BetaResponseTextEditorCodeExecutionToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseTextEditorCodeExecutionToolResultBlockContent,
 };
 
 pub const RequestToolSearchToolSearchResultBlock = struct {
     tool_references: []const RequestToolReferenceBlock,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsDeletedVault = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsTriggerType = []const u8;
@@ -5859,13 +5859,13 @@ pub const BetaMessageBatchIndividualRequestParams = struct {
 pub const BetaWebhookSessionIdledEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaManagedAgentsCommitCheckout = struct {
     sha: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseCitationsConfig = struct {
@@ -5875,13 +5875,13 @@ pub const ResponseCitationsConfig = struct {
 pub const BetaManagedAgentsUserToolResultEventParams = struct {
     tool_use_id: []const u8,
     is_error: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     content: ?[]const BetaManagedAgentsToolResultContentBlock = null,
 };
 
 pub const BetaManagedAgentsModel = union(enum) {
     null,
-    bool: bool,
+    @"bool": bool,
     integer: i64,
     float: f64,
     number_string: []const u8,
@@ -5932,7 +5932,7 @@ pub const BetaManagedAgentsModel = union(enum) {
 pub const BetaWebhookDeploymentCreatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -5986,19 +5986,19 @@ pub const BetaListResponse_ModelInfo_ = struct {
 
 pub const BetaResponseCompactionBlock = struct {
     encrypted_content: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ?[]const u8,
 };
 
 pub const ResponseThinkingBlock = struct {
     thinking: []const u8,
     signature: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ToolChoiceAny = struct {
     disable_parallel_tool_use: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionErrorEventError = union(enum) {
@@ -6066,12 +6066,12 @@ pub const BetaManagedAgentsSessionErrorEvent = struct {
     @"error": BetaManagedAgentsSessionErrorEventError,
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const APIError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const MessageStreamEvent = union(enum) {
@@ -6123,7 +6123,7 @@ pub const MessageStreamEvent = union(enum) {
 
 pub const BetaManagedAgentsMemoryStoreResourceParam = struct {
     instructions: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     memory_store_id: []const u8,
     access: ?std.json.Value = null,
 };
@@ -6132,12 +6132,12 @@ pub const BetaWebhookVaultCredentialArchivedEventData = struct {
     organization_id: []const u8,
     vault_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaManagedAgentsOrganizationDisabledRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -6183,13 +6183,13 @@ pub const ResponseWebFetchToolResultBlockContent = union(enum) {
 pub const ResponseWebFetchToolResultBlock = struct {
     tool_use_id: []const u8,
     caller: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     content: ResponseWebFetchToolResultBlockContent,
 };
 
 pub const BetaManagedAgentsMcpAuthenticationFailedError = struct {
     retry_status: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
     mcp_server_name: []const u8,
 };
@@ -6277,7 +6277,7 @@ pub const BetaManagedAgentsCredentialHostUnreachableError = struct {
     credential_id: []const u8,
     vault_id: []const u8,
     retry_status: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -6286,7 +6286,7 @@ pub const BetaRequestWebSearchResultLocationCitation = struct {
     encrypted_index: []const u8,
     cited_text: []const u8,
     title: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsEventDeltaEvent_Delta = union(enum) {
@@ -6320,18 +6320,18 @@ pub const RequestCharLocationCitation = struct {
     start_char_index: i64,
     document_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
 pub const BetaManagedAgentsDeletedSession = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsURLImageSource = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestCharLocationCitation = struct {
@@ -6339,7 +6339,7 @@ pub const BetaRequestCharLocationCitation = struct {
     start_char_index: i64,
     document_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
@@ -6348,19 +6348,19 @@ pub const RequestWebSearchResultLocationCitation = struct {
     encrypted_index: []const u8,
     cited_text: []const u8,
     title: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseContainerUploadBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaStopReason = []const u8;
 
 pub const RateLimitError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentThreadMessageReceivedEvent = struct {
@@ -6368,22 +6368,22 @@ pub const BetaManagedAgentsAgentThreadMessageReceivedEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
     from_session_thread_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     from_agent_name: ?[]const u8 = null,
 };
 
 pub const BetaManagedAgentsMcpEgressBlockedDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestImageBlock = struct {
     source: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     cache_control: ?std.json.Value = null,
 };
 
 pub const DirectCaller = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaMemoryTool_20250818_CreateCommand = struct {
@@ -6396,14 +6396,14 @@ pub const BetaResponseTextEditorCodeExecutionStrReplaceResultBlock = struct {
     old_lines: ?i64,
     new_lines: ?i64,
     old_start: ?i64,
-    type: []const u8,
+    @"type": []const u8,
     lines: ?[]const []const u8,
     new_start: ?i64,
 };
 
 pub const RequestWebFetchToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSearchResultBlockCitations = struct {
@@ -6413,14 +6413,14 @@ pub const BetaManagedAgentsSearchResultBlockCitations = struct {
 pub const BetaManagedAgentsSearchResultBlock = struct {
     source: []const u8,
     citations: BetaManagedAgentsSearchResultBlockCitations,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
     content: []const BetaManagedAgentsSearchResultContent,
 };
 
 pub const BetaRequestTextEditorCodeExecutionCreateResultBlock = struct {
     is_file_update: bool,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseContextManagement = struct {
@@ -6429,11 +6429,11 @@ pub const BetaResponseContextManagement = struct {
 
 pub const BetaInvalidRequestError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ThinkingConfigDisabled = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaComputerUseTool_20241022 = struct {
@@ -6446,21 +6446,21 @@ pub const BetaComputerUseTool_20241022 = struct {
     display_number: ?i64 = null,
     strict: ?bool = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const DeleteMessageBatchResponse = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaSignatureContentBlockDelta = struct {
     signature: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaSelfHostedConfig = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebFetchTool_20250910 = struct {
@@ -6474,7 +6474,7 @@ pub const BetaWebFetchTool_20250910 = struct {
     citations: ?BetaRequestCitationsConfig = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseToolUseBlock = struct {
@@ -6482,7 +6482,7 @@ pub const BetaResponseToolUseBlock = struct {
     id: []const u8,
     input: std.json.Value,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMemoryStoreResource = struct {
@@ -6491,7 +6491,7 @@ pub const BetaManagedAgentsMemoryStoreResource = struct {
     access: ?std.json.Value = null,
     description: ?[]const u8 = null,
     name: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     mount_path: ?[]const u8 = null,
 };
 
@@ -6501,19 +6501,19 @@ pub const BetaSelfHostedWorkStopRequest = struct {
 
 pub const BetaRequestWebFetchToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookVaultDeletedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const Model = union(enum) {
     null,
-    bool: bool,
+    @"bool": bool,
     integer: i64,
     float: f64,
     number_string: []const u8,
@@ -6600,14 +6600,14 @@ pub const BetaManagedAgentsEnvironmentVariableCreateParamsInjectionLocation = st
 pub const BetaManagedAgentsEnvironmentVariableCreateParams = struct {
     secret_value: []const u8,
     injection_location: ?BetaManagedAgentsEnvironmentVariableCreateParamsInjectionLocation = null,
-    type: []const u8,
+    @"type": []const u8,
     networking: std.json.Value,
     secret_name: []const u8,
 };
 
 pub const BetaResponseWebFetchToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsModelConfig = struct {
@@ -6617,7 +6617,7 @@ pub const BetaManagedAgentsModelConfig = struct {
 
 pub const BetaRequestCodeExecutionOutputBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ContentBlockSourceContentVariant0 = []const u8;
@@ -6652,7 +6652,7 @@ pub const ContentBlockSourceContent = union(enum) {
 };
 
 pub const ContentBlockSource = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: ContentBlockSourceContent,
 };
 
@@ -6660,7 +6660,7 @@ pub const ToolSearchToolRegex_20251119 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const AllowedCaller = null,
     name: []const u8,
 };
@@ -6699,14 +6699,14 @@ pub const BetaManagedAgentsMultiagentRosterEntryParams = union(enum) {
 pub const BetaManagedAgentsGitHubRepositoryResourceParams = struct {
     url: []const u8,
     checkout: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     mount_path: ?[]const u8 = null,
     authorization_token: []const u8,
 };
 
 pub const BetaRequestContainerUploadBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     cache_control: ?std.json.Value = null,
 };
 
@@ -6763,27 +6763,27 @@ pub const BetaMemoryTool_20250818_Command = union(enum) {
 
 pub const BetaManagedAgentsSearchResultContent = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionThreadStatusTerminatedEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     agent_name: []const u8,
     session_thread_id: []const u8,
 };
 
 pub const BetaSessionWorkData = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaLimitedNetworkParams = struct {
     allowed_hosts: ?[]const []const u8 = null,
     allow_mcp_servers: ?bool = null,
     allow_package_managers: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestPageLocationCitation = struct {
@@ -6791,7 +6791,7 @@ pub const BetaRequestPageLocationCitation = struct {
     document_index: i64,
     start_page_number: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
@@ -6799,7 +6799,7 @@ pub const BetaCodeExecutionTool_20260521 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const BetaAllowedCaller = null,
     name: []const u8,
 };
@@ -6811,18 +6811,18 @@ pub const BetaTextEditor_20241022 = struct {
     allowed_callers: ?[]const BetaAllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ErrorResponse = struct {
     @"error": std.json.Value,
     request_id: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAnthropicSkill = struct {
     version: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     skill_id: []const u8,
 };
 
@@ -6860,14 +6860,14 @@ pub const BetaManagedAgentsPermissionPolicy = union(enum) {
 pub const BetaManagedAgentsMCPToolset = struct {
     default_config: BetaManagedAgentsMCPToolsetDefaultConfig,
     mcp_server_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     configs: []const BetaManagedAgentsMCPToolConfig,
 };
 
 pub const BetaManagedAgentsSessionDeletedEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsUpdateDeploymentParams = struct {
@@ -6909,7 +6909,7 @@ pub const BetaManagedAgentsUpdateMemoryStoreResponse = union(enum) {
 };
 
 pub const BetaServerToolCaller_20260120 = struct {
-    type: []const u8,
+    @"type": []const u8,
     tool_id: []const u8,
 };
 
@@ -6926,28 +6926,28 @@ pub const RequestToolUseBlock = struct {
     cache_control: ?std.json.Value = null,
     caller: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: std.json.Value,
     name: []const u8,
 };
 
 pub const BetaManagedAgentsUserActor = struct {
     user_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestWebSearchResultBlock = struct {
     page_age: ?[]const u8 = null,
     encrypted_content: []const u8,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
 };
 
 pub const ContentBlockDeltaEvent = struct {
     delta: std.json.Value,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSession = struct {
@@ -6965,7 +6965,7 @@ pub const BetaManagedAgentsSession = struct {
     agent: BetaManagedAgentsSessionAgent,
     metadata: std.json.Value,
     vault_ids: []const []const u8,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
 };
 
@@ -7000,12 +7000,12 @@ pub const BetaRequestWebFetchToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
     caller: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaRequestWebFetchToolResultBlockContent,
 };
 
 pub const CanceledResult = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaUserProfile = struct {
@@ -7015,7 +7015,7 @@ pub const BetaUserProfile = struct {
     trust_grants: std.json.Value,
     metadata: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: ?[]const u8 = null,
     updated_at: std.json.Value,
 };
@@ -7047,7 +7047,7 @@ pub const BetaManagedAgentsMultiagent = union(enum) {
 };
 
 pub const BetaCacheMissPreviousMessageNotFound = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TextEditor_20250429 = struct {
@@ -7057,14 +7057,14 @@ pub const TextEditor_20250429 = struct {
     allowed_callers: ?[]const AllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ToolSearchToolBM25_20251119 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const AllowedCaller = null,
     name: []const u8,
 };
@@ -7083,7 +7083,7 @@ pub const BetaTool = struct {
     description: ?[]const u8 = null,
     input_schema: BetaInputSchema,
     name: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     eager_input_streaming: ?bool = null,
 };
 
@@ -7095,7 +7095,7 @@ pub const BetaManagedAgentsAgentToolset20260401_GlobInput = struct {
 pub const BetaManagedAgentsBase64DocumentSource = struct {
     media_type: []const u8,
     data: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseMcptoolResultBlockContentVariant0 = []const u8;
@@ -7132,24 +7132,24 @@ pub const BetaResponseMcptoolResultBlockContent = union(enum) {
 pub const BetaResponseMCPToolResultBlock = struct {
     tool_use_id: []const u8,
     is_error: bool,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaResponseMcptoolResultBlockContent,
 };
 
 pub const BetaManagedAgentsDeletedMemoryStore = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionActor = struct {
-    type: []const u8,
+    @"type": []const u8,
     session_id: []const u8,
 };
 
 pub const BetaResponseBashCodeExecutionResultBlock = struct {
     content: []const BetaResponseBashCodeExecutionOutputBlock,
     return_code: i64,
-    type: []const u8,
+    @"type": []const u8,
     stderr: []const u8,
     stdout: []const u8,
 };
@@ -7203,13 +7203,13 @@ pub const BetaListSkillVersionsResponse = struct {
 
 pub const BetaResponseWebSearchToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookDeploymentUpdatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -7253,7 +7253,7 @@ pub const BetaRequestMCPServerURLDefinition = struct {
     url: []const u8,
     tool_configuration: ?BetaRequestMCPServerToolConfiguration = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     authorization_token: ?[]const u8 = null,
 };
 
@@ -7457,13 +7457,13 @@ pub const BetaManagedAgentsMCPToolConfig = struct {
 pub const BetaWebhookSessionStatusRunStartedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const ResponseWebSearchToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const Usage = struct {
@@ -7481,7 +7481,7 @@ pub const Usage = struct {
 pub const BetaManagedAgentsSpanModelRequestStartEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCreateCredentialRequestBody = struct {
@@ -7527,13 +7527,13 @@ pub const BetaManagedAgentsSessionResourceConfig = union(enum) {
 };
 
 pub const BetaMessageStopEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsDocumentBlock = struct {
     source: std.json.Value,
     context: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     title: ?[]const u8 = null,
 };
 
@@ -7542,16 +7542,16 @@ pub const CompletionResponse = struct {
     id: []const u8,
     model: []const u8,
     stop_reason: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseWebFetchToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsEnvironmentNotFoundRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -7562,14 +7562,14 @@ pub const BetaResponseSearchResultLocationCitation = struct {
     start_block_index: i64,
     cited_text: []const u8,
     title: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseEncryptedCodeExecutionResultBlock = struct {
     encrypted_stdout: []const u8,
     return_code: i64,
     stderr: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaResponseCodeExecutionOutputBlock,
 };
 
@@ -7583,7 +7583,7 @@ pub const BetaAdvisorTool_20260301 = struct {
     cache_control: ?std.json.Value = null,
     model: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestTextEditorCodeExecutionViewResultBlock = struct {
@@ -7591,7 +7591,7 @@ pub const RequestTextEditorCodeExecutionViewResultBlock = struct {
     file_type: []const u8,
     num_lines: ?i64 = null,
     start_line: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -7599,21 +7599,21 @@ pub const BetaRequestDocumentBlock = struct {
     source: std.json.Value,
     context: ?[]const u8 = null,
     citations: ?BetaRequestCitationsConfig = null,
-    type: []const u8,
+    @"type": []const u8,
     title: ?[]const u8 = null,
     cache_control: ?std.json.Value = null,
 };
 
 pub const BetaURLPDFSource = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestServerToolUseBlock = struct {
     cache_control: ?std.json.Value = null,
     caller: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: std.json.Value,
     name: []const u8,
 };
@@ -7621,7 +7621,7 @@ pub const BetaRequestServerToolUseBlock = struct {
 pub const BetaManagedAgentsUserToolConfirmationEventParams = struct {
     tool_use_id: []const u8,
     result: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     deny_message: ?[]const u8 = null,
 };
 
@@ -7634,25 +7634,25 @@ pub const BetaManagedAgentsAgentEvaluatedPermission = []const u8;
 
 pub const ToolChoiceAuto = struct {
     disable_parallel_tool_use: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsFileNotFoundRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const BetaRequestFallbackBlock = struct {
     from: BetaRequestFallbackHopInfo,
     to: BetaRequestFallbackHopInfo,
-    type: []const u8,
+    @"type": []const u8,
     trigger: ?std.json.Value = null,
 };
 
 pub const BetaInputSchema = struct {
     properties: ?std.json.Value = null,
     required: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebSearchToolResultErrorCode = []const u8;
@@ -7666,14 +7666,14 @@ pub const BetaMCPToolset = struct {
     cache_control: ?std.json.Value = null,
     default_config: ?BetaMCPToolDefaultConfig = null,
     mcp_server_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     configs: ?std.json.Value = null,
 };
 
 pub const RequestTextEditorCodeExecutionToolResultError = struct {
     error_code: []const u8,
     error_message: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsListDeploymentsData = struct {
@@ -7691,13 +7691,13 @@ pub const BetaFileListResponse = struct {
 pub const BetaWebhookSessionArchivedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaBillingError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestToolSearchToolResultBlockContent = union(enum) {
@@ -7730,7 +7730,7 @@ pub const RequestToolSearchToolResultBlockContent = union(enum) {
 pub const RequestToolSearchToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: RequestToolSearchToolResultBlockContent,
 };
 
@@ -7800,7 +7800,7 @@ pub const BetaRequestEncryptedCodeExecutionResultBlock = struct {
     encrypted_stdout: []const u8,
     return_code: i64,
     stderr: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaRequestCodeExecutionOutputBlock,
 };
 
@@ -7839,7 +7839,7 @@ pub const BetaRequestMCPToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
     is_error: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     content: ?BetaRequestMcptoolResultBlockContent = null,
 };
 
@@ -7847,7 +7847,7 @@ pub const RequestDocumentBlock = struct {
     source: std.json.Value,
     context: ?[]const u8 = null,
     citations: ?RequestCitationsConfig = null,
-    type: []const u8,
+    @"type": []const u8,
     title: ?[]const u8 = null,
     cache_control: ?std.json.Value = null,
 };
@@ -7855,13 +7855,13 @@ pub const RequestDocumentBlock = struct {
 pub const BetaWebhookVaultCreatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
 pub const BetaCloudConfig = struct {
     packages: BetaPackages,
-    type: []const u8,
+    @"type": []const u8,
     networking: std.json.Value,
 };
 
@@ -7900,7 +7900,7 @@ pub const BetaRequestAdvisorToolResultBlockContent = union(enum) {
 pub const BetaRequestAdvisorToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaRequestAdvisorToolResultBlockContent,
 };
 
@@ -7916,19 +7916,19 @@ pub const Container = struct {
 
 pub const BetaManagedAgentsFileImageSource = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCompactionContentBlockDelta = struct {
     encrypted_content: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ?[]const u8,
 };
 
 pub const BetaManagedAgentsSessionStatusRescheduledEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaModelCapabilities = struct {
@@ -7945,7 +7945,7 @@ pub const BetaModelCapabilities = struct {
 
 pub const BetaManagedAgentsScheduleTriggerContext = struct {
     scheduled_at: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentToolset20260401_BashInput = struct {
@@ -7956,7 +7956,7 @@ pub const BetaManagedAgentsAgentToolset20260401_BashInput = struct {
 
 pub const BetaRateLimitError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMcpOauthUpdateParamsRefreshTokenEndpointAuth = union(enum) {
@@ -8000,7 +8000,7 @@ pub const BetaManagedAgentsMcpOauthUpdateParams = struct {
     access_token: ?[]const u8 = null,
     expires_at: ?[]const u8 = null,
     refresh: ?BetaManagedAgentsMcpOauthUpdateParamsRefresh = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ModelInfo = struct {
@@ -8010,42 +8010,42 @@ pub const ModelInfo = struct {
     max_input_tokens: ?i64,
     display_name: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionStatusRunningEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestWebFetchResultBlock = struct {
     retrieved_at: ?[]const u8 = null,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: RequestDocumentBlock,
 };
 
 pub const ResponseRedactedThinkingBlock = struct {
     data: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsLimitedCredentialNetworkingResponse = struct {
     allowed_hosts: []const []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestContainerUploadBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     cache_control: ?std.json.Value = null,
 };
 
 pub const ResponseCodeExecutionResultBlock = struct {
     content: []const ResponseCodeExecutionOutputBlock,
     return_code: i64,
-    type: []const u8,
+    @"type": []const u8,
     stderr: []const u8,
     stdout: []const u8,
 };
@@ -8082,7 +8082,7 @@ pub const BetaManagedAgentsDeploymentPausedReason = union(enum) {
 };
 
 pub const BetaManagedAgentsTextRubric = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -8090,14 +8090,14 @@ pub const BetaSelfHostedWorkQueueStats = struct {
     oldest_queued_at: ?[]const u8,
     depth: i64,
     workers_polling: ?i64,
-    type: []const u8,
+    @"type": []const u8,
     pending: i64,
 };
 
 pub const BetaResponseThinkingBlock = struct {
     thinking: []const u8,
     signature: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCreateSessionAgentUnionParamsVariant0 = []const u8;
@@ -8133,7 +8133,7 @@ pub const BetaManagedAgentsCreateSessionAgentUnionParams = union(enum) {
 
 pub const BetaManagedAgentsContentSha256Precondition = struct {
     content_sha256: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaTimestamp = []const u8;
@@ -8190,7 +8190,7 @@ pub const BetaManagedAgentsMcpOauthRefreshParams = struct {
 pub const BetaCompact20260112 = struct {
     pause_after_compaction: ?bool = null,
     instructions: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     trigger: ?BetaInputTokensTrigger = null,
 };
 
@@ -8203,7 +8203,7 @@ pub const BetaManagedAgentsMemory = struct {
     content_sha256: []const u8,
     path: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     updated_at: std.json.Value,
 };
 
@@ -8211,7 +8211,7 @@ pub const ResponseEncryptedCodeExecutionResultBlock = struct {
     encrypted_stdout: []const u8,
     return_code: i64,
     stderr: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const ResponseCodeExecutionOutputBlock,
 };
 
@@ -8244,7 +8244,7 @@ pub const ResponseBashCodeExecutionToolResultBlockContent = union(enum) {
 
 pub const ResponseBashCodeExecutionToolResultBlock = struct {
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ResponseBashCodeExecutionToolResultBlockContent,
 };
 
@@ -8257,7 +8257,7 @@ pub const BetaManagedAgentsSessionAgent = struct {
     system: []const u8,
     model: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     mcp_servers: []const BetaManagedAgentsMCPServer,
 };
@@ -8271,31 +8271,31 @@ pub const MessageDelta = struct {
 
 pub const SignatureContentBlockDelta = struct {
     signature: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestWebSearchToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestServerToolUseBlock = struct {
     cache_control: ?std.json.Value = null,
     caller: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: std.json.Value,
     name: []const u8,
 };
 
 pub const BetaFallbackRefusalTrigger = struct {
     category: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestRedactedThinkingBlock = struct {
     data: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentToolset20260401ParamsDefaultConfig = struct {
@@ -8305,7 +8305,7 @@ pub const BetaManagedAgentsAgentToolset20260401ParamsDefaultConfig = struct {
 
 pub const BetaManagedAgentsAgentToolset20260401Params = struct {
     default_config: ?BetaManagedAgentsAgentToolset20260401ParamsDefaultConfig = null,
-    type: []const u8,
+    @"type": []const u8,
     configs: ?[]const BetaManagedAgentsAgentToolConfigParams = null,
 };
 
@@ -8320,7 +8320,7 @@ pub const BetaComputerUseTool_20251124 = struct {
     enable_zoom: ?bool = null,
     strict: ?bool = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsUpdateAgentParams = struct {
@@ -8412,7 +8412,7 @@ pub const BetaDreamModelParams = union(enum) {
 };
 
 pub const BetaCanceledResult = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionThreadStatusIdleEventStopReason = union(enum) {
@@ -8455,7 +8455,7 @@ pub const BetaManagedAgentsSessionThreadStatusIdleEvent = struct {
     session_thread_id: []const u8,
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     stop_reason: BetaManagedAgentsSessionThreadStatusIdleEventStopReason,
     agent_name: []const u8,
 };
@@ -8467,7 +8467,7 @@ pub const CountMessageTokensResponse = struct {
 pub const BetaWebhookDeploymentArchivedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -8481,7 +8481,7 @@ pub const BetaComputerUseTool_20250124 = struct {
     display_number: ?i64 = null,
     strict: ?bool = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCountMessageTokensResponse = struct {
@@ -8584,14 +8584,14 @@ pub const RequestEncryptedCodeExecutionResultBlock = struct {
     encrypted_stdout: []const u8,
     return_code: i64,
     stderr: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const RequestCodeExecutionOutputBlock,
 };
 
 pub const ContentBlockStartEvent = struct {
     content_block: std.json.Value,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaInputMessageContentVariant0 = []const u8;
@@ -8632,12 +8632,12 @@ pub const BetaInputMessage = struct {
 
 pub const BetaCacheMissToolsChanged = struct {
     cache_missed_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCacheControlEphemeral = struct {
     ttl: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsInjectionLocationResponse = struct {
@@ -8646,11 +8646,11 @@ pub const BetaManagedAgentsInjectionLocationResponse = struct {
 };
 
 pub const BetaManagedAgentsTokenEndpointAuthNoneParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsTokenEndpointAuthNoneResponse = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseFallbackHopInfo = struct {
@@ -8665,17 +8665,17 @@ pub const BetaSkillVersion = struct {
     description: []const u8,
     id: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestBashCodeExecutionToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestAdvisorResultBlock = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     stop_reason: ?[]const u8 = null,
 };
 
@@ -8685,7 +8685,7 @@ pub const BetaGetSkillResponse = struct {
     display_title: ?[]const u8,
     id: []const u8,
     latest_version: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
     updated_at: []const u8,
 };
 
@@ -8717,7 +8717,7 @@ pub const BetaManagedAgentsSystemContentBlock = union(enum) {
 
 pub const BetaManagedAgentsEventStartEvent = struct {
     event: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsEventStartEvent_Event = union(enum) {
@@ -8753,20 +8753,20 @@ pub const BetaManagedAgentsEventStartEvent_Event = union(enum) {
 
 pub const BetaResponseBashCodeExecutionToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSessionThreadCreatedEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     agent_name: []const u8,
     session_thread_id: []const u8,
 };
 
 pub const BetaFileDeleteResponse = struct {
     id: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RequestBashCodeExecutionToolResultBlockContent = union(enum) {
@@ -8799,7 +8799,7 @@ pub const RequestBashCodeExecutionToolResultBlockContent = union(enum) {
 pub const RequestBashCodeExecutionToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: RequestBashCodeExecutionToolResultBlockContent,
 };
 
@@ -9004,12 +9004,12 @@ pub const BetaManagedAgentsSpanOutcomeEvaluationOngoingEvent = struct {
     processed_at: std.json.Value,
     iteration: i64,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     outcome_id: []const u8,
 };
 
 pub const BetaManagedAgentsSessionResourceNotFoundDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ModelCapabilities = struct {
@@ -9032,14 +9032,14 @@ pub const BetaCreateSkillVersionResponse = struct {
     description: []const u8,
     id: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestSearchResultBlock = struct {
     source: []const u8,
     cache_control: ?std.json.Value = null,
     citations: ?RequestCitationsConfig = null,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
     content: []const RequestTextBlock,
 };
@@ -9052,7 +9052,7 @@ pub const BetaFileMetadataSchema = struct {
     filename: []const u8,
     size_bytes: i64,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaIterationsUsage = ?[]const std.json.Value;
@@ -9067,25 +9067,25 @@ pub const BetaSelfHostedWork = struct {
     data: BetaSessionWorkData,
     metadata: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     acknowledged_at: ?[]const u8,
     stop_requested_at: ?[]const u8,
 };
 
 pub const AuthenticationError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaDreamMemoryStoreInput = struct {
-    type: []const u8,
+    @"type": []const u8,
     memory_store_id: []const u8,
 };
 
 pub const BetaToolChoiceTool = struct {
     disable_parallel_tool_use: ?bool = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestWebFetchToolResultBlockContent = union(enum) {
@@ -9119,7 +9119,7 @@ pub const RequestWebFetchToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
     caller: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     content: RequestWebFetchToolResultBlockContent,
 };
 
@@ -9163,18 +9163,18 @@ pub const BetaManagedAgentsRubricParams = union(enum) {
 
 pub const PermissionError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsUnknownError = struct {
     retry_status: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const ResponseBashCodeExecutionOutputBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsListOrder = []const u8;
@@ -9190,18 +9190,18 @@ pub const BetaUpdateUserProfileRequestBody = struct {
 
 pub const BetaResponseRedactedThinkingBlock = struct {
     data: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaThinkingConfigEnabled = struct {
     display: ?[]const u8 = null,
     budget_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCitationsDelta = struct {
     citation: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestCitationsConfig = struct {
@@ -9210,19 +9210,19 @@ pub const BetaRequestCitationsConfig = struct {
 
 pub const BetaResponseAdvisorRedactedResultBlock = struct {
     encrypted_content: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     stop_reason: ?[]const u8,
 };
 
 pub const BetaResponseCodeExecutionOutputBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookDeploymentRunFailedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -9234,7 +9234,7 @@ pub const BetaTextEditor_20250728 = struct {
     cache_control: ?std.json.Value = null,
     max_characters: ?i64 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsEventDeltaType = []const u8;
@@ -9246,14 +9246,14 @@ pub const BetaManagedAgentsModelConfigParams = struct {
 
 pub const RequestTextEditorCodeExecutionCreateResultBlock = struct {
     is_file_update: bool,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCodeExecutionTool_20250522 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const BetaAllowedCaller = null,
     name: []const u8,
 };
@@ -9264,7 +9264,7 @@ pub const BetaManagedAgentsCronSchedule = struct {
     timezone: []const u8,
     last_run_at: ?std.json.Value = null,
     upcoming_runs_at: ?[]const BetaTimestamp = null,
-    type: []const u8,
+    @"type": []const u8,
     expression: []const u8,
 };
 
@@ -9273,20 +9273,20 @@ pub const BetaCompactionIterationUsage = struct {
     input_tokens: i64,
     output_tokens: i64,
     cache_creation_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
     cache_creation: ?BetaCacheCreation,
 };
 
 pub const BetaResponseTextBlock = struct {
     text: []const u8,
     citations: ?[]const std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsUserDefineOutcomeEventParams = struct {
     description: []const u8,
     rubric: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     max_iterations: ?i64 = null,
 };
 
@@ -9294,20 +9294,20 @@ pub const ResponseTextEditorCodeExecutionStrReplaceResultBlock = struct {
     old_lines: ?i64,
     new_lines: ?i64,
     old_start: ?i64,
-    type: []const u8,
+    @"type": []const u8,
     lines: ?[]const []const u8,
     new_start: ?i64,
 };
 
 pub const BetaManagedAgentsEnvironmentArchivedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const ResponseToolSearchToolResultError = struct {
     error_code: []const u8,
     error_message: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebSearchToolResultErrorCode = []const u8;
@@ -9318,19 +9318,19 @@ pub const ResponseContentBlockLocationCitation = struct {
     document_index: i64,
     start_block_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
 pub const BetaManagedAgentsVaultArchivedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
 pub const BetaResponseDocumentBlock = struct {
     source: std.json.Value,
     citations: ?BetaResponseCitationsConfig,
-    type: []const u8,
+    @"type": []const u8,
     title: ?[]const u8,
 };
 
@@ -9369,17 +9369,17 @@ pub const BetaThinkingConfigParam = union(enum) {
 };
 
 pub const BetaManagedAgentsUserInterruptEventParams = struct {
-    type: []const u8,
+    @"type": []const u8,
     session_thread_id: ?[]const u8 = null,
 };
 
 pub const BetaCacheMissModelChanged = struct {
     cache_missed_input_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsRetryStatusExhausted = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsToolResultContentBlock = union(enum) {
@@ -9435,7 +9435,7 @@ pub const BetaManagedAgentsMemoryVersion = struct {
     operation: std.json.Value,
     path: ?[]const u8 = null,
     redacted_by: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     created_by: ?std.json.Value = null,
 };
 
@@ -9474,12 +9474,12 @@ pub const RequestToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
     is_error: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     content: ?RequestToolResultBlockContent = null,
 };
 
 pub const BetaManagedAgentsWorkspaceArchivedDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsStreamSessionEvents = union(enum) {
@@ -9711,12 +9711,12 @@ pub const BetaManagedAgentsAddSessionResourceParams = union(enum) {
 
 pub const ResponseToolSearchToolSearchResultBlock = struct {
     tool_references: []const ResponseToolReferenceBlock,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaThinkingContentBlockDelta = struct {
     thinking: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     estimated_tokens: ?i64,
 };
 
@@ -9765,11 +9765,11 @@ pub const ListResponse_MessageBatch_ = struct {
 
 pub const MessageStartEvent = struct {
     message: Message,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSystemMessageEventParams = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const BetaManagedAgentsSystemContentBlock,
 };
 
@@ -9778,7 +9778,7 @@ pub const ResponseTextEditorCodeExecutionViewResultBlock = struct {
     file_type: []const u8,
     num_lines: ?i64,
     start_line: ?i64,
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -9826,12 +9826,12 @@ pub const BetaDreamUsage = struct {
 };
 
 pub const BetaManagedAgentsSkillNotFoundDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsDeploymentAgent = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     version: i64,
 };
 
@@ -9851,7 +9851,7 @@ pub const BetaManagedAgentsDeployment = struct {
     metadata: std.json.Value,
     name: []const u8,
     vault_ids: []const []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsListSessionEvents = struct {
@@ -9866,11 +9866,11 @@ pub const BetaManagedAgentsMCPToolsetDefaultConfigParams = struct {
 
 pub const BetaResponseBashCodeExecutionOutputBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsConflictError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: ?[]const u8 = null,
 };
 
@@ -9879,7 +9879,7 @@ pub const BetaUserProfileRelationship = []const u8;
 pub const BetaManagedAgentsAgentThreadContextCompactedEvent = struct {
     processed_at: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCredentialValidationMcpProbeHttpResponse = struct {
@@ -9912,13 +9912,13 @@ pub const BetaManagedAgentsCredentialValidation = struct {
     credential_id: []const u8,
     status: std.json.Value,
     refresh: BetaManagedAgentsCredentialValidationRefresh,
-    type: []const u8,
+    @"type": []const u8,
     validated_at: std.json.Value,
     has_refresh_token: bool,
 };
 
 pub const BetaManagedAgentsEnvironmentArchivedDeploymentPausedReasonError = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsRunError = union(enum) {
@@ -10023,41 +10023,41 @@ pub const BetaManagedAgentsRunError = union(enum) {
 };
 
 pub const BetaManagedAgentsUnrestrictedCredentialNetworkingResponse = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const URLImageSource = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UserLocation = struct {
     city: ?[]const u8 = null,
     country: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     region: ?[]const u8 = null,
     timezone: ?[]const u8 = null,
 };
 
 pub const BetaRequestCodeExecutionToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaToolUsesKeep = struct {
     value: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaSucceededResult = struct {
     message: BetaMessage,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaPlainTextSource = struct {
     data: []const u8,
     media_type: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ThinkingConfigParam = union(enum) {
@@ -10099,7 +10099,7 @@ pub const BetaManagedAgentsUserToolConfirmationEvent = struct {
     session_thread_id: ?[]const u8 = null,
     tool_use_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ListResponse_ModelInfo_ = struct {
@@ -10115,13 +10115,13 @@ pub const OutputTokensDetails = struct {
 
 pub const BetaManagedAgentsSessionRequiresAction = struct {
     event_ids: []const []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookSessionStatusTerminatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -10140,13 +10140,13 @@ pub const BetaRequestToolUseBlock = struct {
     cache_control: ?std.json.Value = null,
     caller: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: std.json.Value,
     name: []const u8,
 };
 
 pub const BetaManagedAgentsSelfHostedResourcesUnsupportedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -10154,7 +10154,7 @@ pub const CodeExecutionTool_20250825 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const AllowedCaller = null,
     name: []const u8,
 };
@@ -10187,7 +10187,7 @@ pub const BetaManagedAgentsSessionMultiagent = union(enum) {
 
 pub const BetaRequestRedactedThinkingBlock = struct {
     data: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestContentBlockLocationCitation = struct {
@@ -10195,7 +10195,7 @@ pub const RequestContentBlockLocationCitation = struct {
     start_block_index: i64,
     document_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     document_title: ?[]const u8,
 };
 
@@ -10407,12 +10407,12 @@ pub const BetaManagedAgentsStreamSessionThreadEvents = union(enum) {
 
 pub const BetaManagedAgentsApiActor = struct {
     api_key_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RequestWebSearchToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsMemoryStore = struct {
@@ -10421,19 +10421,19 @@ pub const BetaManagedAgentsMemoryStore = struct {
     archived_at: ?std.json.Value = null,
     metadata: ?std.json.Value = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     updated_at: std.json.Value,
 };
 
 pub const BetaThinkingConfigDisabled = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestWebFetchResultBlock = struct {
     retrieved_at: ?[]const u8 = null,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaRequestDocumentBlock,
 };
 
@@ -10443,19 +10443,19 @@ pub const BetaResponseCitationsConfig = struct {
 
 pub const BetaGatewayTimeoutError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaErrorResponse = struct {
     @"error": std.json.Value,
     request_id: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookSessionStatusIdledEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -10494,7 +10494,7 @@ pub const RequestCodeExecutionToolResultBlockContent = union(enum) {
 pub const RequestCodeExecutionToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: RequestCodeExecutionToolResultBlockContent,
 };
 
@@ -10506,13 +10506,13 @@ pub const BetaManagedAgentsMCPToolConfigParams = struct {
 
 pub const BetaNotFoundError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaWebhookDeploymentRunSucceededEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -10523,21 +10523,21 @@ pub const BetaTextEditor_20250429 = struct {
     allowed_callers: ?[]const BetaAllowedCaller = null,
     cache_control: ?std.json.Value = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CodeExecutionTool_20260120 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const AllowedCaller = null,
     name: []const u8,
 };
 
 pub const BetaAuthenticationError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCredential = struct {
@@ -10548,13 +10548,13 @@ pub const BetaManagedAgentsCredential = struct {
     archived_at: std.json.Value,
     metadata: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     updated_at: []const u8,
 };
 
 pub const BetaManagedAgentsCustomSkillParams = struct {
     version: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     skill_id: []const u8,
 };
 
@@ -10565,7 +10565,7 @@ pub const BetaSelfHostedWorkListResponse = struct {
 
 pub const ContentBlockStopEvent = struct {
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseWebSearchResultLocationCitation = struct {
@@ -10573,12 +10573,12 @@ pub const ResponseWebSearchResultLocationCitation = struct {
     encrypted_index: []const u8,
     cited_text: []const u8,
     title: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsFileRubric = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsListCredentialsResponse = struct {
@@ -10588,7 +10588,7 @@ pub const BetaManagedAgentsListCredentialsResponse = struct {
 
 pub const CitationsDelta = struct {
     citation: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentToolsetDefaultConfigParams = struct {
@@ -10600,7 +10600,7 @@ pub const BetaWebhookVaultCredentialCreatedEventData = struct {
     organization_id: []const u8,
     vault_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -10608,7 +10608,7 @@ pub const CodeExecutionTool_20260521 = struct {
     cache_control: ?std.json.Value = null,
     strict: ?bool = null,
     defer_loading: ?bool = null,
-    type: []const u8,
+    @"type": []const u8,
     allowed_callers: ?[]const AllowedCaller = null,
     name: []const u8,
 };
@@ -10618,7 +10618,7 @@ pub const BetaManagedAgentsUserDefineOutcomeEvent = struct {
     description: []const u8,
     outcome_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     max_iterations: i64,
     rubric: std.json.Value,
 };
@@ -10639,7 +10639,7 @@ pub const BetaFallbackConfigV2 = struct {
 };
 
 pub const BetaManagedAgentsRetryStatusTerminal = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentMcpToolUseEvent = struct {
@@ -10650,12 +10650,12 @@ pub const BetaManagedAgentsAgentMcpToolUseEvent = struct {
     mcp_server_name: []const u8,
     id: []const u8,
     input: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsModelRateLimitedError = struct {
     retry_status: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -10670,7 +10670,7 @@ pub const BetaWebFetchTool_20260309 = struct {
     citations: ?BetaRequestCitationsConfig = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     use_cache: ?bool = null,
 };
 
@@ -10686,7 +10686,7 @@ pub const BetaManagedAgentsSpanModelRequestEndEvent = struct {
     processed_at: std.json.Value,
     is_error: bool,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     model_usage: BetaManagedAgentsSpanModelRequestEndEventModelUsage,
     model_request_start_id: []const u8,
 };
@@ -10724,12 +10724,12 @@ pub const BetaRequestWebSearchToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
     caller: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaRequestWebSearchToolResultBlockContent,
 };
 
 pub const BetaToolChoiceNone = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentToolConfigParams = struct {
@@ -10740,7 +10740,7 @@ pub const BetaManagedAgentsAgentToolConfigParams = struct {
 
 pub const BetaManagedAgentsAgentToolset20260401 = struct {
     default_config: BetaManagedAgentsAgentToolsetDefaultConfig,
-    type: []const u8,
+    @"type": []const u8,
     configs: []const BetaManagedAgentsAgentToolConfig,
 };
 
@@ -10773,14 +10773,14 @@ pub const BetaManagedAgentsArchiveMemoryStoreResponse = union(enum) {
 pub const BetaManagedAgentsCustomToolParamsInputSchema = struct {
     properties: ?std.json.Value = null,
     required: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCustomToolParams = struct {
     description: []const u8,
     input_schema: BetaManagedAgentsCustomToolParamsInputSchema,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const Message = struct {
@@ -10791,7 +10791,7 @@ pub const Message = struct {
     usage: Usage,
     model: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     stop_sequence: ?[]const u8,
     content: []const ContentBlock,
 };
@@ -10800,7 +10800,7 @@ pub const RefusalCategory = []const u8;
 
 pub const BetaManagedAgentsTokenEndpointAuthBasicUpdateParam = struct {
     client_secret: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaResponseTextEditorCodeExecutionViewResultBlock = struct {
@@ -10808,7 +10808,7 @@ pub const BetaResponseTextEditorCodeExecutionViewResultBlock = struct {
     file_type: []const u8,
     num_lines: ?i64,
     start_line: ?i64,
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -10819,11 +10819,11 @@ pub const BetaMemoryTool_20250818_DeleteCommand = struct {
 
 pub const RequestCodeExecutionToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaServerToolCaller = struct {
-    type: []const u8,
+    @"type": []const u8,
     tool_id: []const u8,
 };
 
@@ -10831,11 +10831,11 @@ pub const BetaWebhookEvent = struct {
     created_at: []const u8,
     data: BetaWebhookEventData,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaDirectCaller = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsSendSessionEventsParams = struct {
@@ -10853,17 +10853,17 @@ pub const BetaWebSearchTool_20260318 = struct {
     user_location: ?BetaUserLocation = null,
     allowed_domains: ?[]const []const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TextContentBlockDelta = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRequestAdvisorToolResultError = struct {
     error_code: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaCreateMessageParamsSystemVariant0 = []const u8;
@@ -11073,7 +11073,7 @@ pub const BetaCreateMessageParams = struct {
 };
 
 pub const BetaManagedAgentsUnknownRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -11117,7 +11117,7 @@ pub const BetaManagedAgentsAgentUnionParams = union(enum) {
 pub const BetaWebhookSessionUpdatedEventData = struct {
     organization_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     workspace_id: []const u8,
 };
 
@@ -11153,22 +11153,22 @@ pub const ResponseWebSearchToolResultBlockContent = union(enum) {
 pub const ResponseWebSearchToolResultBlock = struct {
     tool_use_id: []const u8,
     caller: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     content: ResponseWebSearchToolResultBlockContent,
 };
 
 pub const BetaManagedAgentsStaticBearerUpdateParams = struct {
     token: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaMessageStartEvent = struct {
     message: BetaMessage,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsCronScheduleParams = struct {
-    type: []const u8,
+    @"type": []const u8,
     expression: []const u8,
     timezone: []const u8,
 };
@@ -11181,7 +11181,7 @@ pub const BetaMessageBatchIndividualResponse = struct {
 pub const BetaEnvironment = struct {
     created_at: []const u8,
     scope: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     archived_at: ?[]const u8,
     description: []const u8,
     metadata: std.json.Value,
@@ -11197,7 +11197,7 @@ pub const BetaResponseCharLocationCitation = struct {
     document_index: i64,
     end_char_index: i64,
     cited_text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     start_char_index: i64,
 };
 
@@ -11205,7 +11205,7 @@ pub const BetaManagedAgentsSessionStatus = []const u8;
 
 pub const GatewayTimeoutError = struct {
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaManagedAgentsAgentToolsetDefaultConfig = struct {
@@ -11214,7 +11214,7 @@ pub const BetaManagedAgentsAgentToolsetDefaultConfig = struct {
 };
 
 pub const BetaManagedAgentsSessionRetriesExhausted = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const BetaRotateTunnelTokenRequestBody = struct {
@@ -11222,7 +11222,7 @@ pub const BetaRotateTunnelTokenRequestBody = struct {
 };
 
 pub const BetaManagedAgentsMcpEgressBlockedRunError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -11275,14 +11275,14 @@ pub const BetaMessageStreamEvent = union(enum) {
 
 pub const ResponseCodeExecutionOutputBlock = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const JsonValue = std.json.Value;
 
 pub const BetaManagedAgentsStruct = union(enum) {
     null,
-    bool: bool,
+    @"bool": bool,
     integer: i64,
     float: f64,
     number_string: []const u8,
@@ -11360,7 +11360,7 @@ pub const BetaRequestBashCodeExecutionToolResultBlockContent = union(enum) {
 pub const BetaRequestBashCodeExecutionToolResultBlock = struct {
     cache_control: ?std.json.Value = null,
     tool_use_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: BetaRequestBashCodeExecutionToolResultBlockContent,
 };
 
@@ -11396,7 +11396,7 @@ pub const BetaContentBlockSourceContent = union(enum) {
 };
 
 pub const BetaContentBlockSource = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: BetaContentBlockSourceContent,
 };
 
@@ -11411,7 +11411,7 @@ pub const BetaManagedAgentsUserToolResultEvent = struct {
     tool_use_id: []const u8,
     is_error: ?bool = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: ?[]const BetaManagedAgentsToolResultContentBlock = null,
 };
 
@@ -11419,7 +11419,7 @@ pub const RequestTextEditorCodeExecutionStrReplaceResultBlock = struct {
     old_lines: ?i64 = null,
     new_lines: ?i64 = null,
     old_start: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
     lines: ?[]const []const u8 = null,
     new_start: ?i64 = null,
 };
@@ -11429,7 +11429,7 @@ pub const BetaUserProfileListOrder = []const u8;
 pub const ResponseDocumentBlock = struct {
     source: std.json.Value,
     citations: ?ResponseCitationsConfig,
-    type: []const u8,
+    @"type": []const u8,
     title: ?[]const u8,
 };
 

--- a/generated/generated_v2.zig
+++ b/generated/generated_v2.zig
@@ -46,7 +46,7 @@ pub const Order = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/generated_v2_yaml.zig
+++ b/generated/generated_v2_yaml.zig
@@ -21,7 +21,7 @@ pub const Pet = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/generated_v3.zig
+++ b/generated/generated_v3.zig
@@ -59,7 +59,7 @@ pub const User = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/generated_v32.zig
+++ b/generated/generated_v32.zig
@@ -46,7 +46,7 @@ pub const Order = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/generated_v3_multiclient_endpoint.zig
+++ b/generated/generated_v3_multiclient_endpoint.zig
@@ -59,7 +59,7 @@ pub const User = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/generated_v3_multiclient_tag.zig
+++ b/generated/generated_v3_multiclient_tag.zig
@@ -59,7 +59,7 @@ pub const User = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/generated_v3_tagfilter.zig
+++ b/generated/generated_v3_tagfilter.zig
@@ -35,7 +35,7 @@ pub const Pet = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/generated_v3_yaml.zig
+++ b/generated/generated_v3_yaml.zig
@@ -59,7 +59,7 @@ pub const User = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/lmstudio-multi/types.zig
+++ b/generated/lmstudio-multi/types.zig
@@ -19,7 +19,7 @@ pub const UnloadModelRequest = struct {
 };
 
 pub const ReasoningOutput = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -82,7 +82,7 @@ pub const LoadedInstance = struct {
 };
 
 pub const TextInput = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -127,7 +127,7 @@ pub const ModelInfo = struct {
     loaded_instances: []const LoadedInstance,
     quantization: ?ModelInfoQuantization = null,
     description: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const EmbeddingLoadConfig = struct {
@@ -148,7 +148,7 @@ pub const DownloadStatusResponse = struct {
 pub const PluginIntegration = struct {
     allowed_tools: ?[]const []const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatStats = struct {
@@ -256,7 +256,7 @@ pub const ChatRequest = struct {
 };
 
 pub const MessageOutput = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -271,7 +271,7 @@ pub const LoadedInstanceConfig = struct {
 
 pub const ImageInput = struct {
     data_url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UnloadModelResponse = struct {
@@ -281,14 +281,14 @@ pub const UnloadModelResponse = struct {
 pub const InvalidToolCallOutputMetadata = struct {
     arguments: ?std.json.Value = null,
     tool_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     provider_info: ?ProviderInfo = null,
 };
 
 pub const InvalidToolCallOutput = struct {
     metadata: InvalidToolCallOutputMetadata,
     reason: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const LoadModelResponseLoadConfig = union(enum) {
@@ -323,11 +323,11 @@ pub const LoadModelResponse = struct {
     status: []const u8,
     instance_id: []const u8,
     load_config: ?LoadModelResponseLoadConfig = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ProviderInfo = struct {
-    type: []const u8,
+    @"type": []const u8,
     plugin_id: ?[]const u8 = null,
     server_label: ?[]const u8 = null,
 };
@@ -366,7 +366,7 @@ pub const ChatInputItem = union(enum) {
 pub const EphemeralMcpIntegration = struct {
     server_url: []const u8,
     allowed_tools: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     headers: ?std.json.Value = null,
     server_label: []const u8,
 };
@@ -375,7 +375,7 @@ pub const ToolCallOutput = struct {
     arguments: std.json.Value,
     tool: []const u8,
     output: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     provider_info: ProviderInfo,
 };
 

--- a/generated/lmstudio.zig
+++ b/generated/lmstudio.zig
@@ -19,7 +19,7 @@ pub const UnloadModelRequest = struct {
 };
 
 pub const ReasoningOutput = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -82,7 +82,7 @@ pub const LoadedInstance = struct {
 };
 
 pub const TextInput = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -127,7 +127,7 @@ pub const ModelInfo = struct {
     loaded_instances: []const LoadedInstance,
     quantization: ?ModelInfoQuantization = null,
     description: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const EmbeddingLoadConfig = struct {
@@ -148,7 +148,7 @@ pub const DownloadStatusResponse = struct {
 pub const PluginIntegration = struct {
     allowed_tools: ?[]const []const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatStats = struct {
@@ -256,7 +256,7 @@ pub const ChatRequest = struct {
 };
 
 pub const MessageOutput = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const u8,
 };
 
@@ -271,7 +271,7 @@ pub const LoadedInstanceConfig = struct {
 
 pub const ImageInput = struct {
     data_url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UnloadModelResponse = struct {
@@ -281,14 +281,14 @@ pub const UnloadModelResponse = struct {
 pub const InvalidToolCallOutputMetadata = struct {
     arguments: ?std.json.Value = null,
     tool_name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     provider_info: ?ProviderInfo = null,
 };
 
 pub const InvalidToolCallOutput = struct {
     metadata: InvalidToolCallOutputMetadata,
     reason: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const LoadModelResponseLoadConfig = union(enum) {
@@ -323,11 +323,11 @@ pub const LoadModelResponse = struct {
     status: []const u8,
     instance_id: []const u8,
     load_config: ?LoadModelResponseLoadConfig = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ProviderInfo = struct {
-    type: []const u8,
+    @"type": []const u8,
     plugin_id: ?[]const u8 = null,
     server_label: ?[]const u8 = null,
 };
@@ -366,7 +366,7 @@ pub const ChatInputItem = union(enum) {
 pub const EphemeralMcpIntegration = struct {
     server_url: []const u8,
     allowed_tools: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     headers: ?std.json.Value = null,
     server_label: []const u8,
 };
@@ -375,7 +375,7 @@ pub const ToolCallOutput = struct {
     arguments: std.json.Value,
     tool: []const u8,
     output: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     provider_info: ProviderInfo,
 };
 

--- a/generated/multi/models.zig
+++ b/generated/multi/models.zig
@@ -59,7 +59,7 @@ pub const User = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/multiple-clients/endpoint/models.zig
+++ b/generated/multiple-clients/endpoint/models.zig
@@ -59,7 +59,7 @@ pub const User = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/multiple-clients/tag/models.zig
+++ b/generated/multiple-clients/tag/models.zig
@@ -59,7 +59,7 @@ pub const User = struct {
 };
 
 pub const ApiResponse = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     code: ?i64 = null,
 };

--- a/generated/openai.zig
+++ b/generated/openai.zig
@@ -29,7 +29,7 @@ pub const FineTuningJobCheckpoint = struct {
 pub const ApplyPatchCreateFileOperationParam = struct {
     path: []const u8,
     diff: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateGroupBody = struct {
@@ -57,7 +57,7 @@ pub const DoneEvent = struct {
 pub const RealtimeBetaServerEventInputAudioBufferCommitted = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     previous_item_id: ?[]const u8 = null,
 };
 
@@ -66,7 +66,7 @@ pub const FunctionShellCallItemStatus = []const u8;
 pub const RealtimeBetaResponseCreateParamsToolsItem = struct {
     description: ?[]const u8 = null,
     name: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     parameters: ?std.json.Value = null,
 };
 
@@ -151,14 +151,14 @@ pub const RealtimeBetaResponseCreateParams = struct {
 pub const RealtimeClientEventConversationItemRetrieve = struct {
     event_id: ?[]const u8 = null,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseContentPartDoneEvent = struct {
     sequence_number: i64,
     item_id: []const u8,
     output_index: i64,
-    type: []const u8,
+    @"type": []const u8,
     part: OutputContent,
     content_index: i64,
 };
@@ -176,7 +176,7 @@ pub const ContainerListResource = struct {
 pub const EvalGraderPython = struct {
     source: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     image_tag: ?[]const u8 = null,
     pass_threshold: ?f64 = null,
 };
@@ -234,7 +234,7 @@ pub const ResponsesClientEventResponseCreate = struct {
     text: ?ResponseTextParam = null,
     metadata: ?Metadata = null,
     input: ?InputParam = null,
-    type: []const u8,
+    @"type": []const u8,
     previous_response_id: ?[]const u8 = null,
     top_logprobs: ?i64 = null,
     reasoning: ?Reasoning = null,
@@ -260,17 +260,17 @@ pub const ResponseTextParam = struct {
 
 pub const ApplyPatchDeleteFileOperation = struct {
     path: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FunctionShellCallOutputExitOutcomeParam = struct {
     exit_code: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FileAnnotation = struct {
     source: FileAnnotationSource,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEventResponseAudioDelta = struct {
@@ -279,7 +279,7 @@ pub const RealtimeServerEventResponseAudioDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -287,7 +287,7 @@ pub const RealtimeServerEventInputAudioBufferTimeoutTriggered = struct {
     event_id: []const u8,
     audio_start_ms: i64,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     audio_end_ms: i64,
 };
 
@@ -308,12 +308,12 @@ pub const EvalResponsesSource = struct {
     created_after: ?i64 = null,
     metadata: ?EvalResponsesSourceMetadata = null,
     model: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     instructions_search: ?[]const u8 = null,
 };
 
 pub const SpecificApplyPatchParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FileSearchRankingOptions = struct {
@@ -367,14 +367,14 @@ pub const CustomToolParamFormat = union(enum) {
 pub const CustomToolParam = struct {
     description: ?[]const u8 = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     format: ?CustomToolParamFormat = null,
     defer_loading: ?bool = null,
 };
 
 pub const EmptyModelParam = union(enum) {
     null,
-    bool: bool,
+    @"bool": bool,
     integer: i64,
     float: f64,
     number_string: []const u8,
@@ -435,28 +435,28 @@ pub const ProjectApiKeyOwnerServiceAccount = struct {
 };
 
 pub const ResponseAudioTranscriptDoneEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
 };
 
 pub const StaticChunkingStrategyResponseParam = struct {
-    type: []const u8,
+    @"type": []const u8,
     static: StaticChunkingStrategy,
 };
 
 pub const CreateEvalCustomDataSourceConfig = struct {
-    type: []const u8,
+    @"type": []const u8,
     item_schema: std.json.Value,
     include_sample_schema: ?bool = null,
 };
 
 pub const ChatCompletionAllowedToolsChoice = struct {
     allowed_tools: ChatCompletionAllowedTools,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeMCPHTTPError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
     code: i64,
 };
@@ -464,7 +464,7 @@ pub const RealtimeMCPHTTPError = struct {
 pub const InputMessage = struct {
     status: ?[]const u8 = null,
     role: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     content: InputMessageContentList,
 };
 
@@ -482,7 +482,7 @@ pub const ProjectApiKeyDeleteResponse = struct {
 
 pub const InputTextContent = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateCompletionResponseChoicesItemLogprobs = ?std.json.Value;
@@ -505,13 +505,13 @@ pub const CreateCompletionResponse = struct {
 };
 
 pub const ScreenshotParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ApplyPatchUpdateFileOperationParam = struct {
     path: []const u8,
     diff: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UsageImagesResult = struct {
@@ -529,7 +529,7 @@ pub const UsageImagesResult = struct {
 pub const RealtimeServerEventMCPListToolsCompleted = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateFineTuningJobRequestIntegrationsItemWandb = struct {
@@ -541,7 +541,7 @@ pub const CreateFineTuningJobRequestIntegrationsItemWandb = struct {
 
 pub const CreateFineTuningJobRequestIntegrationsItem = struct {
     wandb: CreateFineTuningJobRequestIntegrationsItemWandb,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateFineTuningJobRequestHyperparametersLearningRateMultiplier = union(enum) {
@@ -676,7 +676,7 @@ pub const CreateSkillVersionBody = struct {
 };
 
 pub const ResponseAudioDoneEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
 };
 
@@ -713,7 +713,7 @@ pub const CompoundFilterItem = union(enum) {
 };
 
 pub const CompoundFilter = struct {
-    type: []const u8,
+    @"type": []const u8,
     filters: []const CompoundFilterItem,
 };
 
@@ -721,7 +721,7 @@ pub const RealtimeServerEventInputAudioBufferSpeechStarted = struct {
     event_id: []const u8,
     audio_start_ms: i64,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CustomToolCallResource = struct {
@@ -732,7 +732,7 @@ pub const CustomToolCallResource = struct {
     name: []const u8,
     id: []const u8,
     input: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ErrorEvent = struct {
@@ -744,7 +744,7 @@ pub const ResponseImageGenCallPartialImageEvent = struct {
     output_index: i64,
     item_id: []const u8,
     partial_image_b64: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     partial_image_index: i64,
 };
@@ -777,7 +777,7 @@ pub const FunctionShellCallItemParam = struct {
     environment: ?FunctionShellCallItemParamEnvironment = null,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     action: FunctionShellActionParam,
 };
 
@@ -787,13 +787,13 @@ pub const RealtimeBetaServerEventResponseTextDone = struct {
     response_id: []const u8,
     item_id: []const u8,
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const ApplyPatchDeleteFileOperationParam = struct {
     path: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UsageAudioTranscriptionsResult = struct {
@@ -808,7 +808,7 @@ pub const UsageAudioTranscriptionsResult = struct {
 
 pub const RealtimeServerEventResponseCreated = struct {
     event_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     response: RealtimeResponse,
 };
 
@@ -848,7 +848,7 @@ pub const CodeInterpreterToolCall = struct {
     code: ?[]const u8,
     outputs: ?[]const CodeInterpreterToolCallOutputsItem,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     container_id: []const u8,
 };
 
@@ -898,12 +898,12 @@ pub const CreateEvalResponsesRunDataSourceInputMessagesVariant0TemplateItem = un
 
 pub const CreateEvalResponsesRunDataSourceInputMessagesVariant0 = struct {
     template: []const CreateEvalResponsesRunDataSourceInputMessagesVariant0TemplateItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateEvalResponsesRunDataSourceInputMessagesVariant1 = struct {
     item_reference: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateEvalResponsesRunDataSourceInputMessages = union(enum) {
@@ -984,7 +984,7 @@ pub const CreateEvalResponsesRunDataSource = struct {
     source: CreateEvalResponsesRunDataSourceSource,
     model: ?[]const u8 = null,
     sampling_params: ?CreateEvalResponsesRunDataSourceSamplingParams = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatSessionChatkitConfiguration = struct {
@@ -1014,7 +1014,7 @@ pub const CreateChatCompletionResponse = struct {
 };
 
 pub const SpecificFunctionShellParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ListFineTuningCheckpointPermissionResponse = struct {
@@ -1029,7 +1029,7 @@ pub const ResponseFunctionCallArgumentsDoneEvent = struct {
     item_id: []const u8,
     arguments: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -1068,7 +1068,7 @@ pub const MessageContentTextObjectText = struct {
 
 pub const MessageContentTextObject = struct {
     text: MessageContentTextObjectText,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RunStepCompletionUsage = ?std.json.Value;
@@ -1106,7 +1106,7 @@ pub const ModifyCertificateRequest = struct {
 
 pub const TranscriptTextUsageDuration = struct {
     seconds: f64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UploadPart = struct {
@@ -1134,7 +1134,7 @@ pub const ChatCompletionMessageToolCallChunkFunction = struct {
 pub const ChatCompletionMessageToolCallChunk = struct {
     id: ?[]const u8 = null,
     index: i64,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     function: ?ChatCompletionMessageToolCallChunkFunction = null,
 };
 
@@ -1142,7 +1142,7 @@ pub const SearchContextSize = []const u8;
 
 pub const RealtimeTranslationClientEventInputAudioBufferAppend = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     audio: []const u8,
 };
 
@@ -1195,13 +1195,13 @@ pub const FineTuneReinforcementMethod = struct {
 
 pub const ResponseImageGenCallCompletedEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
 
 pub const ResponseInProgressEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     response: Response,
     sequence_number: i64,
 };
@@ -1221,14 +1221,14 @@ pub const AuditLogActorUser = struct {
 
 pub const RealtimeBetaServerEventInputAudioBufferCleared = struct {
     event_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TextResponseFormatJsonSchema = struct {
     description: ?[]const u8 = null,
     schema: ResponseFormatJsonSchemaSchema,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     strict: ?bool = null,
 };
 
@@ -1273,7 +1273,7 @@ pub const ApplyPatchToolCall = struct {
     operation: ApplyPatchToolCallOperation,
     call_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     created_by: ?[]const u8 = null,
 };
 
@@ -1288,7 +1288,7 @@ pub const ProjectUserListResponse = struct {
 pub const RealtimeBetaServerEventMCPListToolsFailed = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionRequestSystemMessageContentPart = union(enum) {
@@ -1399,7 +1399,7 @@ pub const VectorStoreSearchRequest = struct {
 
 pub const InputTextContentParam = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionModalities = ?[]const []const u8;
@@ -1419,7 +1419,7 @@ pub const CreateSpeechRequest = struct {
 pub const RealtimeServerEventResponseContentPartAddedPart = struct {
     text: ?[]const u8 = null,
     transcript: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     audio: ?[]const u8 = null,
 };
 
@@ -1429,13 +1429,13 @@ pub const RealtimeServerEventResponseContentPartAdded = struct {
     event_id: []const u8,
     response_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const RealtimeClientEventInputAudioBufferAppend = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     audio: []const u8,
 };
 
@@ -1456,7 +1456,7 @@ pub const LocalShellToolCall = struct {
     status: []const u8,
     call_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     action: LocalShellExecAction,
 };
 
@@ -1464,7 +1464,7 @@ pub const RunStepDeltaStepDetailsToolCallsFileSearchObject = struct {
     file_search: std.json.Value,
     id: ?[]const u8 = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatSessionFileUpload = struct {
@@ -1537,7 +1537,7 @@ pub const CreateEvalItem = union(enum) {
 };
 
 pub const RealtimeMCPToolExecutionError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
 };
 
@@ -1554,7 +1554,7 @@ pub const RealtimeServerEventResponseFunctionCallArgumentsDone = struct {
     item_id: []const u8,
     arguments: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -1566,7 +1566,7 @@ pub const RealtimeTruncationVariant1TokenLimits = struct {
 
 pub const RealtimeTruncationVariant1 = struct {
     token_limits: ?RealtimeTruncationVariant1TokenLimits = null,
-    type: []const u8,
+    @"type": []const u8,
     retention_ratio: f64,
 };
 
@@ -1601,7 +1601,7 @@ pub const RealtimeTruncation = union(enum) {
 pub const RealtimeBetaServerEventInputAudioBufferSpeechStopped = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     audio_end_ms: i64,
 };
 
@@ -1617,7 +1617,7 @@ pub const FileSearchToolCall = struct {
     status: []const u8,
     results: ?[]const FileSearchToolCallResultsItem = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     queries: []const []const u8,
 };
 
@@ -1633,7 +1633,7 @@ pub const UrlCitationBody = struct {
     end_index: i64,
     url: []const u8,
     start_index: i64,
-    type: []const u8,
+    @"type": []const u8,
     title: []const u8,
 };
 
@@ -1643,20 +1643,20 @@ pub const WidgetMessageItem = struct {
     thread_id: []const u8,
     widget: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const Error = struct {
     code: ?[]const u8,
     message: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     param: ?[]const u8,
 };
 
 pub const MCPApprovalResponse = struct {
     approve: bool,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     reason: ?[]const u8 = null,
     approval_request_id: []const u8,
 };
@@ -1684,7 +1684,7 @@ pub const RealtimeTranscriptionSessionCreateResponseClientSecret = struct {
 
 pub const RealtimeTranscriptionSessionCreateResponseTurnDetection = struct {
     threshold: ?f64 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     prefix_padding_ms: ?i64 = null,
     silence_duration_ms: ?i64 = null,
 };
@@ -1701,7 +1701,7 @@ pub const RealtimeConversationItemWithReferenceContentItem = struct {
     text: ?[]const u8 = null,
     transcript: ?[]const u8 = null,
     id: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     audio: ?[]const u8 = null,
 };
 
@@ -1714,14 +1714,14 @@ pub const RealtimeConversationItemWithReference = struct {
     arguments: ?[]const u8 = null,
     name: ?[]const u8 = null,
     id: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     role: ?[]const u8 = null,
 };
 
 pub const RealtimeBetaServerEventErrorError = struct {
     event_id: ?[]const u8 = null,
     code: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
     param: ?[]const u8 = null,
 };
@@ -1729,7 +1729,7 @@ pub const RealtimeBetaServerEventErrorError = struct {
 pub const RealtimeBetaServerEventError = struct {
     event_id: []const u8,
     @"error": RealtimeBetaServerEventErrorError,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ImageGenToolSize = []const u8;
@@ -1752,7 +1752,7 @@ pub const ImageGenTool = struct {
     model: ?[]const u8 = null,
     action: ?[]const u8 = null,
     input_image_mask: ?ImageGenToolInputImageMask = null,
-    type: []const u8,
+    @"type": []const u8,
     input_fidelity: ?[]const u8 = null,
 };
 
@@ -1817,7 +1817,7 @@ pub const RunStepObject = struct {
     thread_id: []const u8,
     run_id: []const u8,
     metadata: Metadata,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateVoiceRequest = struct {
@@ -1864,13 +1864,13 @@ pub const EvalRunOutputItemResult = struct {
     score: f64,
     sample: ?EvalRunOutputItemResultSample = null,
     name: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const MCPApprovalResponseResource = struct {
     approve: bool,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     reason: ?[]const u8 = null,
     approval_request_id: []const u8,
 };
@@ -1892,7 +1892,7 @@ pub const MessageDeltaContentTextAnnotationsFilePathObject = struct {
     end_index: ?i64 = null,
     start_index: ?i64 = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
     file_path: ?MessageDeltaContentTextAnnotationsFilePathObjectFilePath = null,
 };
 
@@ -1912,14 +1912,14 @@ pub const RealtimeResponseAudio = struct {
 };
 
 pub const RealtimeResponseStatusDetailsError = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     code: ?[]const u8 = null,
 };
 
 pub const RealtimeResponseStatusDetails = struct {
     @"error": ?RealtimeResponseStatusDetailsError = null,
     reason: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeResponseUsageInputTokenDetailsCachedTokensDetails = struct {
@@ -2321,7 +2321,7 @@ pub const AuditLog = struct {
     @"external_key.registered": ?AuditLogExternalKeyRegistered = null,
     @"ip_allowlist.config.deactivated": ?AuditLogIpAllowlistConfigDeactivated = null,
     @"certificate.created": ?AuditLogCertificateCreated = null,
-    type: []const u8,
+    @"type": []const u8,
     @"scim.disabled": ?AuditLogScimDisabled = null,
     @"invite.sent": ?AuditLogInviteSent = null,
     @"rate_limit.updated": ?AuditLogRateLimitUpdated = null,
@@ -2369,27 +2369,27 @@ pub const AuditLog = struct {
 
 pub const ResponseCodeInterpreterCallCompletedEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
 
 pub const TypeParam = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ApplyPatchToolCallOutputItemParam = struct {
     status: []const u8,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     output: ?[]const u8 = null,
 };
 
 pub const ResponseWebSearchCallSearchingEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -2432,7 +2432,7 @@ pub const RunObjectIncompleteDetails = struct {
 
 pub const RunObjectTruncationStrategy = struct {
     last_messages: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RunObjectRequiredActionSubmitToolOutputs = struct {
@@ -2441,7 +2441,7 @@ pub const RunObjectRequiredActionSubmitToolOutputs = struct {
 
 pub const RunObjectRequiredAction = struct {
     submit_tool_outputs: RunObjectRequiredActionSubmitToolOutputs,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RunObjectLastError = struct {
@@ -2480,7 +2480,7 @@ pub const RunObject = struct {
 };
 
 pub const MessageContentRefusalObject = struct {
-    type: []const u8,
+    @"type": []const u8,
     refusal: []const u8,
 };
 
@@ -2532,19 +2532,19 @@ pub const ValidateGraderResponse = struct {
 
 pub const RealtimeTranslationClientEventSessionClose = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const EvalItemInputImage = struct {
     image_url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     detail: ?[]const u8 = null,
 };
 
 pub const GraderStringCheck = struct {
     operation: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: []const u8,
     reference: []const u8,
 };
@@ -2554,7 +2554,7 @@ pub const AssistantsNamedToolChoiceFunction = struct {
 };
 
 pub const AssistantsNamedToolChoice = struct {
-    type: []const u8,
+    @"type": []const u8,
     function: ?AssistantsNamedToolChoiceFunction = null,
 };
 
@@ -2601,7 +2601,7 @@ pub const DeletedConversationResource = struct {
 pub const AuditLogActor = struct {
     session: ?AuditLogActorSession = null,
     api_key: ?AuditLogActorApiKey = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const CostsResultAmount = struct {
@@ -2651,7 +2651,7 @@ pub const CreateSpeechResponseStreamEvent = union(enum) {
 
 pub const EvalCustomDataSourceConfig = struct {
     schema: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FineTuneSupervisedHyperparametersLearningRateMultiplier = union(enum) {
@@ -2739,7 +2739,7 @@ pub const FunctionShellToolParamEnvironment = ?std.json.Value;
 
 pub const FunctionShellToolParam = struct {
     environment: ?FunctionShellToolParamEnvironment = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const @"ConversationParam-2" = struct {
@@ -2749,7 +2749,7 @@ pub const @"ConversationParam-2" = struct {
 pub const RealtimeBetaServerEventConversationItemCreated = struct {
     event_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     previous_item_id: ?[]const u8 = null,
 };
 
@@ -2789,12 +2789,12 @@ pub const CreateEvalJsonlRunDataSourceSource = union(enum) {
 
 pub const CreateEvalJsonlRunDataSource = struct {
     source: CreateEvalJsonlRunDataSourceSource,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const VadConfig = struct {
     threshold: ?f64 = null,
-    type: []const u8,
+    @"type": []const u8,
     prefix_padding_ms: ?i64 = null,
     silence_duration_ms: ?i64 = null,
 };
@@ -2803,7 +2803,7 @@ pub const TruncationEnum = []const u8;
 
 pub const VectorStoreSearchResultContentObject = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const EasyInputMessageContentVariant0 = []const u8;
@@ -2838,7 +2838,7 @@ pub const EasyInputMessageContent = union(enum) {
 pub const EasyInputMessage = struct {
     phase: ?[]const u8 = null,
     role: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     content: EasyInputMessageContent,
 };
 
@@ -2850,7 +2850,7 @@ pub const DeleteCertificateResponse = struct {
 pub const MessagePhase = []const u8;
 
 pub const LocalShellToolParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebhookEvalRunSucceededData = struct {
@@ -2862,7 +2862,7 @@ pub const WebhookEvalRunSucceeded = struct {
     data: WebhookEvalRunSucceededData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const AssistantsApiResponseFormatOptionVariant0 = []const u8;
@@ -2910,25 +2910,25 @@ pub const ChatCompletionMessageCustomToolCallCustom = struct {
 pub const ChatCompletionMessageCustomToolCall = struct {
     custom: ChatCompletionMessageCustomToolCallCustom,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const SkillReferenceParam = struct {
     version: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     skill_id: []const u8,
 };
 
 pub const LocalEnvironmentParam = struct {
     skills: ?[]const LocalSkillParam = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebSearchPreviewTool = struct {
     search_context_size: ?[]const u8 = null,
     search_content_types: ?[]const SearchContentType = null,
     user_location: ?ApproximateLocation = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatkitWorkflowTracing = struct {
@@ -2937,7 +2937,7 @@ pub const ChatkitWorkflowTracing = struct {
 
 pub const RealtimeClientEventOutputAudioBufferClear = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ThreadResourceStatus = union(enum) {
@@ -2988,19 +2988,19 @@ pub const ThreadResource = struct {
 pub const RealtimeBetaServerEventResponseMCPCallCompleted = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const ResponseCodeInterpreterCallInterpretingEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
 
 pub const ResponseFormatText = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEventResponseTextDelta = struct {
@@ -3009,7 +3009,7 @@ pub const RealtimeServerEventResponseTextDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -3064,7 +3064,7 @@ pub const TranscriptTextUsageTokens = struct {
     input_token_details: ?TranscriptTextUsageTokensInputTokenDetails = null,
     output_tokens: i64,
     total_tokens: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaServerEventConversationItemInputAudioTranscriptionDelta = struct {
@@ -3072,7 +3072,7 @@ pub const RealtimeBetaServerEventConversationItemInputAudioTranscriptionDelta = 
     item_id: []const u8,
     delta: ?[]const u8 = null,
     logprobs: ?[]const LogProbProperties = null,
-    type: []const u8,
+    @"type": []const u8,
     content_index: ?i64 = null,
 };
 
@@ -3180,19 +3180,19 @@ pub const RealtimeTranslationServerEvent = union(enum) {
 pub const RealtimeServerEventResponseMCPCallCompleted = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const CodeInterpreterOutputLogs = struct {
     logs: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FileCitationBody = struct {
     file_id: []const u8,
     filename: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     index: i64,
 };
 
@@ -3204,7 +3204,7 @@ pub const ResponseOutputTextAnnotationAddedEvent = struct {
     annotation_index: i64,
     content_index: i64,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -3219,7 +3219,7 @@ pub const RunStepDeltaStepDetailsToolCallsCodeOutputImageObjectImage = struct {
 pub const RunStepDeltaStepDetailsToolCallsCodeOutputImageObject = struct {
     image: ?RunStepDeltaStepDetailsToolCallsCodeOutputImageObjectImage = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const StopConfigurationVariant0 = []const u8;
@@ -3257,7 +3257,7 @@ pub const FunctionShellCallStatus = []const u8;
 
 pub const ResponseOutputItemAddedEvent = struct {
     item: OutputItem,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -3266,7 +3266,7 @@ pub const RealtimeServerEventResponseOutputItemAdded = struct {
     event_id: []const u8,
     response_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -3274,7 +3274,7 @@ pub const OutputTextContent = struct {
     text: []const u8,
     annotations: []const Annotation,
     logprobs: []const LogProb,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateChatCompletionStreamResponseChoicesItemLogprobs = struct {
@@ -3325,12 +3325,12 @@ pub const ChatCompletionRequestToolMessageContentPart = union(enum) {
 pub const CompactionSummaryItemParam = struct {
     encrypted_content: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ReasoningTextContent = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeCreateClientSecretRequestExpiresAfter = struct {
@@ -3419,7 +3419,7 @@ pub const ChatCompletionMessageToolCallFunction = struct {
 
 pub const ChatCompletionMessageToolCall = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     function: ChatCompletionMessageToolCallFunction,
 };
 
@@ -3436,14 +3436,14 @@ pub const Reasoning = struct {
 
 pub const ResponseMCPCallCompletedEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
 
 pub const VectorStoreFileContentResponseDataItem = struct {
     text: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const VectorStoreFileContentResponse = struct {
@@ -3515,7 +3515,7 @@ pub const CustomToolCallOutputResource = struct {
     status: []const u8,
     call_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output: CustomToolCallOutputResourceOutput,
     created_by: ?[]const u8 = null,
 };
@@ -3531,7 +3531,7 @@ pub const ListBatchesResponse = struct {
 pub const RealtimeBetaServerEventConversationItemTruncated = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     audio_end_ms: i64,
     content_index: i64,
 };
@@ -3545,7 +3545,7 @@ pub const WebhookResponseCancelled = struct {
     data: WebhookResponseCancelledData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const EvalRunOutputItemSampleOutputItem = struct {
@@ -3593,14 +3593,14 @@ pub const EvalRunOutputItem = struct {
 
 pub const RealtimeConversationItemMessageSystemContentItem = struct {
     text: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeConversationItemMessageSystem = struct {
     object: ?[]const u8 = null,
     status: ?[]const u8 = null,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     role: []const u8,
     content: []const RealtimeConversationItemMessageSystemContentItem,
 };
@@ -3653,7 +3653,7 @@ pub const RealtimeBetaServerEventResponseTextDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -3662,7 +3662,7 @@ pub const RealtimeServerEventConversationItemInputAudioTranscriptionDelta = stru
     item_id: []const u8,
     delta: ?[]const u8 = null,
     logprobs: ?[]const LogProbProperties = null,
-    type: []const u8,
+    @"type": []const u8,
     content_index: ?i64 = null,
 };
 
@@ -3705,7 +3705,7 @@ pub const ApplyPatchOperationParam = union(enum) {
 pub const RealtimeServerEventTranscriptionSessionUpdated = struct {
     event_id: []const u8,
     session: RealtimeTranscriptionSessionCreateResponse,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UserUser = struct {
@@ -3749,7 +3749,7 @@ pub const RealtimeServerEventResponseAudioDone = struct {
     response_id: []const u8,
     item_id: []const u8,
     output_index: i64,
-    type: []const u8,
+    @"type": []const u8,
     content_index: i64,
 };
 
@@ -3857,7 +3857,7 @@ pub const Invite = struct {
 pub const RealtimeTranslationServerEventSessionUpdated = struct {
     event_id: []const u8,
     session: RealtimeTranslationSession,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UserMessageItemContentItem = union(enum) {
@@ -3898,20 +3898,20 @@ pub const UserMessageItem = struct {
     object: []const u8,
     thread_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const UserMessageItemContentItem,
 };
 
 pub const FunctionShellCallOutputExitOutcome = struct {
     exit_code: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const GraderLabelModel = struct {
     passing_labels: []const []const u8,
     model: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: []const EvalItem,
     labels: []const []const u8,
 };
@@ -3924,7 +3924,7 @@ pub const HistoryParam = struct {
 pub const RealtimeServerEventMCPListToolsInProgress = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ComputerCallOutputStatus = []const u8;
@@ -3933,7 +3933,7 @@ pub const AudioResponseFormat = []const u8;
 
 pub const FilePath = struct {
     file_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     index: i64,
 };
 
@@ -3946,7 +3946,7 @@ pub const PublicCreateOrganizationRoleBody = struct {
 pub const RealtimeServerEventResponseContentPartDonePart = struct {
     text: ?[]const u8 = null,
     transcript: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     audio: ?[]const u8 = null,
 };
 
@@ -3956,7 +3956,7 @@ pub const RealtimeServerEventResponseContentPartDone = struct {
     event_id: []const u8,
     response_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -4050,7 +4050,7 @@ pub const ResponseCustomToolCallInputDoneEvent = struct {
     output_index: i64,
     item_id: []const u8,
     input: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
 };
 
@@ -4202,18 +4202,18 @@ pub const ItemField = union(enum) {
 
 pub const RealtimeBetaServerEventResponseDone = struct {
     event_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     response: RealtimeBetaResponse,
 };
 
 pub const KeyPressAction = struct {
     keys: []const []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEventResponseDone = struct {
     event_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     response: RealtimeResponse,
 };
 
@@ -4243,7 +4243,7 @@ pub const ProjectServiceAccountListResponse = struct {
 
 pub const RealtimeBetaClientEventInputAudioBufferCommit = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const VoiceResource = struct {
@@ -4291,7 +4291,7 @@ pub const InputContent = union(enum) {
 
 pub const ResponseMCPListToolsCompletedEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -4400,7 +4400,7 @@ pub const ClickParam = struct {
     x: i64,
     button: []const u8,
     keys: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     y: i64,
 };
 
@@ -4413,7 +4413,7 @@ pub const ListCertificatesResponse = struct {
 };
 
 pub const ResponseFormatTextGrammar = struct {
-    type: []const u8,
+    @"type": []const u8,
     grammar: []const u8,
 };
 
@@ -4447,7 +4447,7 @@ pub const RealtimeClientEventSessionUpdateSession = union(enum) {
 pub const RealtimeClientEventSessionUpdate = struct {
     event_id: ?[]const u8 = null,
     session: RealtimeClientEventSessionUpdateSession,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const EvalRunPerTestingCriteriaResultsItem = struct {
@@ -4522,16 +4522,16 @@ pub const EvalRun = struct {
 };
 
 pub const RealtimeAudioFormatsVariant0 = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     rate: ?i64 = null,
 };
 
 pub const RealtimeAudioFormatsVariant1 = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeAudioFormatsVariant2 = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeAudioFormats = union(enum) {
@@ -4609,12 +4609,12 @@ pub const ChatCompletionRequestMessageContentPartFileFile = struct {
 
 pub const ChatCompletionRequestMessageContentPartFile = struct {
     file: ChatCompletionRequestMessageContentPartFileFile,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeSessionCreateResponseTurnDetection = struct {
     threshold: ?f64 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     prefix_padding_ms: ?i64 = null,
     silence_duration_ms: ?i64 = null,
 };
@@ -4684,12 +4684,12 @@ pub const RealtimeSessionCreateResponseAudioOutput = struct {
 };
 
 pub const RealtimeSessionCreateResponseAudioInputNoiseReduction = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeSessionCreateResponseAudioInputTurnDetection = struct {
     threshold: ?f64 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     prefix_padding_ms: ?i64 = null,
     silence_duration_ms: ?i64 = null,
 };
@@ -4807,7 +4807,7 @@ pub const DeleteMessageResponse = struct {
 pub const RealtimeBetaServerEventResponseContentPartAddedPart = struct {
     text: ?[]const u8 = null,
     transcript: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     audio: ?[]const u8 = null,
 };
 
@@ -4817,12 +4817,12 @@ pub const RealtimeBetaServerEventResponseContentPartAdded = struct {
     event_id: []const u8,
     response_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const AutoChunkingStrategyRequestParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TranscriptTextDoneEventLogprobsItem = struct {
@@ -4835,7 +4835,7 @@ pub const TranscriptTextDoneEvent = struct {
     text: []const u8,
     logprobs: ?[]const TranscriptTextDoneEventLogprobsItem = null,
     usage: ?TranscriptTextUsageTokens = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ProjectServiceAccountCreateResponse = struct {
@@ -4854,7 +4854,7 @@ pub const ImageGenCompletedEvent = struct {
     quality: []const u8,
     output_format: []const u8,
     usage: ImagesUsage,
-    type: []const u8,
+    @"type": []const u8,
     background: []const u8,
 };
 
@@ -4875,7 +4875,7 @@ pub const MCPToolCall = struct {
     status: ?[]const u8 = null,
     arguments: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     approval_request_id: ?[]const u8 = null,
 };
@@ -4884,7 +4884,7 @@ pub const ResponseReasoningTextDeltaEvent = struct {
     delta: []const u8,
     item_id: []const u8,
     output_index: i64,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     content_index: i64,
 };
@@ -4920,7 +4920,7 @@ pub const RealtimeSessionCreateRequestInputAudioTranscription = struct {
 
 pub const RealtimeSessionCreateRequestTurnDetection = struct {
     threshold: ?f64 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     prefix_padding_ms: ?i64 = null,
     silence_duration_ms: ?i64 = null,
 };
@@ -4928,7 +4928,7 @@ pub const RealtimeSessionCreateRequestTurnDetection = struct {
 pub const RealtimeSessionCreateRequestToolsItem = struct {
     description: ?[]const u8 = null,
     name: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     parameters: ?std.json.Value = null,
 };
 
@@ -4994,7 +4994,7 @@ pub const ToolSearchCall = struct {
     status: []const u8,
     arguments: std.json.Value,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     execution: []const u8,
     created_by: ?[]const u8 = null,
 };
@@ -5007,24 +5007,24 @@ pub const ResponseTextDoneEvent = struct {
     content_index: i64,
     text: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const ReasoningEffort = ?[]const u8;
 
 pub const AssistantToolsFileSearchTypeOnly = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebSearchActionSearchSourcesItem = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebSearchActionSearch = struct {
     queries: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     query: []const u8,
     sources: ?[]const WebSearchActionSearchSourcesItem = null,
 };
@@ -5036,7 +5036,7 @@ pub const MessageContentImageUrlObjectImageUrl = struct {
 
 pub const MessageContentImageUrlObject = struct {
     image_url: MessageContentImageUrlObjectImageUrl,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const VectorStoreFileAttributes = ?std.json.Value;
@@ -5147,12 +5147,12 @@ pub const DeleteAssistantResponse = struct {
 pub const RealtimeBetaClientEventSessionUpdate = struct {
     event_id: ?[]const u8 = null,
     session: RealtimeSessionCreateRequest,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseCodeInterpreterCallInProgressEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -5173,12 +5173,12 @@ pub const RunStepDeltaStepDetailsMessageCreationObjectMessageCreation = struct {
 };
 
 pub const RunStepDeltaStepDetailsMessageCreationObject = struct {
-    type: []const u8,
+    @"type": []const u8,
     message_creation: ?RunStepDeltaStepDetailsMessageCreationObjectMessageCreation = null,
 };
 
 pub const ResponseQueuedEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     response: Response,
     sequence_number: i64,
 };
@@ -5188,7 +5188,7 @@ pub const ResponseReasoningSummaryTextDeltaEvent = struct {
     item_id: []const u8,
     output_index: i64,
     sequence_number: i64,
-    type: []const u8,
+    @"type": []const u8,
     summary_index: i64,
 };
 
@@ -5198,7 +5198,7 @@ pub const LocalShellExecAction = struct {
     timeout_ms: ?i64 = null,
     env: std.json.Value,
     user: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const MessageContentTextAnnotationsFileCitationObjectFileCitation = struct {
@@ -5210,7 +5210,7 @@ pub const MessageContentTextAnnotationsFileCitationObject = struct {
     file_citation: MessageContentTextAnnotationsFileCitationObjectFileCitation,
     start_index: i64,
     end_index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateVideoExtendMultipartBodyVideoVariant1 = []const u8;
@@ -5332,7 +5332,7 @@ pub const FunctionCallOutputItemParam = struct {
     status: ?[]const u8 = null,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     output: FunctionCallOutputItemParamOutput,
 };
 
@@ -5342,14 +5342,14 @@ pub const ResponseTextDeltaEvent = struct {
     content_index: i64,
     delta: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const OutputAudio = struct {
     data: []const u8,
     transcript: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FunctionShellCallOutput = struct {
@@ -5358,21 +5358,21 @@ pub const FunctionShellCallOutput = struct {
     max_output_length: ?i64,
     status: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     created_by: ?[]const u8 = null,
 };
 
 pub const ParallelToolCalls = bool;
 
 pub const ResponseCreatedEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     response: Response,
     sequence_number: i64,
 };
 
 pub const RealtimeClientEventInputAudioBufferClear = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const MessageContentImageFileObjectImageFile = struct {
@@ -5382,7 +5382,7 @@ pub const MessageContentImageFileObjectImageFile = struct {
 
 pub const MessageContentImageFileObject = struct {
     image_file: MessageContentImageFileObjectImageFile,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const MessageObjectAttachmentsItemToolsItem = union(enum) {
@@ -5478,7 +5478,7 @@ pub const ComputerCallOutputItemParam = struct {
     acknowledged_safety_checks: ?[]const ComputerCallSafetyCheckParam = null,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     output: ComputerScreenshotImage,
 };
 
@@ -5511,7 +5511,7 @@ pub const ResponsesClientEvent = union(enum) {
 pub const RealtimeBetaServerEventConversationItemDeleted = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionRequestMessage = union(enum) {
@@ -5575,7 +5575,7 @@ pub const RunStepDetailsMessageCreationObjectMessageCreation = struct {
 };
 
 pub const RunStepDetailsMessageCreationObject = struct {
-    type: []const u8,
+    @"type": []const u8,
     message_creation: RunStepDetailsMessageCreationObjectMessageCreation,
 };
 
@@ -5640,19 +5640,19 @@ pub const ProjectApiKeyOwnerUser = struct {
 pub const MCPToolCallStatus = []const u8;
 
 pub const WaitParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CodeInterpreterTextOutput = struct {
     logs: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const InlineSkillParam = struct {
     source: InlineSkillSourceParam,
     description: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeMcptoolCallError = ?std.json.Value;
@@ -5663,7 +5663,7 @@ pub const RealtimeMCPToolCall = struct {
     server_label: []const u8,
     arguments: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     approval_request_id: ?[]const u8 = null,
 };
@@ -5671,13 +5671,13 @@ pub const RealtimeMCPToolCall = struct {
 pub const ComputerScreenshotContent = struct {
     file_id: ?[]const u8,
     image_url: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
     detail: []const u8,
 };
 
 pub const ResponseWebSearchCallCompletedEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -5689,7 +5689,7 @@ pub const RunToolCallObjectFunction = struct {
 
 pub const RunToolCallObject = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     function: RunToolCallObjectFunction,
 };
 
@@ -5701,7 +5701,7 @@ pub const DeleteFineTuningCheckpointPermissionResponse = struct {
 
 pub const ResponseReasoningSummaryPartDoneEventPart = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseReasoningSummaryPartDoneEvent = struct {
@@ -5710,7 +5710,7 @@ pub const ResponseReasoningSummaryPartDoneEvent = struct {
     output_index: i64,
     sequence_number: i64,
     part: ResponseReasoningSummaryPartDoneEventPart,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatkitConfigurationParam = struct {
@@ -5730,7 +5730,7 @@ pub const RunStepDetailsToolCallsCodeOutputImageObjectImage = struct {
 
 pub const RunStepDetailsToolCallsCodeOutputImageObject = struct {
     image: RunStepDetailsToolCallsCodeOutputImageObjectImage,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEvent = union(enum) {
@@ -6000,7 +6000,7 @@ pub const WebhookBatchCancelled = struct {
     data: WebhookBatchCancelledData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeTranslationSessionUpdateRequestAudioOutput = struct {
@@ -6027,7 +6027,7 @@ pub const RealtimeTranslationSessionUpdateRequest = struct {
 
 pub const ResponseMCPCallInProgressEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -6099,7 +6099,7 @@ pub const ContainerAutoParam = struct {
     memory_limit: ?[]const u8 = null,
     network_policy: ?ContainerAutoParamNetworkPolicy = null,
     file_ids: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatSessionHistory = struct {
@@ -6111,7 +6111,7 @@ pub const AdminApiKeyOwner = struct {
     object: ?[]const u8 = null,
     created_at: ?i64 = null,
     id: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     name: ?[]const u8 = null,
     role: ?[]const u8 = null,
 };
@@ -6176,7 +6176,7 @@ pub const AssistantStreamEvent = union(enum) {
 pub const ComputerScreenshotImage = struct {
     file_id: ?[]const u8 = null,
     image_url: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const MessageDeltaContentTextObjectTextAnnotationsItem = union(enum) {
@@ -6214,7 +6214,7 @@ pub const MessageDeltaContentTextObjectText = struct {
 pub const MessageDeltaContentTextObject = struct {
     text: ?MessageDeltaContentTextObjectText = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const VectorStoreFileObjectChunkingStrategy = union(enum) {
@@ -6262,7 +6262,7 @@ pub const EvalGraderLabelModel = struct {
     passing_labels: []const []const u8,
     model: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: []const EvalItem,
     labels: []const []const u8,
 };
@@ -6291,7 +6291,7 @@ pub const ChatCompletionMessageListDataItemAnnotationsItemUrlCitation = struct {
 
 pub const ChatCompletionMessageListDataItemAnnotationsItem = struct {
     url_citation: ChatCompletionMessageListDataItemAnnotationsItemUrlCitation,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionMessageListDataItemContentPartsItem = union(enum) {
@@ -6344,7 +6344,7 @@ pub const ChatCompletionMessageList = struct {
 pub const RealtimeBetaServerEventSessionCreated = struct {
     event_id: []const u8,
     session: RealtimeSession,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ContainerNetworkPolicyDomainSecretParam = struct {
@@ -6367,7 +6367,7 @@ pub const ChatCompletionRequestMessageContentPartAudioInputAudio = struct {
 
 pub const ChatCompletionRequestMessageContentPartAudio = struct {
     input_audio: ChatCompletionRequestMessageContentPartAudioInputAudio,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebhookResponseFailedData = struct {
@@ -6379,7 +6379,7 @@ pub const WebhookResponseFailed = struct {
     data: WebhookResponseFailedData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const VideoStatus = []const u8;
@@ -6414,7 +6414,7 @@ pub const RealtimeServerEventSessionCreatedSession = union(enum) {
 pub const RealtimeServerEventSessionCreated = struct {
     event_id: []const u8,
     session: RealtimeServerEventSessionCreatedSession,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeTranslationServerEventSessionOutputAudioDelta = struct {
@@ -6424,7 +6424,7 @@ pub const RealtimeTranslationServerEventSessionOutputAudioDelta = struct {
     event_id: []const u8,
     delta: []const u8,
     elapsed_ms: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEventResponseMCPCallArgumentsDone = struct {
@@ -6432,14 +6432,14 @@ pub const RealtimeServerEventResponseMCPCallArgumentsDone = struct {
     response_id: []const u8,
     item_id: []const u8,
     arguments: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const CompactionBody = struct {
     encrypted_content: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     created_by: ?[]const u8 = null,
 };
 
@@ -6482,13 +6482,13 @@ pub const RealtimeServerEventSessionUpdatedSession = union(enum) {
 pub const RealtimeServerEventSessionUpdated = struct {
     event_id: []const u8,
     session: RealtimeServerEventSessionUpdatedSession,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaClientEventTranscriptionSessionUpdate = struct {
     event_id: ?[]const u8 = null,
     session: RealtimeTranscriptionSessionCreateRequest,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FineTuneDPOMethod = struct {
@@ -6513,7 +6513,7 @@ pub const SpeechAudioDoneEventUsage = struct {
 
 pub const SpeechAudioDoneEvent = struct {
     usage: SpeechAudioDoneEventUsage,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UsageVectorStoresResult = struct {
@@ -6525,7 +6525,7 @@ pub const UsageVectorStoresResult = struct {
 pub const RealtimeServerEventOutputAudioBufferStarted = struct {
     event_id: []const u8,
     response_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const SearchContentType = []const u8;
@@ -6533,7 +6533,7 @@ pub const SearchContentType = []const u8;
 pub const Attachment = struct {
     mime_type: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     preview_url: ?[]const u8,
 };
@@ -6543,7 +6543,7 @@ pub const RealtimeBetaServerEventResponseAudioDone = struct {
     response_id: []const u8,
     item_id: []const u8,
     output_index: i64,
-    type: []const u8,
+    @"type": []const u8,
     content_index: i64,
 };
 
@@ -6551,7 +6551,7 @@ pub const FunctionToolParam = struct {
     description: ?[]const u8 = null,
     strict: ?bool = null,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     parameters: ?EmptyModelParam = null,
     defer_loading: ?bool = null,
 };
@@ -6562,7 +6562,7 @@ pub const RealtimeBetaServerEventResponseAudioTranscriptDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -6602,7 +6602,7 @@ pub const NamespaceToolParamToolsItem = union(enum) {
 pub const NamespaceToolParam = struct {
     description: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     tools: []const NamespaceToolParamToolsItem,
 };
 
@@ -6783,7 +6783,7 @@ pub const FileSearchTool = struct {
     max_num_results: ?i64 = null,
     ranking_options: ?RankingOptions = null,
     filters: ?Filters = null,
-    type: []const u8,
+    @"type": []const u8,
     vector_store_ids: []const []const u8,
 };
 
@@ -6806,7 +6806,7 @@ pub const ClientToolCallItem = struct {
     status: []const u8,
     arguments: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
 };
 
@@ -6831,13 +6831,13 @@ pub const InputFileContent = struct {
     filename: ?[]const u8 = null,
     file_data: ?[]const u8 = null,
     file_url: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     detail: ?[]const u8 = null,
 };
 
 pub const ChatCompletionRequestMessageContentPartText = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseContentPartAddedEvent = struct {
@@ -6845,7 +6845,7 @@ pub const ResponseContentPartAddedEvent = struct {
     item_id: []const u8,
     output_index: i64,
     sequence_number: i64,
-    type: []const u8,
+    @"type": []const u8,
     content_index: i64,
 };
 
@@ -6861,7 +6861,7 @@ pub const AdminApiKeyCreateResponseOwner = struct {
     object: ?[]const u8 = null,
     created_at: ?i64 = null,
     id: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     name: ?[]const u8 = null,
     role: ?[]const u8 = null,
 };
@@ -6922,11 +6922,11 @@ pub const ChatCompletionRequestUserMessageContentPart = union(enum) {
 
 pub const RealtimeBetaClientEventInputAudioBufferClear = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const StaticChunkingStrategyRequestParam = struct {
-    type: []const u8,
+    @"type": []const u8,
     static: StaticChunkingStrategy,
 };
 
@@ -6938,7 +6938,7 @@ pub const HybridSearchOptions = struct {
 pub const ResponseMCPCallArgumentsDeltaEvent = struct {
     delta: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -6953,14 +6953,14 @@ pub const VideoListResource = struct {
 
 pub const RealtimeServerEventInputAudioBufferCleared = struct {
     event_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TranscriptTextSegmentEvent = struct {
     text: []const u8,
     speaker: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     start: f64,
     end: f64,
 };
@@ -6974,12 +6974,12 @@ pub const WebhookFineTuningJobCancelled = struct {
     data: WebhookFineTuningJobCancelledData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ToolSearchToolParam = struct {
     description: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     execution: ?[]const u8 = null,
     parameters: ?EmptyModelParam = null,
 };
@@ -6990,12 +6990,12 @@ pub const ResponsePromptVariables = ?std.json.Value;
 
 pub const RealtimeBetaServerEventResponseCreated = struct {
     event_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     response: RealtimeBetaResponse,
 };
 
 pub const ResponseFormatJsonObject = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ThreadObjectToolResources = ?std.json.Value;
@@ -7048,13 +7048,13 @@ pub const ChatCompletionRequestToolMessage = struct {
 pub const MoveParam = struct {
     x: i64,
     keys: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     y: i64,
 };
 
 pub const ResponseFileSearchCallCompletedEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -7216,14 +7216,14 @@ pub const ItemResource = union(enum) {
 
 pub const ResponseImageGenCallInProgressEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
 
 pub const ToolChoiceAllowed = struct {
     tools: []const std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
     mode: []const u8,
 };
 
@@ -7276,14 +7276,14 @@ pub const RunStepDetailsToolCallsFunctionObjectFunction = struct {
 
 pub const RunStepDetailsToolCallsFunctionObject = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     function: RunStepDetailsToolCallsFunctionObjectFunction,
 };
 
 pub const ResponseCodeInterpreterCallCodeDoneEvent = struct {
     output_index: i64,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     code: []const u8,
 };
@@ -7291,7 +7291,7 @@ pub const ResponseCodeInterpreterCallCodeDoneEvent = struct {
 pub const RealtimeClientEventTranscriptionSessionUpdate = struct {
     event_id: ?[]const u8 = null,
     session: RealtimeTranscriptionSessionCreateRequest,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ListFineTuningJobCheckpointsResponse = struct {
@@ -7334,7 +7334,7 @@ pub const WebhookRealtimeCallIncoming = struct {
     data: WebhookRealtimeCallIncomingData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateThreadAndRunRequestToolsItem = union(enum) {
@@ -7373,7 +7373,7 @@ pub const CreateThreadAndRunRequestModel = []const u8;
 
 pub const CreateThreadAndRunRequestTruncationStrategy = struct {
     last_messages: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateThreadAndRunRequestToolResourcesFileSearch = struct {
@@ -7420,12 +7420,12 @@ pub const CreateModerationRequestInputVariant2ItemVariant0ImageUrl = struct {
 
 pub const CreateModerationRequestInputVariant2ItemVariant0 = struct {
     image_url: CreateModerationRequestInputVariant2ItemVariant0ImageUrl,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateModerationRequestInputVariant2ItemVariant1 = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateModerationRequestInputVariant2Item = union(enum) {
@@ -7663,7 +7663,7 @@ pub const ResponseReasoningTextDoneEvent = struct {
     text: []const u8,
     item_id: []const u8,
     output_index: i64,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     content_index: i64,
 };
@@ -7674,7 +7674,7 @@ pub const ComputerToolCallOutputResource = struct {
     output: ComputerScreenshotImage,
     status: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     created_by: ?[]const u8 = null,
 };
 
@@ -7831,12 +7831,12 @@ pub const CreateEvalCompletionsRunDataSourceInputMessagesVariant0TemplateItem = 
 
 pub const CreateEvalCompletionsRunDataSourceInputMessagesVariant0 = struct {
     template: []const CreateEvalCompletionsRunDataSourceInputMessagesVariant0TemplateItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateEvalCompletionsRunDataSourceInputMessagesVariant1 = struct {
     item_reference: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateEvalCompletionsRunDataSourceInputMessages = union(enum) {
@@ -7945,7 +7945,7 @@ pub const CreateEvalCompletionsRunDataSource = struct {
     source: CreateEvalCompletionsRunDataSourceSource,
     model: ?[]const u8 = null,
     sampling_params: ?CreateEvalCompletionsRunDataSourceSamplingParams = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ListRunsResponse = struct {
@@ -7966,7 +7966,7 @@ pub const ComputerAction = union(enum) {
     move: MoveParam,
     screenshot: ScreenshotParam,
     scroll: ScrollParam,
-    type: TypeParam,
+    @"type": TypeParam,
     wait: WaitParam,
     raw: std.json.Value,
 
@@ -8026,7 +8026,7 @@ pub const ComputerAction = union(enum) {
 
 pub const ResponseFileSearchCallInProgressEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -8056,7 +8056,7 @@ pub const RealtimeTranslationSessionAudio = struct {
 pub const RealtimeTranslationSession = struct {
     expires_at: i64,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     model: []const u8,
     audio: RealtimeTranslationSessionAudio,
 };
@@ -8070,7 +8070,7 @@ pub const Image = struct {
 pub const CustomGrammarFormatParam = struct {
     syntax: []const u8,
     definition: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateContainerBodySkillsItem = union(enum) {
@@ -8151,7 +8151,7 @@ pub const CreateContainerBody = struct {
 
 pub const UrlAnnotation = struct {
     source: UrlAnnotationSource,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaServerEventConversationItemInputAudioTranscriptionSegment = struct {
@@ -8161,7 +8161,7 @@ pub const RealtimeBetaServerEventConversationItemInputAudioTranscriptionSegment 
     text: []const u8,
     speaker: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     start: f64,
     end: f64,
 };
@@ -8236,7 +8236,7 @@ pub const CreateChatCompletionRequestResponseFormat = union(enum) {
 
 pub const CreateChatCompletionRequestWebSearchOptionsUserLocation = struct {
     approximate: WebSearchLocation,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateChatCompletionRequestWebSearchOptions = struct {
@@ -8469,7 +8469,7 @@ pub const OutputMessage = struct {
     status: []const u8,
     phase: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     role: []const u8,
     content: []const OutputMessageContent,
 };
@@ -8521,13 +8521,13 @@ pub const GroupListResource = struct {
 pub const RealtimeFunctionTool = struct {
     description: ?[]const u8 = null,
     name: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     parameters: ?std.json.Value = null,
 };
 
 pub const RealtimeClientEventInputAudioBufferCommit = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionRequestAssistantMessageAudio = ?std.json.Value;
@@ -8563,7 +8563,7 @@ pub const ProjectRateLimitUpdateRequest = struct {
 
 pub const ResponseAudioDeltaEvent = struct {
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
 };
 
@@ -8624,14 +8624,14 @@ pub const ResponseFormatJsonSchemaJsonSchema = struct {
 
 pub const ResponseFormatJsonSchema = struct {
     json_schema: ResponseFormatJsonSchemaJsonSchema,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const @"MessagePhase-2" = []const u8;
 
 pub const ResponseMCPListToolsInProgressEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -8639,7 +8639,7 @@ pub const ResponseMCPListToolsInProgressEvent = struct {
 pub const RealtimeMCPApprovalRequest = struct {
     arguments: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     server_label: []const u8,
 };
@@ -8679,7 +8679,7 @@ pub const Upload = struct {
 pub const InputImageContent = struct {
     file_id: ?[]const u8 = null,
     image_url: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     detail: []const u8,
 };
 
@@ -8737,7 +8737,7 @@ pub const CreateEmbeddingResponse = struct {
 };
 
 pub const ResponseFailedEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     response: Response,
 };
@@ -8753,7 +8753,7 @@ pub const ResponseItemList = struct {
 pub const InlineSkillSourceParam = struct {
     media_type: []const u8,
     data: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RunStepDetailsToolCallsObjectToolCallsItem = union(enum) {
@@ -8790,11 +8790,11 @@ pub const RunStepDetailsToolCallsObjectToolCallsItem = union(enum) {
 
 pub const RunStepDetailsToolCallsObject = struct {
     tool_calls: []const RunStepDetailsToolCallsObjectToolCallsItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FunctionShellCallOutputTimeoutOutcome = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WorkflowTracingParam = struct {
@@ -8866,16 +8866,16 @@ pub const RealtimeTranslationServerEventSessionInputTranscriptDelta = struct {
     event_id: []const u8,
     delta: []const u8,
     elapsed_ms: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const LocalEnvironmentResource = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UrlAnnotationSource = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UpdateVectorStoreFileAttributesRequest = struct {
@@ -8883,7 +8883,7 @@ pub const UpdateVectorStoreFileAttributesRequest = struct {
 };
 
 pub const OtherChunkingStrategyResponseParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ImageDetail = []const u8;
@@ -8962,13 +8962,13 @@ pub const CodeInterpreterFileOutputFilesItem = struct {
 
 pub const CodeInterpreterFileOutput = struct {
     files: []const CodeInterpreterFileOutputFilesItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FunctionCallItemStatus = []const u8;
 
 pub const RefusalContent = struct {
-    type: []const u8,
+    @"type": []const u8,
     refusal: []const u8,
 };
 
@@ -8977,7 +8977,7 @@ pub const ApplyPatchToolCallItemParam = struct {
     operation: ApplyPatchOperationParam,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ImageGenStreamEvent = union(enum) {
@@ -9129,13 +9129,13 @@ pub const FineTuneDPOHyperparameters = struct {
 pub const RealtimeMCPApprovalResponse = struct {
     approve: bool,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     reason: ?[]const u8 = null,
     approval_request_id: []const u8,
 };
 
 pub const ContainerReferenceResource = struct {
-    type: []const u8,
+    @"type": []const u8,
     container_id: []const u8,
 };
 
@@ -9176,7 +9176,7 @@ pub const AutoCodeInterpreterToolParam = struct {
     memory_limit: ?[]const u8 = null,
     network_policy: ?AutoCodeInterpreterToolParamNetworkPolicy = null,
     file_ids: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const PredictionContentContentVariant0 = []const u8;
@@ -9211,7 +9211,7 @@ pub const PredictionContentContent = union(enum) {
 };
 
 pub const PredictionContent = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: PredictionContentContent,
 };
 
@@ -9256,7 +9256,7 @@ pub const GroupResourceWithSuccess = struct {
 pub const RealtimeConversationItemMessageAssistantContentItem = struct {
     text: ?[]const u8 = null,
     transcript: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     audio: ?[]const u8 = null,
 };
 
@@ -9264,14 +9264,14 @@ pub const RealtimeConversationItemMessageAssistant = struct {
     object: ?[]const u8 = null,
     status: ?[]const u8 = null,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     role: []const u8,
     content: []const RealtimeConversationItemMessageAssistantContentItem,
 };
 
 pub const RunStepDetailsToolCallsCodeOutputLogsObject = struct {
     logs: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TranscriptionWord = struct {
@@ -9287,7 +9287,7 @@ pub const CreateTranslationResponseJson = struct {
 pub const RealtimeClientEventConversationItemDelete = struct {
     event_id: ?[]const u8 = null,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionResponseMessageFunctionCall = struct {
@@ -9306,7 +9306,7 @@ pub const ChatCompletionResponseMessageAnnotationsItemUrlCitation = struct {
 
 pub const ChatCompletionResponseMessageAnnotationsItem = struct {
     url_citation: ChatCompletionResponseMessageAnnotationsItemUrlCitation,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionResponseMessage = struct {
@@ -9351,7 +9351,7 @@ pub const FunctionShellCallOutputOutcomeParam = union(enum) {
 };
 
 pub const CustomTextFormatParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ContainerFileListResource = struct {
@@ -9365,7 +9365,7 @@ pub const ContainerFileListResource = struct {
 pub const RealtimeServerEventInputAudioBufferSpeechStopped = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     audio_end_ms: i64,
 };
 
@@ -9383,14 +9383,14 @@ pub const MessageDeltaContentImageFileObjectImageFile = struct {
 pub const MessageDeltaContentImageFileObject = struct {
     image_file: ?MessageDeltaContentImageFileObjectImageFile = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ComputerUsePreviewTool = struct {
     environment: []const u8,
     display_width: i64,
     display_height: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ProjectGroup = struct {
@@ -9410,7 +9410,7 @@ pub const UsageCodeInterpreterSessionsResult = struct {
 
 pub const EvalJsonlFileIdSource = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const NoiseReductionType = []const u8;
@@ -9418,13 +9418,13 @@ pub const NoiseReductionType = []const u8;
 pub const WebSearchApproximateLocation = ?std.json.Value;
 
 pub const ContextManagementParam = struct {
-    type: []const u8,
+    @"type": []const u8,
     compact_threshold: ?i64 = null,
 };
 
 pub const CreateEvalLogsDataSourceConfig = struct {
     metadata: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateCompletionRequestPromptVariant0 = []const u8;
@@ -9504,7 +9504,7 @@ pub const VoiceConsentListResource = struct {
 };
 
 pub const ChatCompletionTool = struct {
-    type: []const u8,
+    @"type": []const u8,
     function: FunctionObject,
 };
 
@@ -9582,7 +9582,7 @@ pub const ServiceTier = ?[]const u8;
 pub const RealtimeTranslationServerEventSessionCreated = struct {
     event_id: []const u8,
     session: RealtimeTranslationSession,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateRunRequestToolsItem = union(enum) {
@@ -9621,7 +9621,7 @@ pub const CreateRunRequestModel = []const u8;
 
 pub const CreateRunRequestTruncationStrategy = struct {
     last_messages: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateRunRequest = struct {
@@ -9651,19 +9651,19 @@ pub const ChatSessionRateLimits = struct {
 pub const FineTuneMethod = struct {
     dpo: ?FineTuneDPOMethod = null,
     reinforcement: ?FineTuneReinforcementMethod = null,
-    type: []const u8,
+    @"type": []const u8,
     supervised: ?FineTuneSupervisedMethod = null,
 };
 
 pub const RealtimeClientEventResponseCreate = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     response: ?RealtimeResponseCreateParams = null,
 };
 
 pub const ClosedStatus = struct {
     reason: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionRequestAssistantMessageContentPart = union(enum) {
@@ -9726,7 +9726,7 @@ pub const RunGraderResponseMetadata = struct {
     token_usage: ?i64,
     execution_time: f64,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RunGraderResponse = struct {
@@ -9738,7 +9738,7 @@ pub const RunGraderResponse = struct {
 
 pub const ResponseReasoningSummaryPartAddedEventPart = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseReasoningSummaryPartAddedEvent = struct {
@@ -9747,7 +9747,7 @@ pub const ResponseReasoningSummaryPartAddedEvent = struct {
     output_index: i64,
     sequence_number: i64,
     part: ResponseReasoningSummaryPartAddedEventPart,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const Model = struct {
@@ -9825,7 +9825,7 @@ pub const ChatCompletionMessageToolCalls = []const ChatCompletionMessageToolCall
 
 pub const TextContent = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RunStepDetailsToolCallsFileSearchObjectFileSearch = struct {
@@ -9836,13 +9836,13 @@ pub const RunStepDetailsToolCallsFileSearchObjectFileSearch = struct {
 pub const RunStepDetailsToolCallsFileSearchObject = struct {
     file_search: RunStepDetailsToolCallsFileSearchObjectFileSearch,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaServerEventSessionUpdated = struct {
     event_id: []const u8,
     session: RealtimeSession,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ImageGenActionEnum = []const u8;
@@ -9850,7 +9850,7 @@ pub const ImageGenActionEnum = []const u8;
 pub const RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject = struct {
     logs: ?[]const u8 = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateTranscriptionResponseVerboseJson = struct {
@@ -9867,7 +9867,7 @@ pub const FunctionToolCall = struct {
     status: ?[]const u8 = null,
     arguments: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     namespace: ?[]const u8 = null,
 };
@@ -9875,13 +9875,13 @@ pub const FunctionToolCall = struct {
 pub const ResponseMCPCallArgumentsDoneEvent = struct {
     item_id: []const u8,
     arguments: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
 
 pub const ContainerReferenceParam = struct {
-    type: []const u8,
+    @"type": []const u8,
     container_id: []const u8,
 };
 
@@ -9890,7 +9890,7 @@ pub const ResponseRefusalDoneEvent = struct {
     item_id: []const u8,
     output_index: i64,
     sequence_number: i64,
-    type: []const u8,
+    @"type": []const u8,
     content_index: i64,
 };
 
@@ -10012,7 +10012,7 @@ pub const DeletedVideoResource = struct {
 pub const RealtimeServerEventErrorError = struct {
     event_id: ?[]const u8 = null,
     code: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
     param: ?[]const u8 = null,
 };
@@ -10020,7 +10020,7 @@ pub const RealtimeServerEventErrorError = struct {
 pub const RealtimeServerEventError = struct {
     event_id: []const u8,
     @"error": RealtimeServerEventErrorError,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const @"ImageRefParam-2" = struct {
@@ -10030,7 +10030,7 @@ pub const @"ImageRefParam-2" = struct {
 
 pub const FileAnnotationSource = struct {
     filename: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateTranslationRequestModel = []const u8;
@@ -10046,7 +10046,7 @@ pub const CreateTranslationRequest = struct {
 pub const RealtimeClientEventConversationItemCreate = struct {
     event_id: ?[]const u8 = null,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     previous_item_id: ?[]const u8 = null,
 };
 
@@ -10060,12 +10060,12 @@ pub const EvalJsonlFileContentSourceContentItem = struct {
 };
 
 pub const EvalJsonlFileContentSource = struct {
-    type: []const u8,
+    @"type": []const u8,
     content: []const EvalJsonlFileContentSourceContentItem,
 };
 
 pub const AssistantToolsCode = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RoleListResource = struct {
@@ -10081,7 +10081,7 @@ pub const AddUploadPartRequest = struct {
 
 pub const ResponseMCPListToolsFailedEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -10102,7 +10102,7 @@ pub const CreateVectorStoreFileBatchRequest = struct {
 
 pub const ToolChoiceMCP = struct {
     name: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     server_label: []const u8,
 };
 
@@ -10244,7 +10244,7 @@ pub const RealtimeSessionCreateRequestGaAudioOutput = struct {
 };
 
 pub const RealtimeSessionCreateRequestGaAudioInputNoiseReduction = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeSessionCreateRequestGaAudioInput = struct {
@@ -10273,7 +10273,7 @@ pub const RealtimeSessionCreateRequestGA = struct {
     include: ?[]const []const u8 = null,
     tool_choice: ?RealtimeSessionCreateRequestGaToolChoice = null,
     audio: ?RealtimeSessionCreateRequestGaAudio = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const GraderScoreModelSamplingParams = struct {
@@ -10288,7 +10288,7 @@ pub const GraderScoreModel = struct {
     input: []const EvalItem,
     model: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     range: ?[]const f64 = null,
     sampling_params: ?GraderScoreModelSamplingParams = null,
 };
@@ -10305,7 +10305,7 @@ pub const RealtimeServerEventResponseTextDone = struct {
     response_id: []const u8,
     item_id: []const u8,
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -10408,7 +10408,7 @@ pub const RealtimeSessionCreateResponseGaAudioOutput = struct {
 };
 
 pub const RealtimeSessionCreateResponseGaAudioInputNoiseReduction = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeSessionCreateResponseGaAudioInput = struct {
@@ -10439,7 +10439,7 @@ pub const RealtimeSessionCreateResponseGA = struct {
     expires_at: ?i64 = null,
     tool_choice: ?RealtimeSessionCreateResponseGaToolChoice = null,
     audio: ?RealtimeSessionCreateResponseGaAudio = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEventResponseAudioTranscriptDone = struct {
@@ -10448,12 +10448,12 @@ pub const RealtimeServerEventResponseAudioTranscriptDone = struct {
     event_id: []const u8,
     response_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const ApplyPatchToolParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ConversationResource = struct {
@@ -10475,7 +10475,7 @@ pub const ToolSearchCallItemParam = struct {
     arguments: EmptyModelParam,
     call_id: ?[]const u8 = null,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     execution: ?[]const u8 = null,
 };
 
@@ -10488,14 +10488,14 @@ pub const WebhookEvalRunFailed = struct {
     data: WebhookEvalRunFailedData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FunctionShellCallOutputStatusEnum = []const u8;
 
 pub const LockedStatus = struct {
     reason: ?[]const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ImageEditCompletedEvent = struct {
@@ -10505,20 +10505,20 @@ pub const ImageEditCompletedEvent = struct {
     quality: []const u8,
     output_format: []const u8,
     usage: ImagesUsage,
-    type: []const u8,
+    @"type": []const u8,
     background: []const u8,
 };
 
 pub const RealtimeServerEventConversationItemCreated = struct {
     event_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     previous_item_id: ?[]const u8 = null,
 };
 
 pub const CodeInterpreterOutputImage = struct {
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeCallCreateRequestSessionToolsItem = union(enum) {
@@ -10651,7 +10651,7 @@ pub const RealtimeCallCreateRequestSessionAudioOutput = struct {
 };
 
 pub const RealtimeCallCreateRequestSessionAudioInputNoiseReduction = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeCallCreateRequestSessionAudioInput = struct {
@@ -10680,7 +10680,7 @@ pub const RealtimeCallCreateRequestSession = struct {
     include: ?[]const []const u8 = null,
     tool_choice: ?RealtimeCallCreateRequestSessionToolChoice = null,
     audio: ?RealtimeCallCreateRequestSessionAudio = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeCallCreateRequest = struct {
@@ -10711,7 +10711,7 @@ pub const FunctionShellCall = struct {
     status: []const u8,
     action: FunctionShellAction,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     created_by: ?[]const u8 = null,
 };
 
@@ -10763,7 +10763,7 @@ pub const ReasoningItem = struct {
     status: ?[]const u8 = null,
     encrypted_content: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     summary: []const SummaryTextContent,
     content: ?[]const ReasoningTextContent = null,
 };
@@ -10771,7 +10771,7 @@ pub const ReasoningItem = struct {
 pub const RealtimeServerEventOutputAudioBufferCleared = struct {
     event_id: []const u8,
     response_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const SubmitToolOutputsRunRequestToolOutputsItem = struct {
@@ -10831,7 +10831,7 @@ pub const ChatCompletionRequestUserMessage = struct {
 };
 
 pub const ToolChoiceTypes = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const SkillVersionResource = struct {
@@ -10969,7 +10969,7 @@ pub const RunStepDeltaStepDetailsToolCallsFunctionObjectFunction = struct {
 pub const RunStepDeltaStepDetailsToolCallsFunctionObject = struct {
     id: ?[]const u8 = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
     function: ?RunStepDeltaStepDetailsToolCallsFunctionObjectFunction = null,
 };
 
@@ -10986,7 +10986,7 @@ pub const ListRunStepsResponse = struct {
 };
 
 pub const RealtimeMCPProtocolError = struct {
-    type: []const u8,
+    @"type": []const u8,
     message: []const u8,
     code: i64,
 };
@@ -11115,7 +11115,7 @@ pub const ComputerToolCallOutput = struct {
     acknowledged_safety_checks: ?[]const ComputerCallSafetyCheckParam = null,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     output: ComputerScreenshotImage,
 };
 
@@ -11139,7 +11139,7 @@ pub const TaskItem = struct {
     object: []const u8,
     thread_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     task_type: []const u8,
 };
 
@@ -11147,7 +11147,7 @@ pub const RealtimeBetaServerEventResponseOutputItemDone = struct {
     event_id: []const u8,
     response_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -11319,7 +11319,7 @@ pub const CreateResponse = struct {
 pub const MCPListTools = struct {
     @"error": ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     tools: []const MCPListToolsTool,
     server_label: []const u8,
 };
@@ -11328,7 +11328,7 @@ pub const ImageGenToolCall = struct {
     status: []const u8,
     result: ?[]const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ModelIdsResponses = []const u8;
@@ -11338,7 +11338,7 @@ pub const ComputerActionList = []const ComputerAction;
 pub const RealtimeServerEventConversationItemRetrieved = struct {
     event_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const VectorStoreFileBatchObjectFileCounts = struct {
@@ -11372,7 +11372,7 @@ pub const CreateVideoEditJsonBody = struct {
 pub const ApproximateLocation = struct {
     city: ?[]const u8 = null,
     country: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     region: ?[]const u8 = null,
     timezone: ?[]const u8 = null,
 };
@@ -11386,7 +11386,7 @@ pub const RealtimeServerEventConversationCreatedConversation = struct {
 
 pub const RealtimeServerEventConversationCreated = struct {
     event_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     conversation: RealtimeServerEventConversationCreatedConversation,
 };
 
@@ -11397,7 +11397,7 @@ pub const DeleteVectorStoreFileResponse = struct {
 };
 
 pub const ChatCompletionRequestMessageContentPartRefusal = struct {
-    type: []const u8,
+    @"type": []const u8,
     refusal: []const u8,
 };
 
@@ -11413,12 +11413,12 @@ pub const RealtimeServerEventResponseFunctionCallArgumentsDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const ResponseCompletedEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     response: Response,
     sequence_number: i64,
 };
@@ -11558,11 +11558,11 @@ pub const MessageDeltaContentImageUrlObjectImageUrl = struct {
 pub const MessageDeltaContentImageUrlObject = struct {
     image_url: ?MessageDeltaContentImageUrlObjectImageUrl = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeTranscriptionSessionCreateResponseGaAudioInputNoiseReduction = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeTranscriptionSessionCreateResponseGaAudioInputTurnDetection = ?std.json.Value;
@@ -11583,7 +11583,7 @@ pub const RealtimeTranscriptionSessionCreateResponseGA = struct {
     include: ?[]const []const u8 = null,
     expires_at: ?i64 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     audio: ?RealtimeTranscriptionSessionCreateResponseGaAudio = null,
 };
 
@@ -11687,7 +11687,7 @@ pub const FunctionToolCallResource = struct {
     status: []const u8,
     arguments: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     namespace: ?[]const u8 = null,
 };
@@ -11710,7 +11710,7 @@ pub const WebhookBatchCompleted = struct {
     data: WebhookBatchCompletedData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateVideoRemixBody = struct {
@@ -11726,7 +11726,7 @@ pub const WebhookResponseCompleted = struct {
     data: WebhookResponseCompletedData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const InviteRequestProjectsItem = struct {
@@ -11751,7 +11751,7 @@ pub const ProjectApiKeyListResponse = struct {
 pub const RealtimeServerEventInputAudioBufferDtmfEventReceived = struct {
     received_at: i64,
     event: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseStreamEvent = union(enum) {
@@ -12082,7 +12082,7 @@ pub const ResponseOutputTextAnnotationsItem = union(enum) {
 pub const ResponseOutputText = struct {
     text: []const u8,
     annotations: []const ResponseOutputTextAnnotationsItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TokenCountsBodyInput = ?std.json.Value;
@@ -12104,7 +12104,7 @@ pub const TokenCountsBody = struct {
 pub const AuditLogActorApiKey = struct {
     service_account: ?AuditLogActorServiceAccount = null,
     id: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     user: ?AuditLogActorUser = null,
 };
 
@@ -12130,7 +12130,7 @@ pub const Certificate = struct {
 
 pub const RealtimeBetaClientEventOutputAudioBufferClear = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RunStepDeltaStepDetailsToolCallsObjectToolCallsItem = union(enum) {
@@ -12167,7 +12167,7 @@ pub const RunStepDeltaStepDetailsToolCallsObjectToolCallsItem = union(enum) {
 
 pub const RunStepDeltaStepDetailsToolCallsObject = struct {
     tool_calls: ?[]const RunStepDeltaStepDetailsToolCallsObjectToolCallsItem = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEventConversationItemInputAudioTranscriptionSegment = struct {
@@ -12177,7 +12177,7 @@ pub const RealtimeServerEventConversationItemInputAudioTranscriptionSegment = st
     text: []const u8,
     speaker: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     start: f64,
     end: f64,
 };
@@ -12329,7 +12329,7 @@ pub const ChatCompletionNamedToolChoiceCustomCustom = struct {
 
 pub const ChatCompletionNamedToolChoiceCustom = struct {
     custom: ChatCompletionNamedToolChoiceCustomCustom,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseErrorCode = []const u8;
@@ -12343,7 +12343,7 @@ pub const DeleteThreadResponse = struct {
 pub const RealtimeBetaClientEventResponseCancel = struct {
     event_id: ?[]const u8 = null,
     response_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const VideoReferenceInputParam = struct {
@@ -12354,32 +12354,32 @@ pub const RealtimeServerEventResponseOutputItemDone = struct {
     event_id: []const u8,
     response_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const RealtimeTranslationClientEventSessionUpdate = struct {
     event_id: ?[]const u8 = null,
     session: RealtimeTranslationSessionUpdateRequest,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaClientEventResponseCreate = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     response: ?RealtimeBetaResponseCreateParams = null,
 };
 
 pub const ChatSessionStatus = []const u8;
 
 pub const ActiveStatus = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ApplyPatchCallStatusParam = []const u8;
 
 pub const RealtimeTranscriptionSessionCreateRequestGaAudioInputNoiseReduction = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeTranscriptionSessionCreateRequestGaAudioInput = struct {
@@ -12395,7 +12395,7 @@ pub const RealtimeTranscriptionSessionCreateRequestGaAudio = struct {
 
 pub const RealtimeTranscriptionSessionCreateRequestGA = struct {
     include: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     audio: ?RealtimeTranscriptionSessionCreateRequestGaAudio = null,
 };
 
@@ -12465,7 +12465,7 @@ pub const ListFineTuningJobEventsResponse = struct {
 pub const EvalLogsDataSourceConfig = struct {
     metadata: ?Metadata = null,
     schema: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const GroupRoleAssignment = struct {
@@ -12477,7 +12477,7 @@ pub const GroupRoleAssignment = struct {
 pub const RealtimeBetaServerEventResponseContentPartDonePart = struct {
     text: ?[]const u8 = null,
     transcript: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     audio: ?[]const u8 = null,
 };
 
@@ -12487,7 +12487,7 @@ pub const RealtimeBetaServerEventResponseContentPartDone = struct {
     event_id: []const u8,
     response_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -12495,13 +12495,13 @@ pub const RealtimeBetaServerEventResponseOutputItemAdded = struct {
     event_id: []const u8,
     response_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const ResponseOutputItemDoneEvent = struct {
     item: OutputItem,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -12509,7 +12509,7 @@ pub const ResponseOutputItemDoneEvent = struct {
 pub const RealtimeServerEventConversationItemDeleted = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionRequestSystemMessageContentVariant0 = []const u8;
@@ -12594,7 +12594,7 @@ pub const GraderMultiGraders = union(enum) {
 pub const GraderMulti = struct {
     graders: GraderMultiGraders,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     calculate_output: []const u8,
 };
 
@@ -12609,7 +12609,7 @@ pub const Project = struct {
 };
 
 pub const CustomToolChatCompletionsCustomFormatVariant0 = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CustomToolChatCompletionsCustomFormatVariant1Grammar = struct {
@@ -12618,7 +12618,7 @@ pub const CustomToolChatCompletionsCustomFormatVariant1Grammar = struct {
 };
 
 pub const CustomToolChatCompletionsCustomFormatVariant1 = struct {
-    type: []const u8,
+    @"type": []const u8,
     grammar: CustomToolChatCompletionsCustomFormatVariant1Grammar,
 };
 
@@ -12657,12 +12657,12 @@ pub const CustomToolChatCompletionsCustom = struct {
 
 pub const CustomToolChatCompletions = struct {
     custom: CustomToolChatCompletionsCustom,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaClientEventInputAudioBufferAppend = struct {
     event_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     audio: []const u8,
 };
 
@@ -12671,7 +12671,7 @@ pub const CustomToolCall = struct {
     call_id: []const u8,
     id: ?[]const u8 = null,
     input: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
 };
 
@@ -12684,7 +12684,7 @@ pub const ListVectorStoresResponse = struct {
 };
 
 pub const FunctionShellCallOutputTimeoutOutcomeParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ProjectRateLimit = struct {
@@ -12721,7 +12721,7 @@ pub const MessageContentTextAnnotationsFilePathObject = struct {
     text: []const u8,
     end_index: i64,
     start_index: i64,
-    type: []const u8,
+    @"type": []const u8,
     file_path: MessageContentTextAnnotationsFilePathObjectFilePath,
 };
 
@@ -12735,7 +12735,7 @@ pub const OrganizationCertificateDeactivationResponse = struct {
 pub const RealtimeServerEventConversationItemTruncated = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     audio_end_ms: i64,
     content_index: i64,
 };
@@ -12771,7 +12771,7 @@ pub const CodeInterpreterToolContainer = union(enum) {
 
 pub const CodeInterpreterTool = struct {
     container: CodeInterpreterToolContainer,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ContainerFileCitationBody = struct {
@@ -12779,24 +12779,24 @@ pub const ContainerFileCitationBody = struct {
     start_index: i64,
     end_index: i64,
     filename: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     container_id: []const u8,
 };
 
 pub const ItemReferenceParam = struct {
     id: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeReasoningEffort = []const u8;
 
 pub const RealtimeTranscriptionSessionCreateRequestInputAudioNoiseReduction = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeTranscriptionSessionCreateRequestTurnDetection = struct {
     threshold: ?f64 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     prefix_padding_ms: ?i64 = null,
     silence_duration_ms: ?i64 = null,
 };
@@ -12817,7 +12817,7 @@ pub const RealtimeBetaServerEventResponseFunctionCallArgumentsDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -12852,17 +12852,17 @@ pub const RealtimeTranslationSessionCreateRequest = struct {
 pub const RealtimeBetaServerEventTranscriptionSessionCreated = struct {
     event_id: []const u8,
     session: RealtimeTranscriptionSessionCreateResponse,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ToolChoiceCustom = struct {
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FunctionParameters = union(enum) {
     null,
-    bool: bool,
+    @"bool": bool,
     integer: i64,
     float: f64,
     number_string: []const u8,
@@ -13068,7 +13068,7 @@ pub const ApplyPatchToolCallOutput = struct {
     status: []const u8,
     call_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output: ?[]const u8 = null,
     created_by: ?[]const u8 = null,
 };
@@ -13078,20 +13078,20 @@ pub const EvalStoredCompletionsSource = struct {
     created_after: ?i64 = null,
     metadata: ?Metadata = null,
     model: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     created_before: ?i64 = null,
 };
 
 pub const ResponseFileSearchCallSearchingEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
 
 pub const ResponseImageGenCallGeneratingEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -13114,7 +13114,7 @@ pub const DeletedSkillResource = struct {
 
 pub const ResponseMCPCallFailedEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -13129,14 +13129,14 @@ pub const RealtimeServerEventRateLimitsUpdatedRateLimitsItem = struct {
 pub const RealtimeServerEventRateLimitsUpdated = struct {
     event_id: []const u8,
     rate_limits: []const RealtimeServerEventRateLimitsUpdatedRateLimitsItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ScrollParam = struct {
     x: i64,
     keys: ?[]const []const u8 = null,
     scroll_x: i64,
-    type: []const u8,
+    @"type": []const u8,
     y: i64,
     scroll_y: i64,
 };
@@ -13149,11 +13149,11 @@ pub const CoordParam = struct {
 pub const EvalStoredCompletionsDataSourceConfig = struct {
     metadata: ?Metadata = null,
     schema: std.json.Value,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseFormatTextPython = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebhookFineTuningJobSucceededData = struct {
@@ -13165,7 +13165,7 @@ pub const WebhookFineTuningJobSucceeded = struct {
     data: WebhookFineTuningJobSucceededData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const UpdateVoiceConsentRequest = struct {
@@ -13175,7 +13175,7 @@ pub const UpdateVoiceConsentRequest = struct {
 pub const ResponseCustomToolCallInputDeltaEvent = struct {
     delta: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -13214,7 +13214,7 @@ pub const GroupUserAssignment = struct {
 
 pub const UserMessageInputText = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ContainerMemoryLimit = []const u8;
@@ -13265,14 +13265,14 @@ pub const VideoCharacterResource = struct {
 
 pub const MessageDeltaContentRefusalObject = struct {
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
     refusal: ?[]const u8 = null,
 };
 
 pub const RealtimeBetaClientEventConversationItemRetrieve = struct {
     event_id: ?[]const u8 = null,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RunStreamEventVariant0 = struct {
@@ -13405,14 +13405,14 @@ pub const ImageEditPartialImageEvent = struct {
     quality: []const u8,
     output_format: []const u8,
     background: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     partial_image_index: i64,
 };
 
 pub const ResponseCodeInterpreterCallCodeDeltaEvent = struct {
     delta: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -13430,7 +13430,7 @@ pub const MCPTool = struct {
     authorization: ?[]const u8 = null,
     server_url: ?[]const u8 = null,
     allowed_tools: ?McptoolAllowedTools = null,
-    type: []const u8,
+    @"type": []const u8,
     headers: ?MCPToolHeaders = null,
 };
 
@@ -13497,7 +13497,7 @@ pub const CreateTranscriptionResponseStreamEvent = union(enum) {
 pub const RealtimeBetaClientEventConversationItemDelete = struct {
     event_id: ?[]const u8 = null,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const DeletedRoleAssignmentResource = struct {
@@ -13515,14 +13515,14 @@ pub const LogProb = struct {
 pub const RealtimeBetaClientEventConversationItemCreate = struct {
     event_id: ?[]const u8 = null,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     previous_item_id: ?[]const u8 = null,
 };
 
 pub const DragParam = struct {
     keys: ?[]const []const u8 = null,
     path: []const CoordParam,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionRole = []const u8;
@@ -13561,14 +13561,14 @@ pub const CustomToolCallOutputOutput = union(enum) {
 pub const CustomToolCallOutput = struct {
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     output: CustomToolCallOutputOutput,
 };
 
 pub const RealtimeServerEventResponseMCPCallFailed = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -13611,7 +13611,7 @@ pub const RealtimeCreateClientSecretResponse = struct {
 
 pub const ResponseWebSearchCallInProgressEvent = struct {
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -13622,7 +13622,7 @@ pub const RealtimeBetaServerEventResponseAudioTranscriptDone = struct {
     event_id: []const u8,
     response_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -13634,7 +13634,7 @@ pub const TaskGroupItem = struct {
     thread_id: []const u8,
     tasks: []const TaskGroupTask,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FineTuningCheckpointPermission = struct {
@@ -13655,7 +13655,7 @@ pub const ChatCompletionAllowedTools = struct {
 
 pub const ProjectApiKeyOwner = struct {
     service_account: ?ProjectApiKeyOwnerServiceAccount = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     user: ?ProjectApiKeyOwnerUser = null,
 };
 
@@ -13673,21 +13673,21 @@ pub const EvalItemContentText = []const u8;
 
 pub const WebSearchActionOpenPage = struct {
     url: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaServerEventInputAudioBufferSpeechStarted = struct {
     event_id: []const u8,
     audio_start_ms: i64,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FunctionShellCallOutputItemParam = struct {
     status: ?[]const u8 = null,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     output: []const FunctionShellCallOutputContentParam,
     max_output_length: ?i64 = null,
 };
@@ -13712,12 +13712,12 @@ pub const RealtimeBetaServerEventResponseFunctionCallArgumentsDone = struct {
     item_id: []const u8,
     arguments: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const TaskGroupTask = struct {
-    type: []const u8,
+    @"type": []const u8,
     heading: ?[]const u8,
     summary: ?[]const u8,
 };
@@ -13730,7 +13730,7 @@ pub const ResponseRefusalDeltaEvent = struct {
     delta: []const u8,
     item_id: []const u8,
     output_index: i64,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     content_index: i64,
 };
@@ -13740,7 +13740,7 @@ pub const InputFileContentParam = struct {
     filename: ?[]const u8 = null,
     file_data: ?[]const u8 = null,
     file_url: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     detail: ?[]const u8 = null,
 };
 
@@ -13760,7 +13760,7 @@ pub const OrganizationCertificate = struct {
 
 pub const RealtimeMCPListTools = struct {
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     tools: []const MCPListToolsTool,
     server_label: []const u8,
 };
@@ -13805,14 +13805,14 @@ pub const RunStepDetailsToolCallsCodeObjectCodeInterpreter = struct {
 
 pub const RunStepDetailsToolCallsCodeObject = struct {
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     code_interpreter: RunStepDetailsToolCallsCodeObjectCodeInterpreter,
 };
 
 pub const DoubleClickAction = struct {
     x: i64,
     keys: ?[]const []const u8,
-    type: []const u8,
+    @"type": []const u8,
     y: i64,
 };
 
@@ -13855,7 +13855,7 @@ pub const PublicRoleListResource = struct {
 };
 
 pub const ResponseIncompleteEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     response: Response,
     sequence_number: i64,
 };
@@ -13875,7 +13875,7 @@ pub const ComputerToolCall = struct {
     status: []const u8,
     action: ?ComputerAction = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TranscriptTextDeltaEventLogprobsItem = struct {
@@ -13887,7 +13887,7 @@ pub const TranscriptTextDeltaEventLogprobsItem = struct {
 pub const TranscriptTextDeltaEvent = struct {
     delta: []const u8,
     logprobs: ?[]const TranscriptTextDeltaEventLogprobsItem = null,
-    type: []const u8,
+    @"type": []const u8,
     segment_id: ?[]const u8 = null,
 };
 
@@ -13905,7 +13905,7 @@ pub const AssistantMessageItem = struct {
     created_at: i64,
     thread_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     content: []const ResponseOutputText,
 };
 
@@ -13915,7 +13915,7 @@ pub const RealtimeServerEventResponseAudioTranscriptDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -14030,7 +14030,7 @@ pub const CreateMessageRequest = struct {
 
 pub const RealtimeTranslationServerEventSessionClosed = struct {
     event_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebhookFineTuningJobFailedData = struct {
@@ -14042,12 +14042,12 @@ pub const WebhookFineTuningJobFailed = struct {
     data: WebhookFineTuningJobFailedData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseFormatJsonSchemaSchema = union(enum) {
     null,
-    bool: bool,
+    @"bool": bool,
     integer: i64,
     float: f64,
     number_string: []const u8,
@@ -14102,7 +14102,7 @@ pub const ChatCompletionRequestMessageContentPartImageImageUrl = struct {
 
 pub const ChatCompletionRequestMessageContentPartImage = struct {
     image_url: ChatCompletionRequestMessageContentPartImageImageUrl,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ComparisonFilterValueVariant0 = []const u8;
@@ -14178,7 +14178,7 @@ pub const ComparisonFilterValue = union(enum) {
 pub const ComparisonFilter = struct {
     value: ComparisonFilterValue,
     key: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const FileUploadParam = struct {
@@ -14190,7 +14190,7 @@ pub const FileUploadParam = struct {
 pub const ApplyPatchCreateFileOperation = struct {
     path: []const u8,
     diff: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionDeleted = struct {
@@ -14202,7 +14202,7 @@ pub const ChatCompletionDeleted = struct {
 pub const LocalShellToolCallOutput = struct {
     status: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output: []const u8,
 };
 
@@ -14241,14 +14241,14 @@ pub const RunStepDeltaStepDetailsToolCallsCodeObjectCodeInterpreter = struct {
 pub const RunStepDeltaStepDetailsToolCallsCodeObject = struct {
     id: ?[]const u8 = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
     code_interpreter: ?RunStepDeltaStepDetailsToolCallsCodeObjectCodeInterpreter = null,
 };
 
 pub const MCPApprovalRequest = struct {
     arguments: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
     server_label: []const u8,
 };
@@ -14257,7 +14257,7 @@ pub const CreateEvalLabelModelGrader = struct {
     passing_labels: []const []const u8,
     model: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: []const CreateEvalItem,
     labels: []const []const u8,
 };
@@ -14265,7 +14265,7 @@ pub const CreateEvalLabelModelGrader = struct {
 pub const RealtimeServerEventConversationItemDone = struct {
     event_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     previous_item_id: ?[]const u8 = null,
 };
 
@@ -14302,7 +14302,7 @@ pub const EvalGraderScoreModel = struct {
     sampling_params: ?EvalGraderScoreModelSamplingParams = null,
     name: []const u8,
     input: []const EvalItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const AssistantToolsFileSearchFileSearch = struct {
@@ -14312,7 +14312,7 @@ pub const AssistantToolsFileSearchFileSearch = struct {
 
 pub const AssistantToolsFileSearch = struct {
     file_search: ?AssistantToolsFileSearchFileSearch = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const CreateThreadRequestToolResources = ?std.json.Value;
@@ -14329,7 +14329,7 @@ pub const RealtimeServerEventResponseMCPCallArgumentsDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     obfuscation: ?[]const u8 = null,
 };
 
@@ -14367,12 +14367,12 @@ pub const RealtimeServerEventConversationItemInputAudioTranscriptionCompleted = 
     event_id: []const u8,
     item_id: []const u8,
     usage: RealtimeServerEventConversationItemInputAudioTranscriptionCompletedUsage,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ContainerResourceNetworkPolicy = struct {
     allowed_domains: ?[]const []const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ContainerResourceExpiresAfter = struct {
@@ -14393,7 +14393,7 @@ pub const ContainerResource = struct {
 };
 
 pub const AssistantToolsFunction = struct {
-    type: []const u8,
+    @"type": []const u8,
     function: FunctionObject,
 };
 
@@ -14404,7 +14404,7 @@ pub const ModifyRunRequest = struct {
 pub const RealtimeBetaServerEventResponseMCPCallInProgress = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -14465,13 +14465,13 @@ pub const UserRoleAssignment = struct {
 pub const RealtimeServerEventOutputAudioBufferStopped = struct {
     event_id: []const u8,
     response_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseFunctionCallArgumentsDeltaEvent = struct {
     delta: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
     output_index: i64,
 };
@@ -14481,14 +14481,14 @@ pub const RealtimeBetaServerEventResponseMCPCallArgumentsDone = struct {
     response_id: []const u8,
     item_id: []const u8,
     arguments: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
 pub const RealtimeServerEventResponseMCPCallInProgress = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -14505,13 +14505,13 @@ pub const UsageAudioSpeechesResult = struct {
 pub const RealtimeBetaServerEventTranscriptionSessionUpdated = struct {
     event_id: []const u8,
     session: RealtimeTranscriptionSessionCreateResponse,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ApplyPatchUpdateFileOperation = struct {
     path: []const u8,
     diff: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const VoiceIdsShared = []const u8;
@@ -14606,7 +14606,7 @@ pub const WebSearchToolCall = struct {
     status: []const u8,
     action: WebSearchToolCallAction,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ModifyMessageRequest = struct {
@@ -14618,7 +14618,7 @@ pub const RealtimeConversationItemFunctionCallOutput = struct {
     status: ?[]const u8 = null,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     output: []const u8,
 };
 
@@ -14633,19 +14633,19 @@ pub const MessageDeltaContentTextAnnotationsFileCitationObject = struct {
     start_index: ?i64 = null,
     end_index: ?i64 = null,
     index: i64,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ToolChoiceFunction = struct {
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const TranscriptionDiarizedSegment = struct {
     text: []const u8,
     speaker: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     start: f64,
     end: f64,
 };
@@ -14702,7 +14702,7 @@ pub const RealtimeBetaServerEventResponseAudioDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -14715,12 +14715,12 @@ pub const FineTuningIntegrationWandb = struct {
 
 pub const FineTuningIntegration = struct {
     wandb: FineTuningIntegrationWandb,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEventConversationItemInputAudioTranscriptionFailedError = struct {
     code: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     param: ?[]const u8 = null,
 };
@@ -14729,7 +14729,7 @@ pub const RealtimeServerEventConversationItemInputAudioTranscriptionFailed = str
     event_id: []const u8,
     item_id: []const u8,
     @"error": RealtimeServerEventConversationItemInputAudioTranscriptionFailedError,
-    type: []const u8,
+    @"type": []const u8,
     content_index: i64,
 };
 
@@ -14809,14 +14809,14 @@ pub const RealtimeBetaResponseMaxOutputTokens = union(enum) {
 };
 
 pub const RealtimeBetaResponseStatusDetailsError = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     code: ?[]const u8 = null,
 };
 
 pub const RealtimeBetaResponseStatusDetails = struct {
     @"error": ?RealtimeBetaResponseStatusDetailsError = null,
     reason: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeBetaResponse = struct {
@@ -14852,7 +14852,7 @@ pub const WebhookBatchFailed = struct {
     data: WebhookBatchFailedData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeConversationItemFunctionCall = struct {
@@ -14861,7 +14861,7 @@ pub const RealtimeConversationItemFunctionCall = struct {
     status: ?[]const u8 = null,
     arguments: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     name: []const u8,
 };
 
@@ -14933,7 +14933,7 @@ pub const ResponseReasoningSummaryTextDoneEvent = struct {
     item_id: []const u8,
     output_index: i64,
     sequence_number: i64,
-    type: []const u8,
+    @"type": []const u8,
     summary_index: i64,
 };
 
@@ -14943,7 +14943,7 @@ pub const ResponseErrorEvent = struct {
     message: []const u8,
     code: ?[]const u8,
     sequence_number: i64,
-    type: []const u8,
+    @"type": []const u8,
     param: ?[]const u8,
 };
 
@@ -14956,7 +14956,7 @@ pub const UserRoleUpdateRequest = struct {
 
 pub const RealtimeBetaServerEventConversationItemInputAudioTranscriptionFailedError = struct {
     code: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     message: ?[]const u8 = null,
     param: ?[]const u8 = null,
 };
@@ -14965,7 +14965,7 @@ pub const RealtimeBetaServerEventConversationItemInputAudioTranscriptionFailed =
     event_id: []const u8,
     item_id: []const u8,
     @"error": RealtimeBetaServerEventConversationItemInputAudioTranscriptionFailedError,
-    type: []const u8,
+    @"type": []const u8,
     content_index: i64,
 };
 
@@ -14976,18 +14976,18 @@ pub const FineTuningJobEvent = struct {
     id: []const u8,
     level: []const u8,
     message: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const EvalItem = struct {
     role: []const u8,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     content: EvalItemContent,
 };
 
 pub const RunStepDetailsToolCallsFileSearchResultObjectContentItem = struct {
     text: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RunStepDetailsToolCallsFileSearchResultObject = struct {
@@ -15001,7 +15001,7 @@ pub const FunctionTool = struct {
     description: ?[]const u8 = null,
     strict: ?bool,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     parameters: ?FunctionParameters,
     defer_loading: ?bool = null,
 };
@@ -15015,13 +15015,13 @@ pub const WebhookEvalRunCanceled = struct {
     data: WebhookEvalRunCanceledData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const EvalGraderStringCheck = struct {
     operation: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: []const u8,
     reference: []const u8,
 };
@@ -15029,7 +15029,7 @@ pub const EvalGraderStringCheck = struct {
 pub const RealtimeServerEventInputAudioBufferCommitted = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     previous_item_id: ?[]const u8 = null,
 };
 
@@ -15048,11 +15048,11 @@ pub const WebhookResponseIncomplete = struct {
     data: WebhookResponseIncompleteData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ComputerTool = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ToolChoiceOptions = []const u8;
@@ -15067,7 +15067,7 @@ pub const ToolSearchOutputItemParam = struct {
     status: ?[]const u8 = null,
     call_id: ?[]const u8 = null,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     execution: ?[]const u8 = null,
     tools: []const Tool,
 };
@@ -15076,7 +15076,7 @@ pub const EvalGraderTextSimilarity = struct {
     pass_threshold: f64,
     evaluation_metric: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: []const u8,
     reference: []const u8,
 };
@@ -15234,14 +15234,14 @@ pub const RealtimeBetaServerEventResponseMCPCallArgumentsDelta = struct {
     response_id: []const u8,
     item_id: []const u8,
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     obfuscation: ?[]const u8 = null,
 };
 
 pub const RealtimeBetaServerEventResponseMCPCallFailed = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output_index: i64,
 };
 
@@ -15280,14 +15280,14 @@ pub const FunctionToolCallOutput = struct {
     status: ?[]const u8 = null,
     call_id: []const u8,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     output: FunctionToolCallOutputOutput,
 };
 
 pub const GraderPython = struct {
     source: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     image_tag: ?[]const u8 = null,
 };
 
@@ -15349,24 +15349,24 @@ pub const UpdateVectorStoreRequest = struct {
 
 pub const UserMessageQuotedText = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeServerEventConversationItemAdded = struct {
     event_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
     previous_item_id: ?[]const u8 = null,
 };
 
 pub const RealtimeBetaServerEventMCPListToolsInProgress = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ContainerNetworkPolicyDisabledParam = struct {
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const WebhookBatchExpiredData = struct {
@@ -15378,7 +15378,7 @@ pub const WebhookBatchExpired = struct {
     data: WebhookBatchExpiredData,
     object: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const InputAudioInputAudio = struct {
@@ -15388,7 +15388,7 @@ pub const InputAudioInputAudio = struct {
 
 pub const InputAudio = struct {
     input_audio: InputAudioInputAudio,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ResponseStreamOptions = ?std.json.Value;
@@ -15469,14 +15469,14 @@ pub const Message = struct {
     status: []const u8,
     phase: ?[]const u8 = null,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     role: []const u8,
     content: []const MessageContentItem,
 };
 
 pub const ResponseAudioTranscriptDeltaEvent = struct {
     delta: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     sequence_number: i64,
 };
 
@@ -15599,7 +15599,7 @@ pub const DetailEnum = []const u8;
 
 pub const TruncationObject = struct {
     last_messages: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaServerEventRateLimitsUpdatedRateLimitsItem = struct {
@@ -15612,7 +15612,7 @@ pub const RealtimeBetaServerEventRateLimitsUpdatedRateLimitsItem = struct {
 pub const RealtimeBetaServerEventRateLimitsUpdated = struct {
     event_id: []const u8,
     rate_limits: []const RealtimeBetaServerEventRateLimitsUpdatedRateLimitsItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const SkillListResource = struct {
@@ -15640,14 +15640,14 @@ pub const EvalRunList = struct {
 };
 
 pub const SpeechAudioDeltaEvent = struct {
-    type: []const u8,
+    @"type": []const u8,
     audio: []const u8,
 };
 
 pub const ContainerNetworkPolicyAllowlistParam = struct {
     domain_secrets: ?[]const ContainerNetworkPolicyDomainSecretParam = null,
     allowed_domains: []const []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ImageGenOutputTokensDetails = struct {
@@ -15660,7 +15660,7 @@ pub const ToolSearchOutput = struct {
     tools: []const Tool,
     status: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     execution: []const u8,
     created_by: ?[]const u8 = null,
 };
@@ -15701,7 +15701,7 @@ pub const RealtimeSessionModel = []const u8;
 pub const RealtimeSessionTracing = ?std.json.Value;
 
 pub const RealtimeSessionInputAudioNoiseReduction = struct {
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
 };
 
 pub const RealtimeSession = struct {
@@ -15740,7 +15740,7 @@ pub const WebSearchContextSize = []const u8;
 pub const InputImageContentParamAutoParam = struct {
     file_id: ?[]const u8 = null,
     image_url: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     detail: ?[]const u8 = null,
 };
 
@@ -15750,7 +15750,7 @@ pub const WebSearchTool = struct {
     search_context_size: ?[]const u8 = null,
     user_location: ?WebSearchApproximateLocation = null,
     filters: ?WebSearchToolFilters = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ProjectRateLimitListResponse = struct {
@@ -15769,7 +15769,7 @@ pub const OrganizationProjectCertificateDeactivationResponse = struct {
 pub const RealtimeClientEventConversationItemTruncate = struct {
     event_id: ?[]const u8 = null,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     audio_end_ms: i64,
     content_index: i64,
 };
@@ -15892,7 +15892,7 @@ pub const PromptCacheRetentionEnum = []const u8;
 
 pub const CreateEvalStoredCompletionsDataSourceConfig = struct {
     metadata: ?std.json.Value = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaServerEventConversationItemInputAudioTranscriptionCompletedUsage = union(enum) {
@@ -15929,7 +15929,7 @@ pub const RealtimeBetaServerEventConversationItemInputAudioTranscriptionComplete
     event_id: []const u8,
     item_id: []const u8,
     usage: RealtimeBetaServerEventConversationItemInputAudioTranscriptionCompletedUsage,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const Embedding = struct {
@@ -15941,13 +15941,13 @@ pub const Embedding = struct {
 pub const WebSearchActionFind = struct {
     pattern: []const u8,
     url: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaServerEventMCPListToolsCompleted = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ChatCompletionNamedToolChoiceFunction = struct {
@@ -15955,27 +15955,27 @@ pub const ChatCompletionNamedToolChoiceFunction = struct {
 };
 
 pub const ChatCompletionNamedToolChoice = struct {
-    type: []const u8,
+    @"type": []const u8,
     function: ChatCompletionNamedToolChoiceFunction,
 };
 
 pub const InputMessageResource = struct {
     status: ?[]const u8 = null,
     role: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     id: []const u8,
     content: InputMessageContentList,
 };
 
 pub const MessageRequestContentTextObject = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeBetaServerEventConversationItemRetrieved = struct {
     event_id: []const u8,
     item: RealtimeConversationItem,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeClientEvent = union(enum) {
@@ -16057,7 +16057,7 @@ pub const RealtimeClientEvent = union(enum) {
 pub const RealtimeClientEventResponseCancel = struct {
     event_id: ?[]const u8 = null,
     response_id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ImageGenPartialImageEvent = struct {
@@ -16067,27 +16067,27 @@ pub const ImageGenPartialImageEvent = struct {
     quality: []const u8,
     output_format: []const u8,
     background: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     partial_image_index: i64,
 };
 
 pub const SummaryTextContent = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeTranslationServerEventSessionOutputTranscriptDelta = struct {
     event_id: []const u8,
     delta: []const u8,
     elapsed_ms: ?i64 = null,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const RealtimeConversationItemMessageUserContentItem = struct {
     text: ?[]const u8 = null,
     image_url: ?[]const u8 = null,
     transcript: ?[]const u8 = null,
-    type: ?[]const u8 = null,
+    @"type": ?[]const u8 = null,
     audio: ?[]const u8 = null,
     detail: ?[]const u8 = null,
 };
@@ -16096,7 +16096,7 @@ pub const RealtimeConversationItemMessageUser = struct {
     object: ?[]const u8 = null,
     status: ?[]const u8 = null,
     id: ?[]const u8 = null,
-    type: []const u8,
+    @"type": []const u8,
     role: []const u8,
     content: []const RealtimeConversationItemMessageUserContentItem,
 };
@@ -16110,7 +16110,7 @@ pub const ProjectUserCreateRequest = struct {
 pub const GraderTextSimilarity = struct {
     evaluation_metric: []const u8,
     name: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     input: []const u8,
     reference: []const u8,
 };
@@ -16118,7 +16118,7 @@ pub const GraderTextSimilarity = struct {
 pub const RealtimeBetaClientEventConversationItemTruncate = struct {
     event_id: ?[]const u8 = null,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     audio_end_ms: i64,
     content_index: i64,
 };
@@ -16208,7 +16208,7 @@ pub const VideoResource = struct {
 pub const RealtimeServerEventMCPListToolsFailed = struct {
     event_id: []const u8,
     item_id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const ProjectServiceAccountApiKey = struct {
@@ -16254,7 +16254,7 @@ pub const FunctionToolCallOutputResource = struct {
     status: []const u8,
     call_id: []const u8,
     id: []const u8,
-    type: []const u8,
+    @"type": []const u8,
     output: FunctionToolCallOutputResourceOutput,
     created_by: ?[]const u8 = null,
 };
@@ -16299,7 +16299,7 @@ pub const FunctionShellCallOutputContent = struct {
 
 pub const EvalItemContentOutputText = struct {
     text: []const u8,
-    type: []const u8,
+    @"type": []const u8,
 };
 
 pub const OpenApi2ZigDynamicObject = std.json.ArrayHashMap(std.json.Value);

--- a/src/generators/unified/ident_utils.zig
+++ b/src/generators/unified/ident_utils.zig
@@ -74,6 +74,7 @@ test "isReservedIdent" {
     try std.testing.expect(isReservedIdent("if"));
     try std.testing.expect(isReservedIdent("return"));
     try std.testing.expect(isReservedIdent("struct"));
+    try std.testing.expect(isReservedIdent("type"));
     try std.testing.expect(!isReservedIdent("foo"));
     try std.testing.expect(!isReservedIdent(""));
 }

--- a/src/generators/unified/ident_utils.zig
+++ b/src/generators/unified/ident_utils.zig
@@ -16,7 +16,7 @@ pub fn isReservedIdent(name: []const u8) bool {
         "extern",    "false",    "fn",        "for",    "if",          "inline",   "isize",          "linksection",
         "noalias",   "noreturn", "nosuspend", "null",   "opaque",      "or",       "orelse",         "packed",
         "pub",       "resume",   "return",    "struct", "suspend",     "switch",   "test",           "threadlocal",
-        "true",      "try",      "undefined", "union",  "unreachable", "usize",    "usingnamespace", "var",
+        "true",      "try",      "type",      "undefined", "union",  "unreachable", "usize",    "usingnamespace", "var",
         "void",      "volatile", "while",
     };
     for (reserved) |word| {

--- a/src/generators/unified/ident_utils.zig
+++ b/src/generators/unified/ident_utils.zig
@@ -74,6 +74,7 @@ test "isReservedIdent" {
     try std.testing.expect(isReservedIdent("if"));
     try std.testing.expect(isReservedIdent("return"));
     try std.testing.expect(isReservedIdent("struct"));
+    try std.testing.expect(isReservedIdent("try"));
     try std.testing.expect(isReservedIdent("type"));
     try std.testing.expect(!isReservedIdent("foo"));
     try std.testing.expect(!isReservedIdent(""));

--- a/src/generators/unified/model_generator.zig
+++ b/src/generators/unified/model_generator.zig
@@ -42,6 +42,15 @@ pub const UnifiedModelGenerator = struct {
         try ident.appendIdentifier(&self.buffer, self.allocator, name);
     }
 
+    fn appendStructFieldName(self: *UnifiedModelGenerator, name: []const u8) !void {
+        if (ident.isReservedIdent(name)) {
+            try self.buffer.appendSlice(self.allocator, name);
+            try self.buffer.append(self.allocator, '_');
+            return;
+        }
+        try self.appendIdentifier(name);
+    }
+
     fn generateHeader(self: *UnifiedModelGenerator) !void {
         try self.buffer.appendSlice(self.allocator,
             \\const std = @import("std");
@@ -81,6 +90,9 @@ pub const UnifiedModelGenerator = struct {
                 try self.generateStructFields(name, properties, schema.required);
                 if (std.mem.eql(u8, name, "ChatCompletionRequestAssistantMessage") and !properties.contains("reasoning_details")) {
                     try self.buffer.appendSlice(self.allocator, "    reasoning_details: ?std.json.Value = null,\n");
+                }
+                if (try self.structNeedsWireNameMapping(properties)) {
+                    try self.generateStructJsonCodec(name, properties, schema.required);
                 }
                 if (isExtensibleRequest(name)) {
                     try self.buffer.appendSlice(self.allocator, "    extra_body: ?std.json.Value = null,\n");
@@ -179,19 +191,18 @@ pub const UnifiedModelGenerator = struct {
         var out = std.ArrayList(u8).empty;
         errdefer out.deinit(self.allocator);
         var prev_was_underscore = false;
-        for (value, 0..) |c, i| {
-            const next = if (i + 1 < value.len) value[i + 1] else 0;
-            const prev = if (i > 0) value[i - 1] else 0;
-            const insert_word_break = std.ascii.isUpper(c) and i > 0 and out.items.len > 0 and !prev_was_underscore and
-                ((std.ascii.isLower(prev) or std.ascii.isDigit(prev)) or (std.ascii.isUpper(prev) and std.ascii.isLower(next)));
-            if (insert_word_break) try out.append(self.allocator, '_');
-
-            const lower = std.ascii.toLower(c);
-            const valid = if (out.items.len == 0) ident.isIdentStart(lower) else ident.isIdentContinue(lower);
-            const byte = if (valid) lower else '_';
-            if (byte == '_' and prev_was_underscore) continue;
-            try out.append(self.allocator, byte);
-            prev_was_underscore = byte == '_';
+        for (value) |c| {
+            const valid = ident.isIdentStart(c) or ident.isIdentContinue(c);
+            if (valid) {
+                if (c == '_' and prev_was_underscore) continue;
+                try out.append(self.allocator, c);
+                prev_was_underscore = c == '_';
+                continue;
+            }
+            if (!prev_was_underscore) {
+                try out.append(self.allocator, '_');
+                prev_was_underscore = true;
+            }
         }
         while (out.items.len > 0 and out.items[out.items.len - 1] == '_') _ = out.pop();
         if (out.items.len == 0 or !ident.isIdentStart(out.items[0])) try out.insert(self.allocator, 0, '_');
@@ -1052,13 +1063,72 @@ pub const UnifiedModelGenerator = struct {
         return true;
     }
 
-    fn generateStructFields(self: *UnifiedModelGenerator, owner_name: []const u8, properties: std.StringHashMap(Schema), required: ?[][]const u8) !void {
+    fn uniqueSanitizedIdentifierAlloc(self: *UnifiedModelGenerator, value: []const u8, used_names: *std.StringHashMap(void)) ![]const u8 {
+        var candidate = if (ident.isReservedIdent(value))
+            try std.fmt.allocPrint(self.allocator, "{s}_", .{value})
+        else
+            try self.allocator.dupe(u8, value);
+        errdefer self.allocator.free(candidate);
+
+        while (std.mem.eql(u8, candidate, "raw") or used_names.contains(candidate)) {
+            const suffix = try std.fmt.allocPrint(self.allocator, "{s}_", .{candidate});
+            self.allocator.free(candidate);
+            candidate = suffix;
+        }
+
+        const result = try self.allocator.dupe(u8, candidate);
+        errdefer self.allocator.free(result);
+        const tracked = try self.allocator.dupe(u8, candidate);
+        errdefer self.allocator.free(tracked);
+
+        try used_names.put(tracked, {});
+        self.allocator.free(candidate);
+        return result;
+    }
+
+    const StructFieldBinding = struct {
+        raw_name: []const u8,
+        sanitized_name: []const u8,
+        field_schema: Schema,
+        is_required: bool,
+    };
+
+    fn collectStructFieldBindings(self: *UnifiedModelGenerator, properties: std.StringHashMap(Schema), required: ?[][]const u8) ![]StructFieldBinding {
+        var bindings = std.ArrayList(StructFieldBinding).empty;
+        errdefer bindings.deinit(self.allocator);
+
+        var used_names = std.StringHashMap(void).init(self.allocator);
+        defer {
+            var iterator = used_names.iterator();
+            while (iterator.next()) |entry| self.allocator.free(entry.key_ptr.*);
+            used_names.deinit();
+        }
+
         var prop_iterator = properties.iterator();
         while (prop_iterator.next()) |entry| {
             const field_name = entry.key_ptr.*;
             const field_schema = entry.value_ptr.*;
-            const is_required = self.isFieldRequired(field_name, required);
-            try self.generateStructField(owner_name, field_name, field_schema, is_required);
+            const sanitized_name = try self.uniqueSanitizedIdentifierAlloc(field_name, &used_names);
+            try bindings.append(self.allocator, .{
+                .raw_name = field_name,
+                .sanitized_name = sanitized_name,
+                .field_schema = field_schema,
+                .is_required = self.isFieldRequired(field_name, required),
+            });
+        }
+
+        return try bindings.toOwnedSlice(self.allocator);
+    }
+
+    fn generateStructFields(self: *UnifiedModelGenerator, owner_name: []const u8, properties: std.StringHashMap(Schema), required: ?[][]const u8) !void {
+        const bindings = try self.collectStructFieldBindings(properties, required);
+        defer {
+            for (bindings) |binding| self.allocator.free(binding.sanitized_name);
+            self.allocator.free(bindings);
+        }
+
+        for (bindings) |binding| {
+            try self.generateStructField(owner_name, binding.raw_name, binding.field_schema, binding.is_required, binding.sanitized_name);
         }
     }
 
@@ -1106,19 +1176,8 @@ pub const UnifiedModelGenerator = struct {
         return false;
     }
 
-    fn generateStructField(self: *UnifiedModelGenerator, owner_name: []const u8, field_name: []const u8, field_schema: Schema, is_required: bool) !void {
-        const sanitized_field_name = try self.sanitizeIdentifierAlloc(field_name);
-        defer self.allocator.free(sanitized_field_name);
-
-        try self.buffer.appendSlice(self.allocator, "    ");
-        try self.buffer.appendSlice(self.allocator, sanitized_field_name);
-        try self.buffer.appendSlice(self.allocator, ": ");
-
-        if (try self.appendManualFieldType(owner_name, field_name)) {
-            if (!is_required) try self.buffer.appendSlice(self.allocator, " = null");
-            try self.buffer.appendSlice(self.allocator, ",\n");
-            return;
-        }
+    fn appendFieldTypeForSchema(self: *UnifiedModelGenerator, owner_name: []const u8, field_name: []const u8, field_schema: Schema, is_required: bool) !void {
+        if (try self.appendManualFieldType(owner_name, field_name)) return;
 
         if (!is_required and !isNullableSchema(field_schema)) {
             try self.buffer.appendSlice(self.allocator, "?");
@@ -1133,12 +1192,117 @@ pub const UnifiedModelGenerator = struct {
                 try self.appendZigType(field_schema);
             }
         }
+    }
+
+    fn generateStructField(self: *UnifiedModelGenerator, owner_name: []const u8, field_name: []const u8, field_schema: Schema, is_required: bool, sanitized_field_name: []const u8) !void {
+        try self.buffer.appendSlice(self.allocator, "    ");
+        try self.buffer.appendSlice(self.allocator, sanitized_field_name);
+        try self.buffer.appendSlice(self.allocator, ": ");
+
+        if (try self.appendManualFieldType(owner_name, field_name)) {
+            if (!is_required) try self.buffer.appendSlice(self.allocator, " = null");
+            try self.buffer.appendSlice(self.allocator, ",\n");
+            return;
+        }
+
+        try self.appendFieldTypeForSchema(owner_name, field_name, field_schema, is_required);
 
         if (!is_required) {
             try self.buffer.appendSlice(self.allocator, " = null");
         }
 
         try self.buffer.appendSlice(self.allocator, ",\n");
+    }
+
+    fn structNeedsWireNameMapping(self: *UnifiedModelGenerator, properties: std.StringHashMap(Schema)) !bool {
+        const bindings = try self.collectStructFieldBindings(properties, null);
+        defer {
+            for (bindings) |binding| self.allocator.free(binding.sanitized_name);
+            self.allocator.free(bindings);
+        }
+
+        for (bindings) |binding| {
+            if (!std.mem.eql(u8, binding.raw_name, binding.sanitized_name)) return true;
+        }
+        return false;
+    }
+
+    fn generateStructJsonCodec(self: *UnifiedModelGenerator, owner_name: []const u8, properties: std.StringHashMap(Schema), required: ?[][]const u8) !void {
+        const bindings = try self.collectStructFieldBindings(properties, required);
+        defer {
+            for (bindings) |binding| self.allocator.free(binding.sanitized_name);
+            self.allocator.free(bindings);
+        }
+
+        var needs_mapping = false;
+        for (bindings) |binding| {
+            if (!std.mem.eql(u8, binding.raw_name, binding.sanitized_name)) {
+                needs_mapping = true;
+                break;
+            }
+        }
+        if (!needs_mapping) return;
+
+        try self.buffer.appendSlice(self.allocator,
+            \\
+            \\    pub fn jsonParse(allocator: std.mem.Allocator, source: anytype, options: std.json.ParseOptions) !@This() {
+            \\        const value = try std.json.innerParse(std.json.Value, allocator, source, options);
+            \\        return jsonParseFromValue(allocator, value, options);
+            \\    }
+            \\
+            \\    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, options: std.json.ParseOptions) !@This() {
+            \\        if (source != .object) return error.UnexpectedToken;
+            \\        var result: @This() = .{};
+        );
+
+        for (bindings) |binding| {
+            if (std.mem.eql(u8, binding.raw_name, binding.sanitized_name)) continue;
+            try self.buffer.appendSlice(self.allocator, "        if (source.object.get(");
+            try self.appendStringLiteral(binding.raw_name);
+            try self.buffer.appendSlice(self.allocator, ")) |value| {\n");
+            try self.buffer.appendSlice(self.allocator, "            result.");
+            try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
+            try self.buffer.appendSlice(self.allocator, " = try std.json.parseFromValueLeaky(");
+            try self.appendFieldTypeForSchema(owner_name, binding.raw_name, binding.field_schema, binding.is_required);
+            try self.buffer.appendSlice(self.allocator, ", allocator, value, options);\n");
+            try self.buffer.appendSlice(self.allocator, "        }\n");
+        }
+
+        try self.buffer.appendSlice(self.allocator,
+            \\
+            \\        return result;
+            \\    }
+            \\    pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) !void {
+            \\        try jw.beginObject();
+        );
+
+        for (bindings) |binding| {
+            if (binding.is_required) {
+                try self.buffer.appendSlice(self.allocator, "        try jw.objectField(");
+                try self.appendStringLiteral(binding.raw_name);
+                try self.buffer.appendSlice(self.allocator, ");\n");
+                try self.buffer.appendSlice(self.allocator, "        try jw.write(self.");
+                try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
+                try self.buffer.appendSlice(self.allocator, ");\n");
+            } else {
+                try self.buffer.appendSlice(self.allocator, "        if (self.");
+                try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
+                try self.buffer.appendSlice(self.allocator, ") |value| {\n");
+                try self.buffer.appendSlice(self.allocator, "            try jw.objectField(");
+                try self.appendStringLiteral(binding.raw_name);
+                try self.buffer.appendSlice(self.allocator, ");\n");
+                try self.buffer.appendSlice(self.allocator, "            try jw.write(value);\n");
+                try self.buffer.appendSlice(self.allocator, "        }\n");
+            }
+        }
+
+        try self.buffer.appendSlice(self.allocator,
+            \\
+            \\        try jw.endObject();
+            \\    }
+            \\}
+            \\
+        );
     }
 
     fn generateJsonStringify(self: *UnifiedModelGenerator, properties: std.StringHashMap(Schema), required: ?[][]const u8) !void {
@@ -1149,25 +1313,27 @@ pub const UnifiedModelGenerator = struct {
             \\
         );
 
-        var prop_iterator = properties.iterator();
-        while (prop_iterator.next()) |entry| {
-            const field_name = entry.key_ptr.*;
-            const sanitized_field_name = try self.sanitizeIdentifierAlloc(field_name);
-            defer self.allocator.free(sanitized_field_name);
-            if (self.isFieldRequired(field_name, required)) {
-                try self.buffer.appendSlice(self.allocator, "        try jw.objectField(\"");
-                try self.buffer.appendSlice(self.allocator, field_name);
-                try self.buffer.appendSlice(self.allocator, "\");\n");
+        const bindings = try self.collectStructFieldBindings(properties, required);
+        defer {
+            for (bindings) |binding| self.allocator.free(binding.sanitized_name);
+            self.allocator.free(bindings);
+        }
+
+        for (bindings) |binding| {
+            if (binding.is_required) {
+                try self.buffer.appendSlice(self.allocator, "        try jw.objectField(");
+                try self.appendStringLiteral(binding.raw_name);
+                try self.buffer.appendSlice(self.allocator, ");\n");
                 try self.buffer.appendSlice(self.allocator, "        try jw.write(self.");
-                try self.buffer.appendSlice(self.allocator, sanitized_field_name);
+                try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
                 try self.buffer.appendSlice(self.allocator, ");\n");
             } else {
                 try self.buffer.appendSlice(self.allocator, "        if (self.");
-                try self.buffer.appendSlice(self.allocator, sanitized_field_name);
+                try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
                 try self.buffer.appendSlice(self.allocator, ") |value| {\n");
-                try self.buffer.appendSlice(self.allocator, "            try jw.objectField(\"");
-                try self.buffer.appendSlice(self.allocator, field_name);
-                try self.buffer.appendSlice(self.allocator, "\");\n");
+                try self.buffer.appendSlice(self.allocator, "            try jw.objectField(");
+                try self.appendStringLiteral(binding.raw_name);
+                try self.buffer.appendSlice(self.allocator, ");\n");
                 try self.buffer.appendSlice(self.allocator, "            try jw.write(value);\n");
                 try self.buffer.appendSlice(self.allocator, "        }\n");
             }

--- a/src/generators/unified/model_generator.zig
+++ b/src/generators/unified/model_generator.zig
@@ -42,15 +42,6 @@ pub const UnifiedModelGenerator = struct {
         try ident.appendIdentifier(&self.buffer, self.allocator, name);
     }
 
-    fn appendStructFieldName(self: *UnifiedModelGenerator, name: []const u8) !void {
-        if (ident.isReservedIdent(name)) {
-            try self.buffer.appendSlice(self.allocator, name);
-            try self.buffer.append(self.allocator, '_');
-            return;
-        }
-        try self.appendIdentifier(name);
-    }
-
     fn generateHeader(self: *UnifiedModelGenerator) !void {
         try self.buffer.appendSlice(self.allocator,
             \\const std = @import("std");
@@ -913,7 +904,7 @@ pub const UnifiedModelGenerator = struct {
                 \\};
                 \\
                 \\pub const CompoundFilter = struct {
-                \\    type: []const u8,
+                \\    @"type": []const u8,
                 \\    filters: []const CompoundFilterItem,
                 \\};
                 \\
@@ -1064,10 +1055,7 @@ pub const UnifiedModelGenerator = struct {
     }
 
     fn uniqueSanitizedIdentifierAlloc(self: *UnifiedModelGenerator, value: []const u8, used_names: *std.StringHashMap(void)) ![]const u8 {
-        var candidate = if (ident.isReservedIdent(value))
-            try std.fmt.allocPrint(self.allocator, "{s}_", .{value})
-        else
-            try self.allocator.dupe(u8, value);
+        var candidate = try self.allocator.dupe(u8, value);
         errdefer self.allocator.free(candidate);
 
         while (std.mem.eql(u8, candidate, "raw") or used_names.contains(candidate)) {
@@ -1196,7 +1184,7 @@ pub const UnifiedModelGenerator = struct {
 
     fn generateStructField(self: *UnifiedModelGenerator, owner_name: []const u8, field_name: []const u8, field_schema: Schema, is_required: bool, sanitized_field_name: []const u8) !void {
         try self.buffer.appendSlice(self.allocator, "    ");
-        try self.buffer.appendSlice(self.allocator, sanitized_field_name);
+        try self.appendIdentifier(sanitized_field_name);
         try self.buffer.appendSlice(self.allocator, ": ");
 
         if (try self.appendManualFieldType(owner_name, field_name)) {
@@ -1261,7 +1249,7 @@ pub const UnifiedModelGenerator = struct {
             try self.appendStringLiteral(binding.raw_name);
             try self.buffer.appendSlice(self.allocator, ")) |value| {\n");
             try self.buffer.appendSlice(self.allocator, "            result.");
-            try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
+            try self.appendIdentifier(binding.sanitized_name);
             try self.buffer.appendSlice(self.allocator, " = try std.json.parseFromValueLeaky(");
             try self.appendFieldTypeForSchema(owner_name, binding.raw_name, binding.field_schema, binding.is_required);
             try self.buffer.appendSlice(self.allocator, ", allocator, value, options);\n");
@@ -1282,11 +1270,11 @@ pub const UnifiedModelGenerator = struct {
                 try self.appendStringLiteral(binding.raw_name);
                 try self.buffer.appendSlice(self.allocator, ");\n");
                 try self.buffer.appendSlice(self.allocator, "        try jw.write(self.");
-                try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
+                try self.appendIdentifier(binding.sanitized_name);
                 try self.buffer.appendSlice(self.allocator, ");\n");
             } else {
                 try self.buffer.appendSlice(self.allocator, "        if (self.");
-                try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
+                try self.appendIdentifier(binding.sanitized_name);
                 try self.buffer.appendSlice(self.allocator, ") |value| {\n");
                 try self.buffer.appendSlice(self.allocator, "            try jw.objectField(");
                 try self.appendStringLiteral(binding.raw_name);
@@ -1300,7 +1288,6 @@ pub const UnifiedModelGenerator = struct {
             \\
             \\        try jw.endObject();
             \\    }
-            \\}
             \\
         );
     }
@@ -1325,11 +1312,11 @@ pub const UnifiedModelGenerator = struct {
                 try self.appendStringLiteral(binding.raw_name);
                 try self.buffer.appendSlice(self.allocator, ");\n");
                 try self.buffer.appendSlice(self.allocator, "        try jw.write(self.");
-                try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
+                try self.appendIdentifier(binding.sanitized_name);
                 try self.buffer.appendSlice(self.allocator, ");\n");
             } else {
                 try self.buffer.appendSlice(self.allocator, "        if (self.");
-                try self.buffer.appendSlice(self.allocator, binding.sanitized_name);
+                try self.appendIdentifier(binding.sanitized_name);
                 try self.buffer.appendSlice(self.allocator, ") |value| {\n");
                 try self.buffer.appendSlice(self.allocator, "            try jw.objectField(");
                 try self.appendStringLiteral(binding.raw_name);
@@ -1338,10 +1325,6 @@ pub const UnifiedModelGenerator = struct {
                 try self.buffer.appendSlice(self.allocator, "        }\n");
             }
         }
-
-        try self.buffer.appendSlice(self.allocator,
-            \\
-            \\        if (self.extra_body) |extra| {
             \\            if (extra == .object) {
             \\                var iterator = extra.object.iterator();
             \\                while (iterator.next()) |entry| {

--- a/src/generators/unified/model_generator.zig
+++ b/src/generators/unified/model_generator.zig
@@ -1107,8 +1107,11 @@ pub const UnifiedModelGenerator = struct {
     }
 
     fn generateStructField(self: *UnifiedModelGenerator, owner_name: []const u8, field_name: []const u8, field_schema: Schema, is_required: bool) !void {
+        const sanitized_field_name = try self.sanitizeIdentifierAlloc(field_name);
+        defer self.allocator.free(sanitized_field_name);
+
         try self.buffer.appendSlice(self.allocator, "    ");
-        try self.appendIdentifier(field_name);
+        try self.buffer.appendSlice(self.allocator, sanitized_field_name);
         try self.buffer.appendSlice(self.allocator, ": ");
 
         if (try self.appendManualFieldType(owner_name, field_name)) {
@@ -1149,16 +1152,18 @@ pub const UnifiedModelGenerator = struct {
         var prop_iterator = properties.iterator();
         while (prop_iterator.next()) |entry| {
             const field_name = entry.key_ptr.*;
+            const sanitized_field_name = try self.sanitizeIdentifierAlloc(field_name);
+            defer self.allocator.free(sanitized_field_name);
             if (self.isFieldRequired(field_name, required)) {
                 try self.buffer.appendSlice(self.allocator, "        try jw.objectField(\"");
                 try self.buffer.appendSlice(self.allocator, field_name);
                 try self.buffer.appendSlice(self.allocator, "\");\n");
                 try self.buffer.appendSlice(self.allocator, "        try jw.write(self.");
-                try self.appendIdentifier(field_name);
+                try self.buffer.appendSlice(self.allocator, sanitized_field_name);
                 try self.buffer.appendSlice(self.allocator, ");\n");
             } else {
                 try self.buffer.appendSlice(self.allocator, "        if (self.");
-                try self.appendIdentifier(field_name);
+                try self.buffer.appendSlice(self.allocator, sanitized_field_name);
                 try self.buffer.appendSlice(self.allocator, ") |value| {\n");
                 try self.buffer.appendSlice(self.allocator, "            try jw.objectField(\"");
                 try self.buffer.appendSlice(self.allocator, field_name);

--- a/src/tests/model_typing_tests.zig
+++ b/src/tests/model_typing_tests.zig
@@ -86,11 +86,8 @@ test "model generator sanitizes only reserved property names and keeps camelCase
 
     try std.testing.expect(std.mem.indexOf(u8, code, "petId: ?[]const u8 = null") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "pet_id: ?[]const u8 = null") == null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "type_: ?[]const u8 = null") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "type: ?[]const u8 = null") == null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "objectField(\"type\")") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "self.type_") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "source.object.get(\"type\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "@\"type\": ?[]const u8 = null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "type_: ?[]const u8 = null") == null);
 }
 
 test "model generator disambiguates type and type_ collisions deterministically" {
@@ -129,10 +126,8 @@ test "model generator disambiguates type and type_ collisions deterministically"
     const code = try generator.generate(document);
     defer allocator.free(code);
 
+    try std.testing.expect(std.mem.indexOf(u8, code, "@\"type\": ?[]const u8 = null") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "type_: ?[]const u8 = null") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "type__: ?[]const u8 = null") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "objectField(\"type\")") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "objectField(\"type_\")") != null);
 }
 
 test "model generator emits empty struct for empty-property object" {

--- a/src/tests/model_typing_tests.zig
+++ b/src/tests/model_typing_tests.zig
@@ -3,13 +3,17 @@ const common = @import("../models/common/document.zig");
 const models = @import("../models.zig");
 const OpenApi31Converter = @import("../generators/converters/openapi31_converter.zig").OpenApi31Converter;
 const UnifiedModelGenerator = @import("../generators/unified/model_generator.zig").UnifiedModelGenerator;
+const test_utils = @import("test_utils.zig");
 
 fn stringSchema() common.Schema {
     return .{ .type = .string };
 }
 
 test "model generator treats properties without type as struct" {
-    const allocator = std.testing.allocator;
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    defer std.debug.assert(gpa.deinit() == .ok);
+
     var properties = std.StringHashMap(common.Schema).init(allocator);
     defer {
         var iterator = properties.iterator();
@@ -44,14 +48,18 @@ test "model generator treats properties without type as struct" {
     try std.testing.expect(std.mem.indexOf(u8, code, "foo: ?[]const u8 = null") != null);
 }
 
-test "model generator sanitizes reserved property names like type" {
-    const allocator = std.testing.allocator;
+test "model generator sanitizes only reserved property names and keeps camelCase wire names" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    defer std.debug.assert(gpa.deinit() == .ok);
+
     var properties = std.StringHashMap(common.Schema).init(allocator);
     defer {
         var iterator = properties.iterator();
         while (iterator.next()) |entry| allocator.free(entry.key_ptr.*);
         properties.deinit();
     }
+    try properties.put(try allocator.dupe(u8, "petId"), stringSchema());
     try properties.put(try allocator.dupe(u8, "type"), stringSchema());
 
     var schemas = std.StringHashMap(common.Schema).init(allocator);
@@ -76,8 +84,55 @@ test "model generator sanitizes reserved property names like type" {
     const code = try generator.generate(document);
     defer allocator.free(code);
 
+    try std.testing.expect(std.mem.indexOf(u8, code, "petId: ?[]const u8 = null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "pet_id: ?[]const u8 = null") == null);
     try std.testing.expect(std.mem.indexOf(u8, code, "type_: ?[]const u8 = null") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "type: ?[]const u8 = null") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "objectField(\"type\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "self.type_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "source.object.get(\"type\")") != null);
+}
+
+test "model generator disambiguates type and type_ collisions deterministically" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    defer std.debug.assert(gpa.deinit() == .ok);
+
+    var properties = std.StringHashMap(common.Schema).init(allocator);
+    defer {
+        var iterator = properties.iterator();
+        while (iterator.next()) |entry| allocator.free(entry.key_ptr.*);
+        properties.deinit();
+    }
+    try properties.put(try allocator.dupe(u8, "type"), stringSchema());
+    try properties.put(try allocator.dupe(u8, "type_"), stringSchema());
+
+    var schemas = std.StringHashMap(common.Schema).init(allocator);
+    defer {
+        var iterator = schemas.iterator();
+        while (iterator.next()) |entry| allocator.free(entry.key_ptr.*);
+        schemas.deinit();
+    }
+    try schemas.put(try allocator.dupe(u8, "Thing"), .{ .properties = properties });
+
+    var paths = std.StringHashMap(common.PathItem).init(allocator);
+    defer paths.deinit();
+    const document: common.UnifiedDocument = .{
+        .version = "3.1.0",
+        .info = .{ .title = "fixture", .version = "1.0.0" },
+        .paths = paths,
+        .schemas = schemas,
+    };
+
+    var generator = UnifiedModelGenerator.init(allocator);
+    defer generator.deinit();
+    const code = try generator.generate(document);
+    defer allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "type_: ?[]const u8 = null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "type__: ?[]const u8 = null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "objectField(\"type\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "objectField(\"type_\")") != null);
 }
 
 test "model generator emits empty struct for empty-property object" {
@@ -392,7 +447,7 @@ test "model generator emits named types for field-level composite schemas" {
     try std.testing.expect(std.mem.indexOf(u8, code, "pub const ThingValue = union(enum)") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "value: ThingValue") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "pub const ThingContent = union(enum)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "text_part_items: []const TextPart") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "TextPart_items: []const TextPart") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "content: ThingContent") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "[]const std.json.Value") == null);
 }

--- a/src/tests/model_typing_tests.zig
+++ b/src/tests/model_typing_tests.zig
@@ -44,6 +44,42 @@ test "model generator treats properties without type as struct" {
     try std.testing.expect(std.mem.indexOf(u8, code, "foo: ?[]const u8 = null") != null);
 }
 
+test "model generator sanitizes reserved property names like type" {
+    const allocator = std.testing.allocator;
+    var properties = std.StringHashMap(common.Schema).init(allocator);
+    defer {
+        var iterator = properties.iterator();
+        while (iterator.next()) |entry| allocator.free(entry.key_ptr.*);
+        properties.deinit();
+    }
+    try properties.put(try allocator.dupe(u8, "type"), stringSchema());
+
+    var schemas = std.StringHashMap(common.Schema).init(allocator);
+    defer {
+        var iterator = schemas.iterator();
+        while (iterator.next()) |entry| allocator.free(entry.key_ptr.*);
+        schemas.deinit();
+    }
+    try schemas.put(try allocator.dupe(u8, "Thing"), .{ .properties = properties });
+
+    var paths = std.StringHashMap(common.PathItem).init(allocator);
+    defer paths.deinit();
+    const document: common.UnifiedDocument = .{
+        .version = "3.1.0",
+        .info = .{ .title = "fixture", .version = "1.0.0" },
+        .paths = paths,
+        .schemas = schemas,
+    };
+
+    var generator = UnifiedModelGenerator.init(allocator);
+    defer generator.deinit();
+    const code = try generator.generate(document);
+    defer allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "type_: ?[]const u8 = null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "type: ?[]const u8 = null") == null);
+}
+
 test "model generator emits empty struct for empty-property object" {
     const allocator = std.testing.allocator;
 


### PR DESCRIPTION
This fixes generated Zig model code for OpenAPI schemas that contain a property named `type`. In Zig, `type` is a reserved keyword, so the previous generator emitted invalid field names and a generated model could fail to compile.

The fix sanitizes reserved property identifiers at generation time while keeping the original JSON field names when serializing, so schema compatibility stays intact on the wire without forcing a breaking API change in the generated code.

Fixes #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated models with reserved property names, such as `type`, by safely normalizing them for use in Zig code.
  * Preserved original property names in JSON output for compatibility with existing schemas.
  * Prevented naming collisions when different properties sanitize to the same Zig identifier.
  * Preserved camelCase property names and improved handling of renamed fields in JSON serialization.

* **Tests**
  * Added coverage for reserved names, naming collisions, and nested generated fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->