### PR TITLE
Add install-release build steps

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -103,6 +103,11 @@ pub fn build(b: *std.Build) void {
         build_all_step.dependOn(&install_cross_exe.step);
     }
 
+    addInstallStep(b, target, build_info, yaml_dep, "install-release", "Build ReleaseSmall and install to $HOME/.local/bin", .ReleaseSmall);
+    addInstallStep(b, target, build_info, yaml_dep, "install-release-safe", "Build ReleaseSafe and install to $HOME/.local/bin", .ReleaseSafe);
+    addInstallStep(b, target, build_info, yaml_dep, "install-release-fast", "Build ReleaseFast and install to $HOME/.local/bin", .ReleaseFast);
+    addInstallStep(b, target, build_info, yaml_dep, "install-debug", "Build Debug and install to $HOME/.local/bin", .Debug);
+
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| {
@@ -562,6 +567,114 @@ fn getPackageSnapshotFiles(allocator: std.mem.Allocator, io: std.Io) ?[]const u8
         "examples/package_consumer",
     });
 }
+
+fn addInstallStep(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    build_info: *std.Build.Step.Options,
+    yaml_dep: *std.Build.Dependency,
+    step_name: []const u8,
+    description: []const u8,
+    optimize: std.builtin.OptimizeMode,
+) void {
+    const exe = addOpenApi2ZigExecutable(b, "openapi2zig", target, optimize, build_info, yaml_dep);
+    const install_step = b.step(step_name, description);
+    const install = InstallReleaseStep.create(b, @tagName(optimize), exe.getEmittedBin(), getInstallPrefix(b), exe.out_filename);
+    install_step.dependOn(&install.step);
+}
+
+fn addOpenApi2ZigExecutable(
+    b: *std.Build,
+    name: []const u8,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    build_info: *std.Build.Step.Options,
+    yaml_dep: *std.Build.Dependency,
+) *std.Build.Step.Compile {
+    const root_module = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    root_module.addOptions("build_info", build_info);
+    root_module.addImport("yaml", yaml_dep.module("yaml"));
+
+    const exe = b.addExecutable(.{
+        .name = name,
+        .root_module = root_module,
+    });
+
+    const openapi2zig_mod = b.createModule(.{
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    openapi2zig_mod.addIncludePath(b.path("src"));
+    openapi2zig_mod.addOptions("build_info", build_info);
+    openapi2zig_mod.addImport("yaml", yaml_dep.module("yaml"));
+    root_module.addImport("openapi2zig", openapi2zig_mod);
+
+    return exe;
+}
+
+fn getInstallPrefix(b: *std.Build) []const u8 {
+    const default_prefix = b.build_root.join(b.allocator, &.{"zig-out"}) catch @panic("OOM");
+    if (!std.mem.eql(u8, b.install_prefix, default_prefix)) {
+        return b.install_prefix;
+    }
+
+    if (b.graph.environ_map.get("INSTALL_DIR")) |install_dir| {
+        if (install_dir.len > 0) return install_dir;
+    }
+
+    if (b.graph.environ_map.get("HOME")) |home| {
+        if (home.len > 0) return b.pathJoin(&.{ home, ".local", "bin" });
+    }
+    if (b.graph.environ_map.get("USERPROFILE")) |home| {
+        if (home.len > 0) return b.pathJoin(&.{ home, ".local", "bin" });
+    }
+
+    @panic("unable to determine install directory: set HOME, USERPROFILE, or INSTALL_DIR");
+}
+
+const InstallReleaseStep = struct {
+    step: std.Build.Step,
+    source: std.Build.LazyPath,
+    dest_dir: []const u8,
+    dest_name: []const u8,
+
+    fn create(
+        b: *std.Build,
+        label: []const u8,
+        source: std.Build.LazyPath,
+        dest_dir: []const u8,
+        dest_name: []const u8,
+    ) *InstallReleaseStep {
+        const self = b.allocator.create(InstallReleaseStep) catch @panic("OOM");
+        self.* = .{
+            .step = std.Build.Step.init(.{
+                .id = .custom,
+                .name = b.fmt("install {s} ({s}) to {s}", .{ dest_name, label, dest_dir }),
+                .owner = b,
+                .makeFn = make,
+            }),
+            .source = source.dupe(b),
+            .dest_dir = b.dupePath(dest_dir),
+            .dest_name = b.dupePath(dest_name),
+        };
+        source.addStepDependencies(&self.step);
+        return self;
+    }
+
+    fn make(step: *std.Build.Step, options: std.Build.Step.MakeOptions) anyerror!void {
+        _ = options;
+        const b = step.owner;
+        const self: *InstallReleaseStep = @fieldParentPtr("step", step);
+        const dest_path = b.pathResolve(&.{ self.dest_dir, self.dest_name });
+        const p = try step.installFile(self.source, dest_path);
+        step.result_cached = p == .fresh;
+    }
+};
 
 fn getGitOutput(allocator: std.mem.Allocator, io: std.Io, argv: []const []const u8) ?[]const u8 {
     const result = std.process.run(allocator, io, .{


### PR DESCRIPTION
Add install-release, install-release-safe, install-release-fast, and install-debug build steps that install the binary to \C:\Users\chris/.local/bin (or custom prefix).

Includes helper functions:
- addInstallStep - Creates install steps for each optimize mode
- addOpenApi2ZigExecutable - Helper to create executable with proper module dependencies
- getInstallPrefix - Determines install directory (honors --prefix, INSTALL_DIR, HOME, USERPROFILE)
- InstallReleaseStep - Custom step that copies the binary to the target directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added installation support for ReleaseSmall, ReleaseSafe, ReleaseFast, and Debug builds.
  * Added automatic resolution of the installation directory using configured or environment-based paths.
  * Added a custom install option that copies the built executable to the selected destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->