### PR TITLE
Reserve Zig type keyword in generated identifiers

### DIFF
--- a/src/generators/unified/ident_utils.zig
+++ b/src/generators/unified/ident_utils.zig
@@ -74,6 +74,7 @@ test "isReservedIdent" {
     try std.testing.expect(isReservedIdent("if"));
     try std.testing.expect(isReservedIdent("return"));
     try std.testing.expect(isReservedIdent("struct"));
+    try std.testing.expect(isReservedIdent("type"));
     try std.testing.expect(!isReservedIdent("foo"));
     try std.testing.expect(!isReservedIdent(""));
 }

--- a/src/generators/unified/ident_utils.zig
+++ b/src/generators/unified/ident_utils.zig
@@ -16,7 +16,7 @@ pub fn isReservedIdent(name: []const u8) bool {
         "extern",    "false",    "fn",        "for",    "if",          "inline",   "isize",          "linksection",
         "noalias",   "noreturn", "nosuspend", "null",   "opaque",      "or",       "orelse",         "packed",
         "pub",       "resume",   "return",    "struct", "suspend",     "switch",   "test",           "threadlocal",
-        "true",      "try",      "undefined", "union",  "unreachable", "usize",    "usingnamespace", "var",
+        "true",      "try",      "type",      "undefined", "union",  "unreachable", "usize",    "usingnamespace", "var",
         "void",      "volatile", "while",
     };
     for (reserved) |word| {


### PR DESCRIPTION
The generator was treating `type` as a normal identifier when it produced parameter names, which let generated Zig functions shadow the builtin `type` primitive. That breaks specs such as NetBox that frequently use `type` as a query parameter.

This change adds `type` to the reserved Zig identifier list used during sanitization, so generated names are escaped safely without changing the rest of the generator behavior.

Closes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identifier validation by correctly reserving the `type` keyword.
  * Prevented generated or user-defined identifiers from conflicting with language-reserved terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->