### PR TITLE
Allow keywords like `type` as struct field names while keeping them escaped in function arguments

### DIFF
--- a/src/generators/unified/ident_utils.zig
+++ b/src/generators/unified/ident_utils.zig
@@ -25,6 +25,24 @@ pub fn isReservedIdent(name: []const u8) bool {
     return false;
 }
 
+/// Keywords that cannot be used bare as struct field names. Primitive type
+/// names such as `type`, `bool`, and `void` are valid field names in Zig and
+/// `zig fmt` rewrites their escaped form back to the bare keyword.
+pub fn isReservedFieldIdent(name: []const u8) bool {
+    const reserved_field = [_][]const u8{
+        "addrspace",   "align",       "allowzero", "and",      "anyframe", "anytype", "asm",         "break",
+        "callconv",    "catch",       "comptime",  "const",    "continue", "defer",   "else",        "enum",
+        "errdefer",    "error",       "export",    "extern",   "fn",       "for",     "if",          "inline",
+        "linksection", "noalias",     "nosuspend", "opaque",   "or",       "orelse",  "packed",      "pub",
+        "resume",      "return",      "struct",    "suspend",  "switch",   "test",    "threadlocal", "try",
+        "union",       "unreachable", "var",       "volatile", "while",
+    };
+    for (reserved_field) |word| {
+        if (std.mem.eql(u8, name, word)) return true;
+    }
+    return false;
+}
+
 pub fn isBareIdentifier(name: []const u8) bool {
     if (name.len == 0 or !isIdentStart(name[0]) or isReservedIdent(name)) return false;
     for (name[1..]) |c| {
@@ -33,8 +51,24 @@ pub fn isBareIdentifier(name: []const u8) bool {
     return true;
 }
 
+pub fn isBareFieldIdentifier(name: []const u8) bool {
+    if (name.len == 0 or !isIdentStart(name[0]) or isReservedFieldIdent(name)) return false;
+    for (name[1..]) |c| {
+        if (!isIdentContinue(c)) return false;
+    }
+    return true;
+}
+
 pub fn appendIdentifier(buffer: *std.ArrayList(u8), allocator: std.mem.Allocator, name: []const u8) !void {
-    if (isBareIdentifier(name)) {
+    try appendIdentifierAs(buffer, allocator, name, isBareIdentifier);
+}
+
+pub fn appendFieldIdentifier(buffer: *std.ArrayList(u8), allocator: std.mem.Allocator, name: []const u8) !void {
+    try appendIdentifierAs(buffer, allocator, name, isBareFieldIdentifier);
+}
+
+fn appendIdentifierAs(buffer: *std.ArrayList(u8), allocator: std.mem.Allocator, name: []const u8, comptime is_bare: fn ([]const u8) bool) !void {
+    if (is_bare(name)) {
         try buffer.appendSlice(allocator, name);
         return;
     }
@@ -79,12 +113,29 @@ test "isReservedIdent" {
     try std.testing.expect(!isReservedIdent(""));
 }
 
+test "isReservedFieldIdent" {
+    try std.testing.expect(isReservedFieldIdent("if"));
+    try std.testing.expect(isReservedFieldIdent("return"));
+    try std.testing.expect(isReservedFieldIdent("struct"));
+    try std.testing.expect(!isReservedFieldIdent("type"));
+    try std.testing.expect(!isReservedFieldIdent("foo"));
+    try std.testing.expect(!isReservedFieldIdent(""));
+}
+
 test "isBareIdentifier" {
     try std.testing.expect(isBareIdentifier("foo"));
     try std.testing.expect(isBareIdentifier("_bar"));
     try std.testing.expect(!isBareIdentifier(""));
     try std.testing.expect(!isBareIdentifier("0foo"));
     try std.testing.expect(!isBareIdentifier("if"));
+}
+
+test "isBareFieldIdentifier" {
+    try std.testing.expect(isBareFieldIdentifier("foo"));
+    try std.testing.expect(isBareFieldIdentifier("type"));
+    try std.testing.expect(!isBareFieldIdentifier(""));
+    try std.testing.expect(!isBareFieldIdentifier("0foo"));
+    try std.testing.expect(!isBareFieldIdentifier("if"));
 }
 
 test "appendIdentifier" {
@@ -98,4 +149,20 @@ test "appendIdentifier" {
     buf.clearRetainingCapacity();
     try appendIdentifier(&buf, std.testing.allocator, "quote\"here");
     try std.testing.expectEqualStrings("@\"quote\\\"here\"", buf.items);
+    buf.clearRetainingCapacity();
+    try appendIdentifier(&buf, std.testing.allocator, "type");
+    try std.testing.expectEqualStrings("@\"type\"", buf.items);
+}
+
+test "appendFieldIdentifier" {
+    var buf = std.ArrayList(u8).empty;
+    defer buf.deinit(std.testing.allocator);
+    try appendFieldIdentifier(&buf, std.testing.allocator, "type");
+    try std.testing.expectEqualStrings("type", buf.items);
+    buf.clearRetainingCapacity();
+    try appendFieldIdentifier(&buf, std.testing.allocator, "if");
+    try std.testing.expectEqualStrings("@\"if\"", buf.items);
+    buf.clearRetainingCapacity();
+    try appendFieldIdentifier(&buf, std.testing.allocator, "has space");
+    try std.testing.expectEqualStrings("@\"has space\"", buf.items);
 }

--- a/src/generators/unified/model_generator.zig
+++ b/src/generators/unified/model_generator.zig
@@ -42,6 +42,10 @@ pub const UnifiedModelGenerator = struct {
         try ident.appendIdentifier(&self.buffer, self.allocator, name);
     }
 
+    fn appendFieldIdentifier(self: *UnifiedModelGenerator, name: []const u8) !void {
+        try ident.appendFieldIdentifier(&self.buffer, self.allocator, name);
+    }
+
     fn generateHeader(self: *UnifiedModelGenerator) !void {
         try self.buffer.appendSlice(self.allocator,
             \\const std = @import("std");
@@ -1113,7 +1117,7 @@ pub const UnifiedModelGenerator = struct {
 
     fn generateStructField(self: *UnifiedModelGenerator, owner_name: []const u8, field_name: []const u8, field_schema: Schema, is_required: bool) !void {
         try self.buffer.appendSlice(self.allocator, "    ");
-        try self.appendIdentifier(field_name);
+        try self.appendFieldIdentifier(field_name);
         try self.buffer.appendSlice(self.allocator, ": ");
 
         if (try self.appendManualFieldType(owner_name, field_name)) {
@@ -1159,11 +1163,11 @@ pub const UnifiedModelGenerator = struct {
                 try self.buffer.appendSlice(self.allocator, field_name);
                 try self.buffer.appendSlice(self.allocator, "\");\n");
                 try self.buffer.appendSlice(self.allocator, "        try jw.write(self.");
-                try self.appendIdentifier(field_name);
+                try self.appendFieldIdentifier(field_name);
                 try self.buffer.appendSlice(self.allocator, ");\n");
             } else {
                 try self.buffer.appendSlice(self.allocator, "        if (self.");
-                try self.appendIdentifier(field_name);
+                try self.appendFieldIdentifier(field_name);
                 try self.buffer.appendSlice(self.allocator, ") |value| {\n");
                 try self.buffer.appendSlice(self.allocator, "            try jw.objectField(\"");
                 try self.buffer.appendSlice(self.allocator, field_name);

--- a/src/tests/binary_payload_tests.zig
+++ b/src/tests/binary_payload_tests.zig
@@ -408,6 +408,47 @@ test "generated v3.0 :: uploadFile takes []const u8 requestBody and emits octet-
     try testing.expect(std.mem.indexOf(u8, upload_block, "\"application/octet-stream\", \"application/json\"") != null);
 }
 
+test "generated v3.0 :: query parameter named type stays escaped as a function argument" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    defer std.debug.assert(gpa.deinit() == .ok);
+
+    const spec =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "T", "version": "1" },
+        \\  "paths": {
+        \\    "/search": {
+        \\      "get": {
+        \\        "operationId": "search",
+        \\        "parameters": [
+        \\          { "name": "type", "in": "query", "required": true, "schema": { "type": "string" } }
+        \\        ],
+        \\        "responses": { "200": { "description": "ok" } }
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    // The parsed document must outlive both the conversion and the generation
+    // because the unified document borrows its string slices.
+    var parsed = try models.OpenApiDocument.parseFromJson(allocator, spec);
+    defer parsed.deinit(allocator);
+    var converter = OpenApiConverter.init(allocator);
+    var unified = try converter.convert(parsed);
+    defer unified.deinit(allocator);
+
+    var generator = UnifiedApiGenerator.init(allocator, .{ .input_path = "fixture.json" });
+    defer generator.deinit();
+    const code = try generator.generate(unified);
+    defer allocator.free(code);
+
+    // Struct fields may use the bare keyword, but function arguments must keep
+    // the escaped form so the generated code does not shadow the type primitive.
+    try testing.expect(std.mem.indexOf(u8, code, "pub fn search(client: *Client, @\"type\": []const u8)") != null);
+    try testing.expect(std.mem.indexOf(u8, code, "pub fn searchRaw(client: *Client, @\"type\": []const u8)") != null);
+}
+
 test "generated v3.0 :: addPet still uses JSON encoding for application/json body" {
     var gpa = test_utils.createTestAllocator();
     const allocator = gpa.allocator();

--- a/src/tests/model_typing_tests.zig
+++ b/src/tests/model_typing_tests.zig
@@ -44,6 +44,43 @@ test "model generator treats properties without type as struct" {
     try std.testing.expect(std.mem.indexOf(u8, code, "foo: ?[]const u8 = null") != null);
 }
 
+test "model generator emits type keyword as bare struct field name" {
+    const allocator = std.testing.allocator;
+    var properties = std.StringHashMap(common.Schema).init(allocator);
+    defer {
+        var iterator = properties.iterator();
+        while (iterator.next()) |entry| allocator.free(entry.key_ptr.*);
+        properties.deinit();
+    }
+    try properties.put(try allocator.dupe(u8, "type"), stringSchema());
+    try properties.put(try allocator.dupe(u8, "foo"), stringSchema());
+
+    var schemas = std.StringHashMap(common.Schema).init(allocator);
+    defer {
+        var iterator = schemas.iterator();
+        while (iterator.next()) |entry| allocator.free(entry.key_ptr.*);
+        schemas.deinit();
+    }
+    try schemas.put(try allocator.dupe(u8, "Thing"), .{ .properties = properties });
+
+    var paths = std.StringHashMap(common.PathItem).init(allocator);
+    defer paths.deinit();
+    const document: common.UnifiedDocument = .{
+        .version = "3.1.0",
+        .info = .{ .title = "fixture", .version = "1.0.0" },
+        .paths = paths,
+        .schemas = schemas,
+    };
+
+    var generator = UnifiedModelGenerator.init(allocator);
+    defer generator.deinit();
+    const code = try generator.generate(document);
+    defer allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "type: ?[]const u8 = null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "@\"type\"") == null);
+}
+
 test "model generator emits empty struct for empty-property object" {
     const allocator = std.testing.allocator;
 


### PR DESCRIPTION
Split reserved-word handling in ident_utils.zig into struct-field and function-argument lists so keywords like type stay bare as struct fields (which zig fmt requires) while remaining escaped in function arguments (to avoid shadowing the type primitive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated client code handling for reserved words used as request parameters and model properties.
  - Generated function arguments now escape names such as `type` when required.
  - Generated model fields preserve valid names such as `type` without unnecessary escaping.
- **Tests**
  - Added coverage for reserved-word parameters and model properties in generated standard and raw methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->