### PR TITLE
Reuse existing runtime via --runtime-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The `generate` command reads a JSON or YAML OpenAPI/Swagger document from a loca
 | `--models-only` | Generate only Zig models, skipping the API client. |
 | `--multiple-files` | Generate separate output files for models, runtime, and API client into the output directory specified by `-o`. |
 | `--file-name <kind>=<name>` | Customize an output file name in `--multiple-files` mode. `<kind>` is `models`, `runtime`, or `client`. `<name>` may include a relative subpath (e.g. `models=gen/types.zig`); any required parent directories are created automatically. Can be specified multiple times. |
+| `--runtime-module <path>` | Re-use an existing `runtime.zig` instead of generating a new one. The path is a Zig import path relative to the generated `client.zig` (e.g. `../runtime.zig` or `../shared/my_runtime.zig`). Requires `--multiple-files` and is mutually exclusive with `--file-name runtime=...`. When given, no `runtime.zig` is emitted; the client imports the supplied path and derives the import alias from the file basename (`my_runtime` for `my_runtime.zig`). |
 | `--force` | Force overwriting output even when unchanged (skip unchanged-content check). |
 | `--parameters-as-struct` | Wrap the method parameters of each operation in a single `options` struct instead of emitting them as individual function arguments. Optional query parameters become nullable fields defaulting to `null`; required path and query parameters stay non-optional. The request body, when present, remains a separate `requestBody` argument. |
 
@@ -320,6 +321,19 @@ defer pet.deinit();
 ```
 
 `--multiple-clients` is mutually exclusive with a non-`none` `--resource-wrappers` and with `--models-only`; combining them is a parse error. It composes with `--multiple-files`: the client structs are emitted into the client file.
+
+**Re-use an existing runtime when generating multiple clients (avoid duplicate `runtime.zig`):**
+```bash
+# Generate a shared runtime once
+openapi2zig generate -i openapi/v3.0/petstore.json -o generated/shared --multiple-files
+
+# Re-use it from other clients via a client-relative import path
+openapi2zig generate -i openapi/v3.1/anthropic.json -o generated/anthropic --multiple-files --runtime-module ../shared/runtime.zig
+openapi2zig generate -i openapi/v3.1/openai.json -o generated/openai --multiple-files --runtime-module ../shared/runtime.zig
+# With custom models file name, the same pattern applies:
+openapi2zig generate -i openapi/v3.1/lmstudio.json -o generated/lmstudio --multiple-files --file-name models=contracts.zig --runtime-module ../shared/runtime.zig
+```
+When `--runtime-module` is given, no `runtime.zig` is emitted in the output directory; `client.zig` instead contains `const runtime = @import("../shared/runtime.zig");` (alias derived from the file basename, e.g. `my_runtime` for `my_runtime.zig`) and re-exports `Owned`, `RawResponse`, etc. from that module. The flag requires `--multiple-files` and is mutually exclusive with `--file-name runtime=...`. If the target file does not yet exist, generation still succeeds with an info log so you can generate the shared runtime first.
 
 ### Upgrading
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -157,7 +157,7 @@ fn findDuplicateFileName(file_names: FileNameOverrides) ?[]const u8 {
 /// Compare two output file names treating '/' and '\' as equivalent path
 /// separators and ignoring case, matching how the same on-disk path resolves on
 /// case-insensitive filesystems.
-fn fileNamesCollide(a: []const u8, b: []const u8) bool {
+pub fn fileNamesCollide(a: []const u8, b: []const u8) bool {
     if (a.len != b.len) return false;
     for (a, b) |ca, cb| {
         const na = if (ca == '/' or ca == '\\') '/' else std.ascii.toLower(ca);
@@ -231,7 +231,7 @@ pub fn importDirname(path: []const u8) ?[]const u8 {
     return null;
 }
 
-fn resolveRuntimeModulePath(allocator: std.mem.Allocator, client_name: []const u8, runtime_mod: []const u8) ![]const u8 {
+pub fn resolveRuntimeModulePath(allocator: std.mem.Allocator, client_name: []const u8, runtime_mod: []const u8) ![]const u8 {
     const client_dir = importDirname(client_name);
     var segments = std.ArrayList([]const u8).empty;
     defer segments.deinit(allocator);
@@ -316,14 +316,14 @@ fn validateFileName(name: []const u8) error{InvalidFileName}!void {
 /// Return true when `path` is absolute under any platform's conventions. This
 /// treats root-relative and Windows drive paths as absolute regardless of the
 /// build host, so import validation does not depend on the platform.
-fn isAbsoluteImportPath(path: []const u8) bool {
+pub fn isAbsoluteImportPath(path: []const u8) bool {
     if (path.len == 0) return false;
     if (path[0] == '/' or path[0] == '\\') return true;
     if (path.len >= 2 and std.ascii.isAlphabetic(path[0]) and path[1] == ':') return true;
     return false;
 }
 
-fn validateImportPath(path: []const u8) error{InvalidFileName}!void {
+pub fn validateImportPath(path: []const u8) error{InvalidFileName}!void {
     if (isAbsoluteImportPath(path)) return error.InvalidFileName;
     if (path.len == 0) return error.InvalidFileName;
     var fwd = std.mem.splitScalar(u8, path, '/');

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -314,13 +314,12 @@ fn validateFileName(name: []const u8) error{InvalidFileName}!void {
 }
 
 /// Return true when `path` is absolute under any platform's conventions. This
-/// treats root-relative and drive-letter paths as absolute regardless of the
+/// treats root-relative and Windows drive paths as absolute regardless of the
 /// build host, so import validation does not depend on the platform.
 fn isAbsoluteImportPath(path: []const u8) bool {
     if (path.len == 0) return false;
     if (path[0] == '/' or path[0] == '\\') return true;
-    if (path.len >= 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and
-        (path[2] == '/' or path[2] == '\\')) return true;
+    if (path.len >= 2 and std.ascii.isAlphabetic(path[0]) and path[1] == ':') return true;
     return false;
 }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1601,6 +1601,8 @@ test "parse rejects --runtime-module with absolute path" {
         "C:\\absolute\\runtime.zig",
         "C:/absolute/runtime.zig",
         "\\\\server\\share\\runtime.zig",
+        "C:runtime.zig",
+        "C:shared\\runtime.zig",
     };
     for (cases) |path| {
         const argv = [_][:0]const u8{
@@ -1663,6 +1665,9 @@ test "validateImportPath rejects absolute paths on any platform" {
     try std.testing.expectError(error.InvalidFileName, validateImportPath("\\abs\\runtime.zig"));
     try std.testing.expectError(error.InvalidFileName, validateImportPath("C:\\abs\\runtime.zig"));
     try std.testing.expectError(error.InvalidFileName, validateImportPath("C:/abs/runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("C:runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("C:shared\\runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("C:shared/runtime.zig"));
     try std.testing.expectError(error.InvalidFileName, validateImportPath("\\\\server\\share\\runtime.zig"));
     try std.testing.expectError(error.InvalidFileName, validateImportPath("//server/share/runtime.zig"));
 }
@@ -1780,6 +1785,21 @@ test "parse rejects runtime-module resolved relative to client dir that collides
         "../models.zig",
         "--file-name",
         "client=sub/client.zig",
+    };
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects runtime-module resolved relative to backslash client dir" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../models.zig",
+        "--file-name",
+        "client=sub\\client.zig",
     };
     try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -204,6 +204,19 @@ pub fn deriveAlias(allocator: std.mem.Allocator, file_name: []const u8, fallback
     return allocator.dupe(u8, deriveAliasInto(&buf, file_name, fallback));
 }
 
+/// Return the basename of an import path, treating both '/' and '\' as
+/// separators. This handles Windows-style paths correctly on non-Windows hosts.
+pub fn importBasename(path: []const u8) []const u8 {
+    var i = path.len;
+    while (i > 0) {
+        i -= 1;
+        if (path[i] == '/' or path[i] == '\\') {
+            return path[i + 1 ..];
+        }
+    }
+    return path;
+}
+
 fn effectiveAliasesInto(file_names: FileNameOverrides, bufs: *[3][max_import_alias_len]u8) [3][]const u8 {
     var aliases: [3][]const u8 = undefined;
     const kinds = [_]FileKind{ .models, .runtime, .client };
@@ -543,7 +556,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
             var alias_bufs: [3][max_import_alias_len]u8 = undefined;
             var aliases: [3][]const u8 = undefined;
             aliases[0] = deriveAliasInto(&alias_bufs[0], models_name, "models");
-            aliases[1] = deriveAliasInto(&alias_bufs[1], std.fs.path.basename(mod), "runtime");
+            aliases[1] = deriveAliasInto(&alias_bufs[1], importBasename(mod), "runtime");
             aliases[2] = deriveAliasInto(&alias_bufs[2], client_name, "client");
             if (findDuplicateAlias(aliases)) |dup| {
                 printUsage();
@@ -1565,4 +1578,50 @@ test "validateImportPath rejects dot segments and absolute paths" {
     try std.testing.expectError(error.InvalidFileName, validateImportPath("./runtime.zig"));
     try std.testing.expectError(error.InvalidFileName, validateImportPath("a//b.zig"));
     try std.testing.expectError(error.InvalidFileName, validateImportPath("/abs/runtime.zig"));
+}
+
+test "importBasename handles both separators" {
+    try std.testing.expectEqualStrings("runtime.zig", importBasename("../runtime.zig"));
+    try std.testing.expectEqualStrings("runtime.zig", importBasename("..\\runtime.zig"));
+    try std.testing.expectEqualStrings("my_runtime.zig", importBasename("..\\shared\\my_runtime.zig"));
+    try std.testing.expectEqualStrings("my_runtime.zig", importBasename("../shared/my_runtime.zig"));
+    try std.testing.expectEqualStrings("file.zig", importBasename("file.zig"));
+}
+
+test "validateImportPath allows windows separators and parent traversal" {
+    try validateImportPath("..\\runtime.zig");
+    try validateImportPath("..\\shared\\runtime.zig");
+    try validateImportPath("a\\b\\runtime.zig");
+}
+
+test "parse accepts windows-style runtime-module path" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "..\\shared\\runtime.zig",
+    };
+
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("..\\shared\\runtime.zig", parsed.args.runtime_module.?);
+}
+
+test "parse rejects windows-style runtime-module alias colliding with models alias" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "..\\shared\\my_runtime.zig",
+        "--file-name",
+        "models=my_runtime.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1413,7 +1413,8 @@ test "parse accepts --runtime-module with --multiple-files" {
         "../runtime.zig",
     };
 
-    const parsed = try parse(std.testing.allocator, &argv);
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("../runtime.zig", parsed.args.runtime_module.?);
     try std.testing.expect(parsed.args.multiple_files);
 }
@@ -1431,7 +1432,8 @@ test "parse accepts --runtime-module with nested path and custom models name" {
         "models=contracts.zig",
     };
 
-    const parsed = try parse(std.testing.allocator, &argv);
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("../shared/runtime.zig", parsed.args.runtime_module.?);
     try std.testing.expectEqualStrings("contracts.zig", parsed.args.file_names.models.?);
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1401,3 +1401,166 @@ test "parse generate defaults parameters-as-struct to false" {
 
     try std.testing.expect(!parsed.args.parameters_as_struct);
 }
+
+test "parse accepts --runtime-module with --multiple-files" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../runtime.zig",
+    };
+
+    const parsed = try parse(std.testing.allocator, &argv);
+    try std.testing.expectEqualStrings("../runtime.zig", parsed.args.runtime_module.?);
+    try std.testing.expect(parsed.args.multiple_files);
+}
+
+test "parse accepts --runtime-module with nested path and custom models name" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../shared/runtime.zig",
+        "--file-name",
+        "models=contracts.zig",
+    };
+
+    const parsed = try parse(std.testing.allocator, &argv);
+    try std.testing.expectEqualStrings("../shared/runtime.zig", parsed.args.runtime_module.?);
+    try std.testing.expectEqualStrings("contracts.zig", parsed.args.file_names.models.?);
+}
+
+test "parse rejects --runtime-module without --multiple-files" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--runtime-module",
+        "../runtime.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-module without value" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects duplicate --runtime-module" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../runtime.zig",
+        "--runtime-module",
+        "../other.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-module combined with --file-name runtime" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../runtime.zig",
+        "--file-name",
+        "runtime=custom.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-module with --models-only" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--models-only",
+        "--runtime-module",
+        "../runtime.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-module with absolute path" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "/absolute/runtime.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-module mapping to reserved alias" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../std.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-module alias colliding with models alias" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../runtime.zig",
+        "--file-name",
+        "models=runtime.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "validateImportPath allows parent traversal and nested paths" {
+    try validateImportPath("../runtime.zig");
+    try validateImportPath("../../shared/runtime.zig");
+    try validateImportPath("a/b/runtime.zig");
+}
+
+test "validateImportPath rejects dot segments and absolute paths" {
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("./runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("a//b.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("/abs/runtime.zig"));
+}

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -42,7 +42,7 @@ fn printUsage() void {
         \\                              Can be specified multiple times.
         \\   --runtime-module <path>    Re-use an existing runtime.zig instead of generating one.
         \\                              The path is a Zig import path relative to the generated
-        \\                              client file (e.g. \"../runtime.zig\").
+        \\                              client file (e.g. "../runtime.zig").
         \\                              Requires --multiple-files and is mutually exclusive with
         \\                              --file-name runtime=... .
         \\   --force                   Force overwriting output even when unchanged

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -277,6 +277,7 @@ fn validateImportPath(path: []const u8) error{InvalidFileName}!void {
     while (bwd.next()) |part| {
         if (part.len == 0 or std.mem.eql(u8, part, ".")) return error.InvalidFileName;
     }
+    if (std.mem.eql(u8, importBasename(path), "..")) return error.InvalidFileName;
 }
 
 pub const CliArgs = struct {
@@ -1624,4 +1625,30 @@ test "parse rejects windows-style runtime-module alias colliding with models ali
     };
 
     try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "validateImportPath rejects basename dotdot" {
+    try std.testing.expectError(error.InvalidFileName, validateImportPath(".."));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("a/.."));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("a\\.."));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("../.."));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("..\\.."));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("a/b/.."));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("a\\b\\.."));
+}
+
+test "parse rejects --runtime-module with trailing dotdot" {
+    const cases = [_][:0]const u8{ "..", "a/..", "a\\..", "../..", "..\\.." };
+    for (cases) |path| {
+        const argv = [_][:0]const u8{
+            "openapi2zig",
+            "generate",
+            "-i",
+            "openapi.json",
+            "--multiple-files",
+            "--runtime-module",
+            path,
+        };
+        try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+    }
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1585,17 +1585,24 @@ test "parse rejects --runtime-module with --models-only" {
 }
 
 test "parse rejects --runtime-module with absolute path" {
-    const argv = [_][:0]const u8{
-        "openapi2zig",
-        "generate",
-        "-i",
-        "openapi.json",
-        "--multiple-files",
-        "--runtime-module",
+    const cases = [_][:0]const u8{
         "/absolute/runtime.zig",
+        "C:\\absolute\\runtime.zig",
+        "C:/absolute/runtime.zig",
+        "\\\\server\\share\\runtime.zig",
     };
-
-    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+    for (cases) |path| {
+        const argv = [_][:0]const u8{
+            "openapi2zig",
+            "generate",
+            "-i",
+            "openapi.json",
+            "--multiple-files",
+            "--runtime-module",
+            path,
+        };
+        try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+    }
 }
 
 test "parse rejects --runtime-module mapping to reserved alias" {
@@ -1638,6 +1645,15 @@ test "validateImportPath rejects dot segments and absolute paths" {
     try std.testing.expectError(error.InvalidFileName, validateImportPath("./runtime.zig"));
     try std.testing.expectError(error.InvalidFileName, validateImportPath("a//b.zig"));
     try std.testing.expectError(error.InvalidFileName, validateImportPath("/abs/runtime.zig"));
+}
+
+test "validateImportPath rejects absolute paths on any platform" {
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("/abs/runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("\\abs\\runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("C:\\abs\\runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("C:/abs/runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("\\\\server\\share\\runtime.zig"));
+    try std.testing.expectError(error.InvalidFileName, validateImportPath("//server/share/runtime.zig"));
 }
 
 test "importBasename handles both separators" {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -313,8 +313,19 @@ fn validateFileName(name: []const u8) error{InvalidFileName}!void {
     }
 }
 
+/// Return true when `path` is absolute under any platform's conventions. This
+/// treats root-relative and drive-letter paths as absolute regardless of the
+/// build host, so import validation does not depend on the platform.
+fn isAbsoluteImportPath(path: []const u8) bool {
+    if (path.len == 0) return false;
+    if (path[0] == '/' or path[0] == '\\') return true;
+    if (path.len >= 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and
+        (path[2] == '/' or path[2] == '\\')) return true;
+    return false;
+}
+
 fn validateImportPath(path: []const u8) error{InvalidFileName}!void {
-    if (std.fs.path.isAbsolute(path)) return error.InvalidFileName;
+    if (isAbsoluteImportPath(path)) return error.InvalidFileName;
     if (path.len == 0) return error.InvalidFileName;
     var fwd = std.mem.splitScalar(u8, path, '/');
     while (fwd.next()) |part| {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -217,6 +217,53 @@ pub fn importBasename(path: []const u8) []const u8 {
     return path;
 }
 
+/// Return the directory of an import path, treating both '/' and '\' as
+/// separators. Returns null if there is no directory component.
+pub fn importDirname(path: []const u8) ?[]const u8 {
+    var i = path.len;
+    while (i > 0) {
+        i -= 1;
+        if (path[i] == '/' or path[i] == '\\') {
+            if (i == 0) return "";
+            return path[0..i];
+        }
+    }
+    return null;
+}
+
+fn resolveRuntimeModulePath(allocator: std.mem.Allocator, client_name: []const u8, runtime_mod: []const u8) ![]const u8 {
+    const client_dir = importDirname(client_name);
+    var segments = std.ArrayList([]const u8).empty;
+    defer segments.deinit(allocator);
+    if (client_dir) |dir| {
+        if (dir.len > 0) {
+            var it = std.mem.splitAny(u8, dir, "/\\");
+            while (it.next()) |part| {
+                if (part.len == 0) continue;
+                try segments.append(allocator, part);
+            }
+        }
+    }
+    var it = std.mem.splitAny(u8, runtime_mod, "/\\");
+    while (it.next()) |part| {
+        if (part.len == 0) continue;
+        if (std.mem.eql(u8, part, ".")) continue;
+        if (std.mem.eql(u8, part, "..")) {
+            if (segments.items.len > 0 and !std.mem.eql(u8, segments.getLast(), "..")) {
+                _ = segments.pop();
+            } else {
+                try segments.append(allocator, "..");
+            }
+        } else {
+            try segments.append(allocator, part);
+        }
+    }
+    if (segments.items.len == 0) {
+        return try allocator.dupe(u8, "");
+    }
+    return try std.mem.join(allocator, "/", segments.items);
+}
+
 fn effectiveAliasesInto(file_names: FileNameOverrides, bufs: *[3][max_import_alias_len]u8) [3][]const u8 {
     var aliases: [3][]const u8 = undefined;
     const kinds = [_]FileKind{ .models, .runtime, .client };
@@ -552,6 +599,18 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
             if (fileNamesCollide(models_name, client_name)) {
                 printUsage();
                 printError("duplicate output file name '{s}' for multiple --file-name options\n", .{models_name});
+                return error.InvalidArguments;
+            }
+            const resolved_runtime = try resolveRuntimeModulePath(allocator, client_name, mod);
+            defer allocator.free(resolved_runtime);
+            if (fileNamesCollide(resolved_runtime, models_name)) {
+                printUsage();
+                printError("runtime module path '{s}' resolves to output file '{s}'\n", .{ mod, models_name });
+                return error.InvalidArguments;
+            }
+            if (fileNamesCollide(resolved_runtime, client_name)) {
+                printUsage();
+                printError("runtime module path '{s}' resolves to output file '{s}'\n", .{ mod, client_name });
                 return error.InvalidArguments;
             }
             var alias_bufs: [3][max_import_alias_len]u8 = undefined;
@@ -1650,5 +1709,142 @@ test "parse rejects --runtime-module with trailing dotdot" {
             path,
         };
         try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+    }
+}
+
+test "parse rejects runtime-module that collides with models via case-insensitive match" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "Types.zig",
+        "--file-name",
+        "models=types.zig",
+    };
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects runtime-module that collides with client via case-insensitive match" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "API.ZIG",
+        "--file-name",
+        "client=api.zig",
+    };
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects runtime-module resolved relative to client dir that collides with models" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../models.zig",
+        "--file-name",
+        "client=sub/client.zig",
+    };
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects runtime-module resolved with separator normalization" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "..\\models.zig",
+        "--file-name",
+        "client=sub/client.zig",
+    };
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects runtime-module resolved case-insensitive collision with models" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../Types.zig",
+        "--file-name",
+        "models=types.zig",
+        "--file-name",
+        "client=sub/client.zig",
+    };
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects runtime-module resolved case-insensitive collision with client" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../sub/API.ZIG",
+        "--file-name",
+        "client=sub/api.zig",
+    };
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse accepts runtime-module that does not collide after resolution" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--multiple-files",
+        "--runtime-module",
+        "../runtime/runtime.zig",
+        "--file-name",
+        "client=sub/client.zig",
+    };
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("../runtime/runtime.zig", parsed.args.runtime_module.?);
+}
+
+test "importDirname handles both separators" {
+    try std.testing.expectEqualStrings("a/b", importDirname("a/b/c.zig").?);
+    try std.testing.expectEqualStrings("a\\b", importDirname("a\\b\\c.zig").?);
+    try std.testing.expectEqualStrings("sub", importDirname("sub/client.zig").?);
+    try std.testing.expect(importDirname("client.zig") == null);
+    try std.testing.expectEqualStrings("a/b", importDirname("a/b\\c.zig").?);
+}
+
+test "resolveRuntimeModulePath normalizes dotdot segments" {
+    const cases = [_]struct {
+        client: []const u8,
+        mod: []const u8,
+        expected: []const u8,
+    }{
+        .{ .client = "sub/client.zig", .mod = "../models.zig", .expected = "models.zig" },
+        .{ .client = "sub/client.zig", .mod = "..\\models.zig", .expected = "models.zig" },
+        .{ .client = "a/b/client.zig", .mod = "../../shared/runtime.zig", .expected = "shared/runtime.zig" },
+        .{ .client = "client.zig", .mod = "Types.zig", .expected = "Types.zig" },
+        .{ .client = "sub/api.zig", .mod = "../sub/API.ZIG", .expected = "sub/API.ZIG" },
+        .{ .client = "sub/client.zig", .mod = "../Types.zig", .expected = "Types.zig" },
+    };
+    for (cases) |c| {
+        const resolved = try resolveRuntimeModulePath(std.testing.allocator, c.client, c.mod);
+        defer std.testing.allocator.free(resolved);
+        try std.testing.expectEqualStrings(c.expected, resolved);
     }
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -40,6 +40,11 @@ fn printUsage() void {
         \\                              <kind> is models, runtime, or client.
         \\                              (default: models.zig, runtime.zig, client.zig)
         \\                              Can be specified multiple times.
+        \\   --runtime-module <path>    Re-use an existing runtime.zig instead of generating one.
+        \\                              The path is a Zig import path relative to the generated
+        \\                              client file (e.g. \"../runtime.zig\").
+        \\                              Requires --multiple-files and is mutually exclusive with
+        \\                              --file-name runtime=... .
         \\   --force                   Force overwriting output even when unchanged
         \\   --parameters-as-struct    Wrap method parameters in a single options struct
         \\                            instead of individual function arguments
@@ -248,6 +253,19 @@ fn validateFileName(name: []const u8) error{InvalidFileName}!void {
     }
 }
 
+fn validateImportPath(path: []const u8) error{InvalidFileName}!void {
+    if (std.fs.path.isAbsolute(path)) return error.InvalidFileName;
+    if (path.len == 0) return error.InvalidFileName;
+    var fwd = std.mem.splitScalar(u8, path, '/');
+    while (fwd.next()) |part| {
+        if (part.len == 0 or std.mem.eql(u8, part, ".")) return error.InvalidFileName;
+    }
+    var bwd = std.mem.splitScalar(u8, path, '\\');
+    while (bwd.next()) |part| {
+        if (part.len == 0 or std.mem.eql(u8, part, ".")) return error.InvalidFileName;
+    }
+}
+
 pub const CliArgs = struct {
     input_path: []const u8,
     output_path: ?[]const u8 = null,
@@ -257,6 +275,10 @@ pub const CliArgs = struct {
     multiple_files: bool = false,
     multiple_clients: ?MultipleClientsMode = null,
     file_names: FileNameOverrides = .{},
+    /// Optional import path to an existing runtime.zig. When set, no
+    /// runtime.zig is generated and the client imports this path instead.
+    /// The path is relative to the generated client file.
+    runtime_module: ?[]const u8 = null,
     /// OpenAPI tags to include. When empty, no tag filtering is applied.
     /// The slice is freed by `deinit(allocator)` when `owns_tags` is true.
     tags: []const []const u8 = &.{},
@@ -309,6 +331,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
     var multiple_files = false;
     var multiple_clients: ?MultipleClientsMode = null;
     var file_names: FileNameOverrides = .{};
+    var runtime_module: ?[]const u8 = null;
     var tags_list = std.ArrayList([]const u8).empty;
     defer tags_list.deinit(allocator);
     var tags: []const []const u8 = &.{};
@@ -423,6 +446,27 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
                     return error.InvalidArguments;
                 },
             };
+        } else if (std.mem.eql(u8, arg, "--runtime-module")) {
+            i += 1;
+            if (i >= args.len) {
+                printUsage();
+                printError("--runtime-module value required\n", .{});
+                return error.InvalidArguments;
+            }
+            if (runtime_module != null) {
+                printUsage();
+                printError("duplicate --runtime-module\n", .{});
+                return error.InvalidArguments;
+            }
+            const value = args[i];
+            validateImportPath(value) catch |err| switch (err) {
+                error.InvalidFileName => {
+                    printUsage();
+                    printError("invalid runtime module path '{s}'\n", .{value});
+                    return error.InvalidArguments;
+                },
+            };
+            runtime_module = value;
         } else if (std.mem.eql(u8, arg, "--force")) {
             force = true;
         } else if (std.mem.eql(u8, arg, "--parameters-as-struct")) {
@@ -439,6 +483,24 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
     if (!multiple_files and file_names.any()) {
         printUsage();
         printError("--file-name requires --multiple-files\n", .{});
+        return error.InvalidArguments;
+    }
+
+    if (runtime_module != null and !multiple_files) {
+        printUsage();
+        printError("--runtime-module requires --multiple-files\n", .{});
+        return error.InvalidArguments;
+    }
+
+    if (runtime_module != null and file_names.runtime != null) {
+        printUsage();
+        printError("--runtime-module and --file-name runtime are mutually exclusive\n", .{});
+        return error.InvalidArguments;
+    }
+
+    if (runtime_module != null and models_only) {
+        printUsage();
+        printError("--runtime-module has no effect with --models-only\n", .{});
         return error.InvalidArguments;
     }
 
@@ -468,25 +530,52 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
     }
 
     if (!models_only) {
-        if (findDuplicateFileName(file_names)) |dup| {
-            printUsage();
-            printError("duplicate output file name '{s}' for multiple --file-name options\n", .{dup});
-            return error.InvalidArguments;
-        }
+        if (runtime_module) |mod| {
+            // When re-using an external runtime, only models and client are emitted, so
+            // duplicate checks must be scoped to those two outputs plus the imported runtime alias.
+            const models_name = file_names.get(.models) orelse FileKind.models.defaultName();
+            const client_name = file_names.get(.client) orelse FileKind.client.defaultName();
+            if (fileNamesCollide(models_name, client_name)) {
+                printUsage();
+                printError("duplicate output file name '{s}' for multiple --file-name options\n", .{models_name});
+                return error.InvalidArguments;
+            }
+            var alias_bufs: [3][max_import_alias_len]u8 = undefined;
+            var aliases: [3][]const u8 = undefined;
+            aliases[0] = deriveAliasInto(&alias_bufs[0], models_name, "models");
+            aliases[1] = deriveAliasInto(&alias_bufs[1], std.fs.path.basename(mod), "runtime");
+            aliases[2] = deriveAliasInto(&alias_bufs[2], client_name, "client");
+            if (findDuplicateAlias(aliases)) |dup| {
+                printUsage();
+                printError("output file names map to the same import alias '{s}' for multiple --file-name options\n", .{dup});
+                return error.InvalidArguments;
+            }
+            if (findReservedAlias(aliases)) |alias| {
+                printUsage();
+                printError("output file name maps to import alias '{s}', which the generated client reserves\n", .{alias});
+                return error.InvalidArguments;
+            }
+        } else {
+            if (findDuplicateFileName(file_names)) |dup| {
+                printUsage();
+                printError("duplicate output file name '{s}' for multiple --file-name options\n", .{dup});
+                return error.InvalidArguments;
+            }
 
-        var alias_bufs: [3][max_import_alias_len]u8 = undefined;
-        const aliases = effectiveAliasesInto(file_names, &alias_bufs);
+            var alias_bufs: [3][max_import_alias_len]u8 = undefined;
+            const aliases = effectiveAliasesInto(file_names, &alias_bufs);
 
-        if (findDuplicateAlias(aliases)) |dup| {
-            printUsage();
-            printError("output file names map to the same import alias '{s}' for multiple --file-name options\n", .{dup});
-            return error.InvalidArguments;
-        }
+            if (findDuplicateAlias(aliases)) |dup| {
+                printUsage();
+                printError("output file names map to the same import alias '{s}' for multiple --file-name options\n", .{dup});
+                return error.InvalidArguments;
+            }
 
-        if (findReservedAlias(aliases)) |alias| {
-            printUsage();
-            printError("output file name maps to import alias '{s}', which the generated client reserves\n", .{alias});
-            return error.InvalidArguments;
+            if (findReservedAlias(aliases)) |alias| {
+                printUsage();
+                printError("output file name maps to import alias '{s}', which the generated client reserves\n", .{alias});
+                return error.InvalidArguments;
+            }
         }
     }
 
@@ -506,6 +595,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
             .multiple_files = multiple_files,
             .multiple_clients = multiple_clients,
             .file_names = file_names,
+            .runtime_module = runtime_module,
             .tags = tags,
             .owns_tags = tags_owned,
             .force = force,

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -206,7 +206,8 @@ fn generateMultipleFiles(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.D
 
     const models_file = args.file_names.get(.models) orelse cli.FileKind.models.defaultName();
     const runtime_file = args.file_names.get(.runtime) orelse cli.FileKind.runtime.defaultName();
-    const client_file = args.file_names.get(.client) orelse cli.FileKind.client.defaultName();
+    const client_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.client) orelse cli.FileKind.client.defaultName(), "\\", "/");
+    defer allocator.free(client_file);
 
     var model_generator = UnifiedModelGenerator.init(allocator);
     defer model_generator.deinit();

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -204,8 +204,10 @@ fn generateMultipleFiles(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.D
     const dir_path = args.output_path orelse default_output_dir;
     try cwd.createDirPath(io, dir_path);
 
-    const models_file = args.file_names.get(.models) orelse cli.FileKind.models.defaultName();
-    const runtime_file = args.file_names.get(.runtime) orelse cli.FileKind.runtime.defaultName();
+    const models_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.models) orelse cli.FileKind.models.defaultName(), "\\", "/");
+    defer allocator.free(models_file);
+    const runtime_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.runtime) orelse cli.FileKind.runtime.defaultName(), "\\", "/");
+    defer allocator.free(runtime_file);
     const client_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.client) orelse cli.FileKind.client.defaultName(), "\\", "/");
     defer allocator.free(client_file);
 

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -237,8 +237,12 @@ fn generateMultipleFiles(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.D
         else
             try std.fs.path.join(allocator, &.{ dir_path, runtime_import_path });
         defer allocator.free(candidate_path);
-        cwd.access(io, candidate_path, .{}) catch {
-            std.log.info("Runtime module '{s}' not found at '{s}' (import will be dangling until file exists)", .{ mod, candidate_path });
+        cwd.access(io, candidate_path, .{}) catch |err| {
+            if (err == error.FileNotFound) {
+                std.log.info("Runtime module '{s}' not found at '{s}' (import will be dangling until file exists)", .{ mod, candidate_path });
+            } else {
+                std.log.warn("Failed to access runtime module '{s}' at '{s}': {}", .{ mod, candidate_path, err });
+            }
         };
     } else {
         var runtime_gen = RuntimeGenerator.init(allocator);

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -1080,6 +1080,40 @@ test "generateMultipleFiles with runtime_module and nested client preserves verb
     try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"../../shared/runtime.zig\")") != null);
 }
 
+test "generateMultipleFiles treats backslash-separated nested client path as a directory" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+
+    var unified = try openapi2zig.parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try generateMultipleFiles(allocator, std.testing.io, tmp.dir, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .output_path = "out",
+        .file_names = .{ .client = "sub\\client.zig" },
+        .runtime_module = "../shared/runtime.zig",
+    });
+
+    const client = try tmp.dir.readFileAlloc(std.testing.io, "out/sub/client.zig", allocator, .unlimited);
+    defer allocator.free(client);
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"../shared/runtime.zig\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const models = @import(\"../models.zig\");") != null);
+}
+
 test "generateMultipleFiles with windows-style runtime_module normalizes separators" {
     const test_utils = @import("tests/test_utils.zig");
 

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -1150,3 +1150,50 @@ test "generateMultipleFiles with windows-style runtime_module normalizes separat
     try std.testing.expect(std.mem.indexOf(u8, client, "const my_runtime = @import(\"../shared/my_runtime.zig\");") != null);
     try std.testing.expect(std.mem.indexOf(u8, client, "const Owned = my_runtime.Owned;") != null);
 }
+
+test "generateMultipleFiles normalizes backslash-separated models and runtime file paths" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+
+    var unified = try openapi2zig.parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try generateMultipleFiles(allocator, std.testing.io, tmp.dir, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .output_path = "out",
+        .file_names = .{ .models = "gen\\models.zig", .runtime = "rt\\runtime.zig", .client = "client.zig" },
+    });
+
+    const models_source = try tmp.dir.readFileAlloc(std.testing.io, "out/gen/models.zig", allocator, .unlimited);
+    defer allocator.free(models_source);
+    const runtime_source = try tmp.dir.readFileAlloc(std.testing.io, "out/rt/runtime.zig", allocator, .unlimited);
+    defer allocator.free(runtime_source);
+    const client = try tmp.dir.readFileAlloc(std.testing.io, "out/client.zig", allocator, .unlimited);
+    defer allocator.free(client);
+
+    // Imports in the generated client should use forward slashes.
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"gen/models.zig\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"rt/runtime.zig\")") != null);
+
+    // No backslash-separated imports should leak into generated code.
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"gen\\models.zig\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"rt\\runtime.zig\")") == null);
+
+    // Aliases are derived from the normalized path stems.
+    try std.testing.expect(std.mem.indexOf(u8, client, "const gen_models = @import(\"gen/models.zig\");") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const rt_runtime = @import(\"rt/runtime.zig\");") != null);
+}

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -227,19 +227,19 @@ fn generateMultipleFiles(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.D
 
     if (args.runtime_module) |mod| {
         std.log.info("Reusing runtime module '{s}' (skipping generation of '{s}')", .{ mod, runtime_file });
+        runtime_import_owned = try std.mem.replaceOwned(u8, allocator, mod, "\\", "/");
+        runtime_import_path = runtime_import_owned.?;
+        runtime_alias_owned = try cli.deriveAlias(allocator, cli.importBasename(runtime_import_path), "runtime");
+        runtime_alias = runtime_alias_owned.?;
         // Best-effort existence check relative to the output directory / client location.
         const candidate_path = if (std.fs.path.dirname(client_file)) |client_dir|
-            try std.fs.path.join(allocator, &.{ dir_path, client_dir, mod })
+            try std.fs.path.join(allocator, &.{ dir_path, client_dir, runtime_import_path })
         else
-            try std.fs.path.join(allocator, &.{ dir_path, mod });
+            try std.fs.path.join(allocator, &.{ dir_path, runtime_import_path });
         defer allocator.free(candidate_path);
         cwd.access(io, candidate_path, .{}) catch {
             std.log.info("Runtime module '{s}' not found at '{s}' (import will be dangling until file exists)", .{ mod, candidate_path });
         };
-        runtime_alias_owned = try cli.deriveAlias(allocator, std.fs.path.basename(mod), "runtime");
-        runtime_alias = runtime_alias_owned.?;
-        runtime_import_owned = try std.mem.replaceOwned(u8, allocator, mod, "\\", "/");
-        runtime_import_path = runtime_import_owned.?;
     } else {
         var runtime_gen = RuntimeGenerator.init(allocator);
         defer runtime_gen.deinit();
@@ -1074,4 +1074,40 @@ test "generateMultipleFiles with runtime_module and nested client preserves verb
     const client = try tmp.dir.readFileAlloc(std.testing.io, "out/sub/client.zig", allocator, .unlimited);
     defer allocator.free(client);
     try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"../../shared/runtime.zig\")") != null);
+}
+
+test "generateMultipleFiles with windows-style runtime_module normalizes separators" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+
+    var unified = try openapi2zig.parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try generateMultipleFiles(allocator, std.testing.io, tmp.dir, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .output_path = "out",
+        .runtime_module = "..\\shared\\my_runtime.zig",
+    });
+
+    const client = try tmp.dir.readFileAlloc(std.testing.io, "out/client.zig", allocator, .unlimited);
+    defer allocator.free(client);
+    // Import should be normalized to forward slashes even when input uses backslashes
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"../shared/my_runtime.zig\")") != null);
+    // Alias should be derived from basename only, not include path separators
+    try std.testing.expect(std.mem.indexOf(u8, client, "const my_runtime = @import(\"../shared/my_runtime.zig\");") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const Owned = my_runtime.Owned;") != null);
 }

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -217,17 +217,50 @@ fn generateMultipleFiles(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.D
 
     if (args.models_only) return;
 
-    var runtime_gen = RuntimeGenerator.init(allocator);
-    defer runtime_gen.deinit();
-    const generated_runtime = try runtime_gen.generate();
-    defer allocator.free(generated_runtime);
+    var runtime_alias_owned: ?[]const u8 = null;
+    defer if (runtime_alias_owned) |v| allocator.free(v);
+    var runtime_import_owned: ?[]const u8 = null;
+    defer if (runtime_import_owned) |v| allocator.free(v);
 
-    try writeFile(allocator, io, cwd, dir_path, runtime_file, generated_runtime, args.force);
+    var runtime_alias: []const u8 = undefined;
+    var runtime_import_path: []const u8 = undefined;
+
+    if (args.runtime_module) |mod| {
+        std.log.info("Reusing runtime module '{s}' (skipping generation of '{s}')", .{ mod, runtime_file });
+        // Best-effort existence check relative to the output directory / client location.
+        const candidate_path = if (std.fs.path.dirname(client_file)) |client_dir|
+            try std.fs.path.join(allocator, &.{ dir_path, client_dir, mod })
+        else
+            try std.fs.path.join(allocator, &.{ dir_path, mod });
+        defer allocator.free(candidate_path);
+        cwd.access(io, candidate_path, .{}) catch {
+            std.log.info("Runtime module '{s}' not found at '{s}' (import will be dangling until file exists)", .{ mod, candidate_path });
+        };
+        runtime_alias_owned = try cli.deriveAlias(allocator, std.fs.path.basename(mod), "runtime");
+        runtime_alias = runtime_alias_owned.?;
+        runtime_import_owned = try std.mem.replaceOwned(u8, allocator, mod, "\\", "/");
+        runtime_import_path = runtime_import_owned.?;
+    } else {
+        var runtime_gen = RuntimeGenerator.init(allocator);
+        defer runtime_gen.deinit();
+        const generated_runtime = try runtime_gen.generate();
+        defer allocator.free(generated_runtime);
+
+        try writeFile(allocator, io, cwd, dir_path, runtime_file, generated_runtime, args.force);
+
+        runtime_alias_owned = try cli.deriveAlias(allocator, runtime_file, "runtime");
+        runtime_alias = runtime_alias_owned.?;
+        const computed_import = if (std.fs.path.dirname(client_file)) |client_dir| blk: {
+            const raw = try std.fs.path.relative(allocator, ".", null, client_dir, runtime_file);
+            defer allocator.free(raw);
+            break :blk try std.mem.replaceOwned(u8, allocator, raw, "\\", "/");
+        } else try allocator.dupe(u8, runtime_file);
+        runtime_import_owned = computed_import;
+        runtime_import_path = runtime_import_owned.?;
+    }
 
     const models_alias = try cli.deriveAlias(allocator, models_file, "models");
     defer allocator.free(models_alias);
-    const runtime_alias = try cli.deriveAlias(allocator, runtime_file, "runtime");
-    defer allocator.free(runtime_alias);
     const models_prefix = try std.mem.concat(allocator, u8, &.{ models_alias, "." });
     defer allocator.free(models_prefix);
 
@@ -237,12 +270,6 @@ fn generateMultipleFiles(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.D
         break :blk try std.mem.replaceOwned(u8, allocator, raw, "\\", "/");
     } else models_file;
     defer if (std.fs.path.dirname(client_file) != null) allocator.free(models_import_path);
-    const runtime_import_path = if (std.fs.path.dirname(client_file)) |client_dir| blk: {
-        const raw = try std.fs.path.relative(allocator, ".", null, client_dir, runtime_file);
-        defer allocator.free(raw);
-        break :blk try std.mem.replaceOwned(u8, allocator, raw, "\\", "/");
-    } else runtime_file;
-    defer if (std.fs.path.dirname(client_file) != null) allocator.free(runtime_import_path);
 
     var api_generator = UnifiedApiGenerator.init(allocator, args);
     api_generator.model_prefix = models_prefix;
@@ -901,4 +928,150 @@ test "generateMultipleFiles overwrites unchanged files when force is set" {
     defer allocator.free(second_models);
 
     try std.testing.expect(!std.mem.eql(u8, first_models, second_models));
+}
+
+test "generateMultipleFiles with runtime_module reuses existing runtime" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {
+        \\    "/pets": {
+        \\      "post": {
+        \\        "operationId": "addPet",
+        \\        "requestBody": {
+        \\          "required": true,
+        \\          "content": {
+        \\            "application/json": {
+        \\              "schema": { "$ref": "#/components/schemas/Pet" }
+        \\            }
+        \\          }
+        \\        },
+        \\        "responses": {
+        \\          "200": { "description": "ok" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "components": {
+        \\    "schemas": {
+        \\      "Pet": {
+        \\        "type": "object",
+        \\        "properties": { "name": { "type": "string" } }
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    var unified = try openapi2zig.parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Leader: normal generation that creates runtime.zig in shared location
+    try generateMultipleFiles(allocator, std.testing.io, tmp.dir, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .output_path = "shared",
+    });
+
+    const shared_runtime = try tmp.dir.readFileAlloc(std.testing.io, "shared/runtime.zig", allocator, .unlimited);
+    defer allocator.free(shared_runtime);
+    try std.testing.expect(std.mem.indexOf(u8, shared_runtime, "pub fn Owned") != null);
+
+    // Follower: reuse existing runtime via client-relative import
+    try generateMultipleFiles(allocator, std.testing.io, tmp.dir, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .output_path = "client",
+        .runtime_module = "../shared/runtime.zig",
+    });
+
+    const client = try tmp.dir.readFileAlloc(std.testing.io, "client/client.zig", allocator, .unlimited);
+    defer allocator.free(client);
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"../shared/runtime.zig\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const runtime = @import(\"../shared/runtime.zig\");") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const Owned = runtime.Owned;") != null);
+
+    // No runtime should be emitted in the follower output
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "client/runtime.zig", .{}));
+
+    const models_content = try tmp.dir.readFileAlloc(std.testing.io, "client/models.zig", allocator, .unlimited);
+    defer allocator.free(models_content);
+    try std.testing.expect(std.mem.indexOf(u8, models_content, "pub const Pet") != null);
+}
+
+test "generateMultipleFiles with runtime_module derives alias from basename and supports custom models name" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+
+    var unified = try openapi2zig.parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try generateMultipleFiles(allocator, std.testing.io, tmp.dir, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .output_path = "out",
+        .runtime_module = "../shared/my_runtime.zig",
+        .file_names = .{ .models = "contracts.zig" },
+    });
+
+    const client = try tmp.dir.readFileAlloc(std.testing.io, "out/client.zig", allocator, .unlimited);
+    defer allocator.free(client);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const my_runtime = @import(\"../shared/my_runtime.zig\");") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const Owned = my_runtime.Owned;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const contracts = @import(\"contracts.zig\");") != null);
+}
+
+test "generateMultipleFiles with runtime_module and nested client preserves verbatim import" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+
+    var unified = try openapi2zig.parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try generateMultipleFiles(allocator, std.testing.io, tmp.dir, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .output_path = "out",
+        .file_names = .{ .client = "sub/client.zig" },
+        .runtime_module = "../../shared/runtime.zig",
+    });
+
+    const client = try tmp.dir.readFileAlloc(std.testing.io, "out/sub/client.zig", allocator, .unlimited);
+    defer allocator.free(client);
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"../../shared/runtime.zig\")") != null);
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -31,6 +31,7 @@
 const std = @import("std");
 const yaml_loader = @import("yaml_loader.zig");
 const generated_header = @import("generators/generated_header.zig");
+const cli = @import("cli.zig");
 
 // Core version detection
 pub const ApiVersion = @import("detector.zig").OpenApiVersion;
@@ -279,6 +280,13 @@ pub const GeneratedFiles = struct {
 /// args.models_only is true. `runtime` is also null when `args.runtime_module` is set
 /// to reuse an existing runtime module instead of generating one.
 pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_doc: UnifiedDocument, args: CliArgs) !GeneratedFiles {
+    const models_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.models) orelse cli.FileKind.models.defaultName(), "\\", "/");
+    defer allocator.free(models_file);
+    const runtime_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.runtime) orelse cli.FileKind.runtime.defaultName(), "\\", "/");
+    defer allocator.free(runtime_file);
+    const client_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.client) orelse cli.FileKind.client.defaultName(), "\\", "/");
+    defer allocator.free(client_file);
+
     const models_code = try generateModels(allocator, unified_doc);
     defer allocator.free(models_code);
 
@@ -296,7 +304,17 @@ pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_do
     var runtime_with_header: ?[]const u8 = null;
     errdefer if (runtime_with_header) |r| allocator.free(r);
 
-    if (args.runtime_module == null) {
+    var runtime_import_owned: ?[]const u8 = null;
+    defer if (runtime_import_owned) |v| allocator.free(v);
+    var runtime_alias_owned: ?[]const u8 = null;
+    defer if (runtime_alias_owned) |v| allocator.free(v);
+
+    if (args.runtime_module) |mod| {
+        const normalized = try std.mem.replaceOwned(u8, allocator, mod, "\\", "/");
+        defer allocator.free(normalized);
+        runtime_alias_owned = try cli.deriveAlias(allocator, cli.importBasename(normalized), "runtime");
+        runtime_import_owned = try allocator.dupe(u8, normalized);
+    } else {
         var runtime_gen = RuntimeGenerator.init(allocator);
         defer runtime_gen.deinit();
         const runtime_code = try runtime_gen.generate();
@@ -307,48 +325,51 @@ pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_do
         defer allocator.free(runtime_header);
 
         runtime_with_header = try std.mem.concat(allocator, u8, &.{ runtime_header, runtime_code });
+
+        runtime_alias_owned = try cli.deriveAlias(allocator, runtime_file, "runtime");
+        const computed_import = if (std.fs.path.dirname(client_file)) |client_dir| blk: {
+            const raw = try std.fs.path.relative(allocator, ".", null, client_dir, runtime_file);
+            defer allocator.free(raw);
+            break :blk try std.mem.replaceOwned(u8, allocator, raw, "\\", "/");
+        } else try allocator.dupe(u8, runtime_file);
+        runtime_import_owned = computed_import;
     }
+
+    const models_alias = try cli.deriveAlias(allocator, models_file, "models");
+    defer allocator.free(models_alias);
+    const models_prefix = try std.mem.concat(allocator, u8, &.{ models_alias, "." });
+    defer allocator.free(models_prefix);
+    const models_import_path = if (std.fs.path.dirname(client_file)) |client_dir| blk: {
+        const raw = try std.fs.path.relative(allocator, ".", null, client_dir, models_file);
+        defer allocator.free(raw);
+        break :blk try std.mem.replaceOwned(u8, allocator, raw, "\\", "/");
+    } else models_file;
+    defer if (std.fs.path.dirname(client_file) != null) allocator.free(models_import_path);
 
     var api_gen = UnifiedApiGenerator.init(allocator, args);
     defer api_gen.deinit();
-    api_gen.model_prefix = "models.";
+    api_gen.model_prefix = models_prefix;
     api_gen.emit_imports = true;
-    if (args.runtime_module) |mod| {
-        const normalized = try std.mem.replaceOwned(u8, allocator, mod, "\\", "/");
-        defer allocator.free(normalized);
-        const alias = try @import("cli.zig").deriveAlias(allocator, @import("cli.zig").importBasename(normalized), "runtime");
-        defer allocator.free(alias);
-        api_gen.runtime_import = normalized;
-        api_gen.runtime_import_alias = alias;
-        const api_code = try api_gen.generateClientOnly(unified_doc);
-        defer allocator.free(api_code);
-        const client_checksum = generated_header.computeChecksum(api_code);
-        const client_header = try generated_header.renderNowWithChecksum(allocator, io, client_checksum);
-        defer allocator.free(client_header);
-        const client_with_header = try std.mem.concat(allocator, u8, &.{ client_header, api_code });
-        errdefer allocator.free(client_with_header);
-        return .{
-            .models = models_with_header,
-            .runtime = runtime_with_header,
-            .client = client_with_header,
-        };
-    } else {
-        const api_code = try api_gen.generateClientOnly(unified_doc);
-        defer allocator.free(api_code);
+    api_gen.models_import = models_import_path;
+    api_gen.models_import_alias = models_alias;
+    api_gen.runtime_import = runtime_import_owned.?;
+    api_gen.runtime_import_alias = runtime_alias_owned.?;
 
-        const client_checksum = generated_header.computeChecksum(api_code);
-        const client_header = try generated_header.renderNowWithChecksum(allocator, io, client_checksum);
-        defer allocator.free(client_header);
+    const api_code = try api_gen.generateClientOnly(unified_doc);
+    defer allocator.free(api_code);
 
-        const client_with_header = try std.mem.concat(allocator, u8, &.{ client_header, api_code });
-        errdefer allocator.free(client_with_header);
+    const client_checksum = generated_header.computeChecksum(api_code);
+    const client_header = try generated_header.renderNowWithChecksum(allocator, io, client_checksum);
+    defer allocator.free(client_header);
 
-        return .{
-            .models = models_with_header,
-            .runtime = runtime_with_header,
-            .client = client_with_header,
-        };
-    }
+    const client_with_header = try std.mem.concat(allocator, u8, &.{ client_header, api_code });
+    errdefer allocator.free(client_with_header);
+
+    return .{
+        .models = models_with_header,
+        .runtime = runtime_with_header,
+        .client = client_with_header,
+    };
 }
 
 fn convertDocument(allocator: std.mem.Allocator, doc: anytype, comptime Converter: type) !UnifiedDocument {
@@ -445,11 +466,11 @@ test "generateCodeMultiple honors custom file names and nested client paths" {
         \\  "paths": {
         \\    "/pets": {
         \\      "get": {
-        \\        "operationId": "listPets",
+        \\        "operationId": "getPet",
         \\        "responses": {
         \\          "200": {
         \\            "description": "ok",
-        \\            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } } } }
+        \\            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } } }
         \\          }
         \\        }
         \\      }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -292,37 +292,71 @@ pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_do
         return .{ .models = models_with_header };
     }
 
-    var runtime_gen = RuntimeGenerator.init(allocator);
-    defer runtime_gen.deinit();
-    const runtime_code = try runtime_gen.generate();
-    defer allocator.free(runtime_code);
+    var runtime_with_header: ?[]const u8 = null;
+    errdefer if (runtime_with_header) |r| allocator.free(r);
 
-    const runtime_checksum = generated_header.computeChecksum(runtime_code);
-    const runtime_header = try generated_header.renderNowWithChecksum(allocator, io, runtime_checksum);
-    defer allocator.free(runtime_header);
+    if (args.runtime_module == null) {
+        var runtime_gen = RuntimeGenerator.init(allocator);
+        defer runtime_gen.deinit();
+        const runtime_code = try runtime_gen.generate();
+        defer allocator.free(runtime_code);
 
-    const runtime_with_header = try std.mem.concat(allocator, u8, &.{ runtime_header, runtime_code });
-    errdefer allocator.free(runtime_with_header);
+        const runtime_checksum = generated_header.computeChecksum(runtime_code);
+        const runtime_header = try generated_header.renderNowWithChecksum(allocator, io, runtime_checksum);
+        defer allocator.free(runtime_header);
+
+        runtime_with_header = try std.mem.concat(allocator, u8, &.{ runtime_header, runtime_code });
+    }
 
     var api_gen = UnifiedApiGenerator.init(allocator, args);
     api_gen.model_prefix = "models.";
     api_gen.emit_imports = true;
-    defer api_gen.deinit();
-    const api_code = try api_gen.generateClientOnly(unified_doc);
-    defer allocator.free(api_code);
+    if (args.runtime_module) |mod| {
+        const alias = try @import("cli.zig").deriveAlias(allocator, std.fs.path.basename(mod), "runtime");
+        defer allocator.free(alias);
+        // Need to keep alias alive until after generateClientOnly; copy into generator-allocated buffer.
+        // UnifiedApiGenerator stores slice reference only for generation, so dupe into its allocator scope.
+        const alias_copy = try allocator.dupe(u8, alias);
+        defer allocator.free(alias_copy);
+        const normalized = try std.mem.replaceOwned(u8, allocator, mod, "\\", "/");
+        defer allocator.free(normalized);
+        api_gen.runtime_import = normalized;
+        api_gen.runtime_import_alias = alias_copy;
+        // generateClientOnly copies the strings into its buffer, so defer above is safe until after call
+        const api_code = try api_gen.generateClientOnly(unified_doc);
+        defer allocator.free(api_code);
+        const client_checksum = generated_header.computeChecksum(api_code);
+        const client_header = try generated_header.renderNowWithChecksum(allocator, io, client_checksum);
+        defer allocator.free(client_header);
+        const client_with_header = try std.mem.concat(allocator, u8, &.{ client_header, api_code });
+        errdefer allocator.free(client_with_header);
+        // Need to free the runtime path if allocated differently? Already deferred.
+        // api_gen may have stored Normalized slice; we need to ensure not use-after-free before deinit.
+        // Copy needed fields already consumed.
+        api_gen.deinit();
+        return .{
+            .models = models_with_header,
+            .runtime = runtime_with_header,
+            .client = client_with_header,
+        };
+    } else {
+        defer api_gen.deinit();
+        const api_code = try api_gen.generateClientOnly(unified_doc);
+        defer allocator.free(api_code);
 
-    const client_checksum = generated_header.computeChecksum(api_code);
-    const client_header = try generated_header.renderNowWithChecksum(allocator, io, client_checksum);
-    defer allocator.free(client_header);
+        const client_checksum = generated_header.computeChecksum(api_code);
+        const client_header = try generated_header.renderNowWithChecksum(allocator, io, client_checksum);
+        defer allocator.free(client_header);
 
-    const client_with_header = try std.mem.concat(allocator, u8, &.{ client_header, api_code });
-    errdefer allocator.free(client_with_header);
+        const client_with_header = try std.mem.concat(allocator, u8, &.{ client_header, api_code });
+        errdefer allocator.free(client_with_header);
 
-    return .{
-        .models = models_with_header,
-        .runtime = runtime_with_header,
-        .client = client_with_header,
-    };
+        return .{
+            .models = models_with_header,
+            .runtime = runtime_with_header,
+            .client = client_with_header,
+        };
+    }
 }
 
 fn convertDocument(allocator: std.mem.Allocator, doc: anytype, comptime Converter: type) !UnifiedDocument {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -276,7 +276,8 @@ pub const GeneratedFiles = struct {
 
 /// Generate separate Zig source files (models, runtime, client) from a unified document.
 /// Only the models field is always present; runtime and client are null when
-/// args.models_only is true.
+/// args.models_only is true. `runtime` is also null when `args.runtime_module` is set
+/// to reuse an existing runtime module instead of generating one.
 pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_doc: UnifiedDocument, args: CliArgs) !GeneratedFiles {
     const models_code = try generateModels(allocator, unified_doc);
     defer allocator.free(models_code);
@@ -309,20 +310,16 @@ pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_do
     }
 
     var api_gen = UnifiedApiGenerator.init(allocator, args);
+    defer api_gen.deinit();
     api_gen.model_prefix = "models.";
     api_gen.emit_imports = true;
     if (args.runtime_module) |mod| {
         const alias = try @import("cli.zig").deriveAlias(allocator, std.fs.path.basename(mod), "runtime");
         defer allocator.free(alias);
-        // Need to keep alias alive until after generateClientOnly; copy into generator-allocated buffer.
-        // UnifiedApiGenerator stores slice reference only for generation, so dupe into its allocator scope.
-        const alias_copy = try allocator.dupe(u8, alias);
-        defer allocator.free(alias_copy);
         const normalized = try std.mem.replaceOwned(u8, allocator, mod, "\\", "/");
         defer allocator.free(normalized);
         api_gen.runtime_import = normalized;
-        api_gen.runtime_import_alias = alias_copy;
-        // generateClientOnly copies the strings into its buffer, so defer above is safe until after call
+        api_gen.runtime_import_alias = alias;
         const api_code = try api_gen.generateClientOnly(unified_doc);
         defer allocator.free(api_code);
         const client_checksum = generated_header.computeChecksum(api_code);
@@ -330,17 +327,12 @@ pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_do
         defer allocator.free(client_header);
         const client_with_header = try std.mem.concat(allocator, u8, &.{ client_header, api_code });
         errdefer allocator.free(client_with_header);
-        // Need to free the runtime path if allocated differently? Already deferred.
-        // api_gen may have stored Normalized slice; we need to ensure not use-after-free before deinit.
-        // Copy needed fields already consumed.
-        api_gen.deinit();
         return .{
             .models = models_with_header,
             .runtime = runtime_with_header,
             .client = client_with_header,
         };
     } else {
-        defer api_gen.deinit();
         const api_code = try api_gen.generateClientOnly(unified_doc);
         defer allocator.free(api_code);
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -432,6 +432,94 @@ test "generateCodeMultiple with windows-style runtime_module normalizes separato
     try std.testing.expect(std.mem.indexOf(u8, result.client.?, "const my_runtime = @import(\"../shared/my_runtime.zig\");") != null);
 }
 
+test "generateCodeMultiple honors custom file names and nested client paths" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {
+        \\    "/pets": {
+        \\      "get": {
+        \\        "operationId": "listPets",
+        \\        "responses": {
+        \\          "200": {
+        \\            "description": "ok",
+        \\            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } } } }
+        \\          }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "components": {
+        \\    "schemas": {
+        \\      "Pet": {
+        \\        "type": "object",
+        \\        "properties": { "name": { "type": "string" } }
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var result = try generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .file_names = .{ .models = "gen\\models.zig", .runtime = "rt\\runtime.zig", .client = "sub\\client.zig" },
+    });
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.runtime != null);
+    try std.testing.expect(result.client != null);
+    const client = result.client.?;
+
+    try std.testing.expect(std.mem.indexOf(u8, client, "const gen_models = @import(\"../gen/models.zig\");") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const rt_runtime = @import(\"../rt/runtime.zig\");") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "gen_models.Pet") != null);
+
+    // No backslash-separated imports should leak into generated code.
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"gen\\models.zig\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "@import(\"rt\\runtime.zig\")") == null);
+}
+
+test "generateCodeMultiple with runtime_module honors custom models name and nested client" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var result = try generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .multiple_files = true,
+        .file_names = .{ .models = "contracts.zig", .client = "sub\\client.zig" },
+        .runtime_module = "..\\shared\\my_runtime.zig",
+    });
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.runtime == null);
+    try std.testing.expect(result.client != null);
+    const client = result.client.?;
+
+    try std.testing.expect(std.mem.indexOf(u8, client, "const contracts = @import(\"../contracts.zig\");") != null);
+    try std.testing.expect(std.mem.indexOf(u8, client, "const my_runtime = @import(\"../shared/my_runtime.zig\");") != null);
+}
+
 // Version information
 pub const version_info = @import("build_info");
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -301,6 +301,48 @@ pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_do
         return .{ .models = models_with_header };
     }
 
+    // Validate file names and import aliases the same way `cli.parse` does, so
+    // the library cannot emit invalid Zig (e.g. duplicate `const <alias>` lines
+    // or `const std = @import("std.zig")` colliding with `const std = @import("std")`).
+    if (args.runtime_module) |mod| {
+        cli.validateImportPath(mod) catch return error.InvalidArguments;
+        if (cli.fileNamesCollide(models_file, client_file)) return error.InvalidArguments;
+        const resolved_runtime = try cli.resolveRuntimeModulePath(allocator, client_file, mod);
+        defer allocator.free(resolved_runtime);
+        if (cli.fileNamesCollide(resolved_runtime, models_file)) return error.InvalidArguments;
+        if (cli.fileNamesCollide(resolved_runtime, client_file)) return error.InvalidArguments;
+        const m_alias = try cli.deriveAlias(allocator, models_file, "models");
+        defer allocator.free(m_alias);
+        const r_alias = try cli.deriveAlias(allocator, cli.importBasename(mod), "runtime");
+        defer allocator.free(r_alias);
+        const c_alias = try cli.deriveAlias(allocator, client_file, "client");
+        defer allocator.free(c_alias);
+        if (std.mem.eql(u8, m_alias, r_alias) or std.mem.eql(u8, m_alias, c_alias) or std.mem.eql(u8, r_alias, c_alias)) {
+            return error.InvalidArguments;
+        }
+        const reserved = [_][]const u8{ "std", "Client", "_" };
+        for ([_][]const u8{ m_alias, r_alias, c_alias }) |a| {
+            for (reserved) |r| if (std.mem.eql(u8, a, r)) return error.InvalidArguments;
+        }
+    } else {
+        if (cli.fileNamesCollide(models_file, runtime_file) or cli.fileNamesCollide(models_file, client_file) or cli.fileNamesCollide(runtime_file, client_file)) {
+            return error.InvalidArguments;
+        }
+        const m_alias = try cli.deriveAlias(allocator, models_file, "models");
+        defer allocator.free(m_alias);
+        const r_alias = try cli.deriveAlias(allocator, runtime_file, "runtime");
+        defer allocator.free(r_alias);
+        const c_alias = try cli.deriveAlias(allocator, client_file, "client");
+        defer allocator.free(c_alias);
+        if (std.mem.eql(u8, m_alias, r_alias) or std.mem.eql(u8, m_alias, c_alias) or std.mem.eql(u8, r_alias, c_alias)) {
+            return error.InvalidArguments;
+        }
+        const reserved = [_][]const u8{ "std", "Client", "_" };
+        for ([_][]const u8{ m_alias, r_alias, c_alias }) |a| {
+            for (reserved) |r| if (std.mem.eql(u8, a, r)) return error.InvalidArguments;
+        }
+    }
+
     var runtime_with_header: ?[]const u8 = null;
     errdefer if (runtime_with_header) |r| allocator.free(r);
 
@@ -619,6 +661,95 @@ test "generateCodeMultiple rejects duplicate alias between models and runtime_mo
         .input_path = "fixture.json",
         .file_names = .{ .models = "runtime.zig" },
         .runtime_module = "../runtime.zig",
+    }));
+}
+
+test "generateCodeMultiple rejects duplicate file name" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+    try std.testing.expectError(error.InvalidArguments, generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .file_names = .{ .models = "foo.zig", .runtime = "foo.zig" },
+    }));
+}
+
+test "generateCodeMultiple rejects runtime_module that resolves to models file" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+    try std.testing.expectError(error.InvalidArguments, generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .file_names = .{ .client = "sub/client.zig" },
+        .runtime_module = "../models.zig",
+    }));
+}
+
+test "generateCodeMultiple allows reserved alias when models_only" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+    var result = try generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .models_only = true,
+        .file_names = .{ .models = "std.zig" },
+    });
+    defer result.deinit(allocator);
+    try std.testing.expect(result.runtime == null);
+    try std.testing.expect(result.client == null);
+}
+
+test "generateCodeMultiple rejects absolute runtime_module path" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+    try std.testing.expectError(error.InvalidArguments, generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .runtime_module = "/absolute/runtime.zig",
+    }));
+    try std.testing.expectError(error.InvalidArguments, generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .runtime_module = "C:runtime.zig",
     }));
 }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -314,10 +314,10 @@ pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_do
     api_gen.model_prefix = "models.";
     api_gen.emit_imports = true;
     if (args.runtime_module) |mod| {
-        const alias = try @import("cli.zig").deriveAlias(allocator, std.fs.path.basename(mod), "runtime");
-        defer allocator.free(alias);
         const normalized = try std.mem.replaceOwned(u8, allocator, mod, "\\", "/");
         defer allocator.free(normalized);
+        const alias = try @import("cli.zig").deriveAlias(allocator, @import("cli.zig").importBasename(normalized), "runtime");
+        defer allocator.free(alias);
         api_gen.runtime_import = normalized;
         api_gen.runtime_import_alias = alias;
         const api_code = try api_gen.generateClientOnly(unified_doc);
@@ -402,6 +402,34 @@ pub fn convertOpenApi32ToUnified(allocator: std.mem.Allocator, openapi32_doc: Op
 /// - UnifiedDocument: Unified representation of the Swagger document
 pub fn convertSwaggerToUnified(allocator: std.mem.Allocator, swagger_doc: SwaggerDocument) !UnifiedDocument {
     return convertDocument(allocator, swagger_doc, SwaggerConverter);
+}
+
+test "generateCodeMultiple with windows-style runtime_module normalizes separators" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+
+    var result = try generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .runtime_module = "..\\shared\\my_runtime.zig",
+    });
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.runtime == null);
+    try std.testing.expect(result.client != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.client.?, "@import(\"../shared/my_runtime.zig\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.client.?, "const my_runtime = @import(\"../shared/my_runtime.zig\");") != null);
 }
 
 // Version information

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -541,6 +541,87 @@ test "generateCodeMultiple with runtime_module honors custom models name and nes
     try std.testing.expect(std.mem.indexOf(u8, client, "const my_runtime = @import(\"../shared/my_runtime.zig\");") != null);
 }
 
+test "generateCodeMultiple rejects reserved alias std" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+    try std.testing.expectError(error.InvalidArguments, generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .file_names = .{ .models = "std.zig" },
+    }));
+}
+
+test "generateCodeMultiple rejects duplicate alias derived from file names" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+    try std.testing.expectError(error.InvalidArguments, generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .file_names = .{ .models = "my-models.zig", .runtime = "my_models.zig" },
+    }));
+}
+
+test "generateCodeMultiple rejects reserved alias via runtime_module" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+    try std.testing.expectError(error.InvalidArguments, generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .runtime_module = "../std.zig",
+    }));
+}
+
+test "generateCodeMultiple rejects duplicate alias between models and runtime_module" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const io = std.testing.io;
+    const json =
+        \\{
+        \\  "openapi": "3.0.0",
+        \\  "info": { "title": "fixture", "version": "1.0.0" },
+        \\  "paths": {}
+        \\}
+    ;
+    var unified = try parseToUnified(allocator, json);
+    defer unified.deinit(allocator);
+    try std.testing.expectError(error.InvalidArguments, generateCodeMultiple(allocator, io, unified, .{
+        .input_path = "fixture.json",
+        .file_names = .{ .models = "runtime.zig" },
+        .runtime_module = "../runtime.zig",
+    }));
+}
+
 // Version information
 pub const version_info = @import("build_info");
 


### PR DESCRIPTION
Implements `--runtime-module` CLI flag to allow multiple generated clients to share a single `runtime.zig`. Addresses P1 of PRD-openapi2zig-runtime.md (triplicate identical runtimes, ~984 lines bloat).

**Changes**
- `src/cli.zig`: adds `--runtime-module <path>` (client-file relative import, e.g. `../runtime.zig`), validation requiring `--multiple-files`, mutual exclusion with `--file-name runtime=...`, alias derivation from basename via `deriveAlias` (`src/cli.zig:194`) with reserved/duplicate checks, `validateImportPath` allowing `..` segments.
- `src/generator.zig` `generateMultipleFiles`: when `args.runtime_module` set, skips `RuntimeGenerator.generate` (`src/generators/unified/runtime_generator.zig:18`) and emits only `models`+`client`; client imports supplied path verbatim (normalized `\` -> `/`) and re-exports via derived alias. Best-effort existence check logs info (warn-only per Q2).
- `src/lib.zig` `generateCodeMultiple`: mirrors logic, returns `runtime=null` when reusing, configures `UnifiedApiGenerator.runtime_import` / `_alias`.
- Tests (TDD): `src/cli.zig` 11 new parse tests, `src/generator.zig` 3 new multi-file tests (shared runtime, alias derivation, nested client).
- `README.md`: documents flag and puny workflow (`src/providers/runtime` leader + followers).

**Workflow for puny (christianhelle/puny#161)**
```bash
openapi2zig generate -i openapi/openai.json -o src/providers/runtime --multiple-files
openapi2zig generate -i openapi/anthropic.json -o src/providers/anthropic --multiple-files --runtime-module ../runtime/runtime.zig --file-name models=contracts.zig
openapi2zig generate -i openapi/lmstudio.json -o src/providers/lmstudio --multiple-files --runtime-module ../runtime/runtime.zig --file-name models=contracts.zig
```
Results in 1 `runtime.zig` instead of 3 identical copies (`src/providers/openai/runtime.zig:1-328` checksum `61f2e6531e1eb593`).

Fixes puny review comment `src/providers/anthropic/runtime.zig:9-181` and prepares for follow-up R2-R5 (CancelWatcher etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `--runtime-module` option for reusing shared runtime modules during multi-file generation.
  - Added cross-platform path handling, including Windows-style separators and normalized imports.
  - Runtime imports now use aliases derived from normalized filenames.
  - Supports custom model, runtime, and client filenames with shared runtime generation.

- **Bug Fixes**
  - Improved validation for invalid paths, unsupported combinations, duplicate options, and file collisions.
  - Missing runtime files now produce clearer notices.
  - Generated output omits runtime files when an external runtime is supplied.

- **Documentation**
  - Added guidance for runtime-module usage, custom filenames, imports, constraints, and missing-file behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->