### PR TITLE
Add --runtime-only flag to generate runtime module only

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,14 @@ The `generate` command reads a JSON or YAML OpenAPI/Swagger document from a loca
 
 | Flag | Description |
 | :--- | :--- |
-| `-i`, `--input <PATH_OR_URL>` | OpenAPI/Swagger JSON or YAML spec from a file path or `http`/`https` URL. Required. |
+| `-i`, `--input <PATH_OR_URL>` | OpenAPI/Swagger JSON or YAML spec from a file path or `http`/`https` URL. Required unless `--runtime-only` is used. |
 | `-o`, `--output <path>` | Output file for the generated Zig code. Defaults to `generated.zig`. Parent directories are created when needed. |
 | `--base-url <url>` | Base URL baked into the generated `Client`. Defaults to the server URL from the OpenAPI/Swagger document. |
 | `--resource-wrappers <mode>` | Generate resource wrapper namespaces. Modes: `none`, `tags`, `paths`, `hybrid`. Defaults to `paths`. |
 | `--multiple-clients <mode>` | Generate per-tag or per-endpoint client structs that delegate to the flat API functions. Modes: `PerTag` (default when the flag is given without a value) and `PerEndpoint`. Mutually exclusive with a non-`none` `--resource-wrappers` and with `--models-only`. |
 | `--tag <name>` | Include only operations carrying the specified OpenAPI tag. Schemas are removed only when unreachable from retained operations; transitively referenced schemas remain preserved. Operations without any of the requested tags (including untagged operations) are skipped. The `--tag` option can be specified multiple times, e.g. `--tag pet --tag store --tag user`. |
 | `--models-only` | Generate only Zig models, skipping the API client. |
+| `--runtime-only` | Generate only the runtime module. No input file is required; when given, `-i` is ignored and output defaults to `generated.zig` (single file) or `generated/runtime.zig` with `--multiple-files`. Mutually exclusive with `--models-only`, `--multiple-clients`, `--runtime-module`, and `--file-name models/client`. |
 | `--multiple-files` | Generate separate output files for models, runtime, and API client into the output directory specified by `-o`. |
 | `--file-name <kind>=<name>` | Customize an output file name in `--multiple-files` mode. `<kind>` is `models`, `runtime`, or `client`. `<name>` may include a relative subpath (e.g. `models=gen/types.zig`); any required parent directories are created automatically. Can be specified multiple times. |
 | `--runtime-module <path>` | Re-use an existing `runtime.zig` instead of generating a new one. The path is a Zig import path relative to the generated `client.zig` (e.g. `../runtime.zig` or `../shared/my_runtime.zig`). Requires `--multiple-files` and is mutually exclusive with `--file-name runtime=...`. When given, no `runtime.zig` is emitted; the client imports the supplied path and derives the import alias from the file basename (`my_runtime` for `my_runtime.zig`). |
@@ -320,7 +321,19 @@ var pet = try op.execute(1);
 defer pet.deinit();
 ```
 
-`--multiple-clients` is mutually exclusive with a non-`none` `--resource-wrappers` and with `--models-only`; combining them is a parse error. It composes with `--multiple-files`: the client structs are emitted into the client file.
+`--multiple-clients` is mutually exclusive with a non-`none` `--resource-wrappers` and with `--models-only` and `--runtime-only`; combining them is a parse error. It composes with `--multiple-files`: the client structs are emitted into the client file.
+
+`--runtime-only` is mutually exclusive with `--models-only`, `--multiple-clients`, `--runtime-module`, and `--file-name models` / `--file-name client`; no input is required.
+
+**Generate only the runtime module:**
+```bash
+# Single file (no input needed)
+openapi2zig generate --runtime-only -o runtime.zig
+
+# Multiple-files directory (only runtime.zig is emitted)
+openapi2zig generate --runtime-only --multiple-files -o generated/runtime-only
+openapi2zig generate --runtime-only --multiple-files -o generated/shared --file-name runtime=http.zig
+```
 
 **Re-use an existing runtime when generating multiple clients (avoid duplicate `runtime.zig`):**
 ```bash

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -45,11 +45,12 @@ fn printUsage() void {
         \\                              client file (e.g. "../runtime.zig").
         \\                              Requires --multiple-files and is mutually exclusive with
         \\                              --file-name runtime=... .
-        \\   --force                   Force overwriting output even when unchanged
-        \\   --parameters-as-struct    Wrap method parameters in a single options struct
-        \\                            instead of individual function arguments
-        \\
-        \\ EXAMPLES:
+         \\   --force                   Force overwriting output even when unchanged
+         \\   --parameters-as-struct    Wrap method parameters in a single options struct
+         \\                            instead of individual function arguments
+         \\   --runtime-only            Generate only the runtime module (no input required)
+         \\
+         \\ EXAMPLES:
         \\   openapi2zig generate -i ./openapi/petstore.json -o api.zig
         \\   openapi2zig generate -i ./openapi/petstore.json -o models.zig --models-only
         \\   openapi2zig generate -i https://petstore3.swagger.io/api/v3/openapi.json -o api.zig
@@ -343,6 +344,7 @@ pub const CliArgs = struct {
     base_url: ?[]const u8 = null,
     resource_wrappers: ResourceWrapperMode = .paths,
     models_only: bool = false,
+    runtime_only: bool = false,
     multiple_files: bool = false,
     multiple_clients: ?MultipleClientsMode = null,
     file_names: FileNameOverrides = .{},
@@ -385,7 +387,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
         };
     }
 
-    if (args.len < 4 or (args.len >= 1 and !std.mem.eql(u8, args[1], "generate"))) {
+    if (args.len < 3 or (args.len >= 1 and !std.mem.eql(u8, args[1], "generate"))) {
         printUsage();
         return .{
             .help = true,
@@ -399,6 +401,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
     var resource_wrappers: ResourceWrapperMode = .paths;
     var resource_wrappers_explicit = false;
     var models_only = false;
+    var runtime_only = false;
     var multiple_files = false;
     var multiple_clients: ?MultipleClientsMode = null;
     var file_names: FileNameOverrides = .{};
@@ -453,6 +456,8 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
             resource_wrappers_explicit = true;
         } else if (std.mem.eql(u8, arg, "--models-only")) {
             models_only = true;
+        } else if (std.mem.eql(u8, arg, "--runtime-only")) {
+            runtime_only = true;
         } else if (std.mem.eql(u8, arg, "--tag")) {
             i += 1;
             if (i >= args.len) {
@@ -546,9 +551,13 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
     }
 
     if (input_path == null) {
-        printUsage();
-        printError("OpenAPI spec path or URL required\n", .{});
-        return error.InvalidArguments;
+        if (runtime_only) {
+            input_path = "";
+        } else {
+            printUsage();
+            printError("OpenAPI spec path or URL required\n", .{});
+            return error.InvalidArguments;
+        }
     }
 
     if (!multiple_files and file_names.any()) {
@@ -600,7 +609,31 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
         return error.InvalidArguments;
     }
 
-    if (!models_only) {
+    if (runtime_only and models_only) {
+        printUsage();
+        printError("--runtime-only and --models-only are mutually exclusive\n", .{});
+        return error.InvalidArguments;
+    }
+
+    if (runtime_only and multiple_clients != null) {
+        printUsage();
+        printError("--runtime-only and --multiple-clients are mutually exclusive\n", .{});
+        return error.InvalidArguments;
+    }
+
+    if (runtime_only and runtime_module != null) {
+        printUsage();
+        printError("--runtime-only and --runtime-module are mutually exclusive\n", .{});
+        return error.InvalidArguments;
+    }
+
+    if (runtime_only and (file_names.models != null or file_names.client != null)) {
+        printUsage();
+        printError("--file-name for models or client has no effect with --runtime-only\n", .{});
+        return error.InvalidArguments;
+    }
+
+    if (!models_only and !runtime_only) {
         if (runtime_module) |mod| {
             // When re-using an external runtime, only models and client are emitted, so
             // duplicate checks must be scoped to those two outputs plus the imported runtime alias.
@@ -675,6 +708,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
             .base_url = base_url,
             .resource_wrappers = resource_wrappers,
             .models_only = models_only,
+            .runtime_only = runtime_only,
             .multiple_files = multiple_files,
             .multiple_clients = multiple_clients,
             .file_names = file_names,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1894,3 +1894,120 @@ test "resolveRuntimeModulePath normalizes dotdot segments" {
         try std.testing.expectEqualStrings(c.expected, resolved);
     }
 }
+
+test "parse generate supports --runtime-only flag" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--runtime-only",
+    };
+
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
+
+    try std.testing.expect(parsed.args.runtime_only);
+    try std.testing.expectEqualStrings("openapi.json", parsed.args.input_path);
+}
+
+test "parse generate with --runtime-only does not require input" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "--runtime-only",
+    };
+
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
+
+    try std.testing.expect(parsed.args.runtime_only);
+}
+
+test "parse generate supports --runtime-only with output" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "--runtime-only",
+        "-o",
+        "runtime.zig",
+    };
+
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
+
+    try std.testing.expect(parsed.args.runtime_only);
+    try std.testing.expectEqualStrings("runtime.zig", parsed.args.output_path.?);
+}
+
+test "parse rejects --runtime-only with --models-only" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--runtime-only",
+        "--models-only",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-only with --multiple-clients" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--runtime-only",
+        "--multiple-clients",
+        "PerTag",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-only with --runtime-module" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--runtime-only",
+        "--multiple-files",
+        "--runtime-module",
+        "../runtime.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-only with --file-name models override" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--runtime-only",
+        "--multiple-files",
+        "--file-name",
+        "models=types.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-only with --file-name client override" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "-i",
+        "openapi.json",
+        "--runtime-only",
+        "--multiple-files",
+        "--file-name",
+        "client=api.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -45,12 +45,12 @@ fn printUsage() void {
         \\                              client file (e.g. "../runtime.zig").
         \\                              Requires --multiple-files and is mutually exclusive with
         \\                              --file-name runtime=... .
-         \\   --force                   Force overwriting output even when unchanged
-         \\   --parameters-as-struct    Wrap method parameters in a single options struct
-         \\                            instead of individual function arguments
-         \\   --runtime-only            Generate only the runtime module (no input required)
-         \\
-         \\ EXAMPLES:
+        \\   --force                   Force overwriting output even when unchanged
+        \\   --parameters-as-struct    Wrap method parameters in a single options struct
+        \\                            instead of individual function arguments
+        \\   --runtime-only            Generate only the runtime module (no input required)
+        \\
+        \\ EXAMPLES:
         \\   openapi2zig generate -i ./openapi/petstore.json -o api.zig
         \\   openapi2zig generate -i ./openapi/petstore.json -o models.zig --models-only
         \\   openapi2zig generate -i https://petstore3.swagger.io/api/v3/openapi.json -o api.zig

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -1199,3 +1199,118 @@ test "generateMultipleFiles normalizes backslash-separated models and runtime fi
     try std.testing.expect(std.mem.indexOf(u8, client, "const gen_models = @import(\"gen/models.zig\");") != null);
     try std.testing.expect(std.mem.indexOf(u8, client, "const rt_runtime = @import(\"rt/runtime.zig\");") != null);
 }
+
+test "generateCode with --runtime-only single file writes runtime source without parsing input" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const out_path = "test_runtime_only_single.zig";
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, out_path) catch {};
+
+    try generateCode(allocator, std.testing.io, .{
+        .input_path = "nonexistent.json",
+        .output_path = out_path,
+        .runtime_only = true,
+    });
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, out_path, allocator, .unlimited);
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "pub fn Owned") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "pub const RawResponse") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "pub const HttpObserver") != null);
+    // Runtime-only output should not contain client-specific code like Client struct? Actually runtime does not contain Client, but check it contains SSE helpers
+    try std.testing.expect(std.mem.indexOf(u8, content, "max_sse_line_size") != null);
+}
+
+test "generateCode with --runtime-only skips input validation for invalid extension" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const out_path = "test_runtime_only_invalid_ext.zig";
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, out_path) catch {};
+
+    try generateCode(allocator, std.testing.io, .{
+        .input_path = "invalid.txt",
+        .output_path = out_path,
+        .runtime_only = true,
+    });
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, out_path, allocator, .unlimited);
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "pub fn Owned") != null);
+}
+
+test "generateCode with --runtime-only and no input succeeds" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const out_path = "test_runtime_only_no_input.zig";
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, out_path) catch {};
+
+    try generateCode(allocator, std.testing.io, .{
+        .input_path = "",
+        .output_path = out_path,
+        .runtime_only = true,
+    });
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, out_path, allocator, .unlimited);
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "pub fn Owned") != null);
+}
+
+test "generateCode with --runtime-only and --multiple-files writes only runtime file" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const out_dir = "test_runtime_only_multi";
+    defer std.Io.Dir.cwd().deleteTree(std.testing.io, out_dir) catch {};
+
+    try generateCode(allocator, std.testing.io, .{
+        .input_path = "nonexistent.json",
+        .output_path = out_dir,
+        .runtime_only = true,
+        .multiple_files = true,
+    });
+
+    const runtime_path = out_dir ++ "/runtime.zig";
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, runtime_path, allocator, .unlimited);
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "pub fn Owned") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "pub const CancellationToken") != null);
+
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, out_dir ++ "/models.zig", .{}));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, out_dir ++ "/client.zig", .{}));
+}
+
+test "generateCode with --runtime-only and custom runtime file name" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    const out_dir = "test_runtime_only_custom";
+    defer std.Io.Dir.cwd().deleteTree(std.testing.io, out_dir) catch {};
+
+    try generateCode(allocator, std.testing.io, .{
+        .input_path = "",
+        .output_path = out_dir,
+        .runtime_only = true,
+        .multiple_files = true,
+        .file_names = .{ .runtime = "http.zig" },
+    });
+
+    const runtime_path = out_dir ++ "/http.zig";
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, runtime_path, allocator, .unlimited);
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "pub fn Owned") != null);
+
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, out_dir ++ "/runtime.zig", .{}));
+}

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -45,6 +45,9 @@ pub fn validateExtension(input_file_path: []const u8) !Extension {
 }
 
 pub fn generateCode(allocator: std.mem.Allocator, io: std.Io, args: cli.CliArgs) !void {
+    if (args.runtime_only) {
+        return try generateRuntimeOnly(allocator, io, std.Io.Dir.cwd(), args);
+    }
     const extension = try validateExtension(args.input_path);
 
     // Determine input source: URL or file path
@@ -290,6 +293,59 @@ fn generateMultipleFiles(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.D
     defer allocator.free(generated_api);
 
     try writeFile(allocator, io, cwd, dir_path, client_file, generated_api, args.force);
+}
+
+fn generateRuntimeOnly(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.Dir, args: cli.CliArgs) !void {
+    if (args.multiple_files) {
+        const dir_path = args.output_path orelse default_output_dir;
+        try cwd.createDirPath(io, dir_path);
+
+        const runtime_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.runtime) orelse cli.FileKind.runtime.defaultName(), "\\", "/");
+        defer allocator.free(runtime_file);
+
+        var runtime_gen = RuntimeGenerator.init(allocator);
+        defer runtime_gen.deinit();
+        const generated_runtime = try runtime_gen.generate();
+        defer allocator.free(generated_runtime);
+
+        try writeFile(allocator, io, cwd, dir_path, runtime_file, generated_runtime, args.force);
+        return;
+    }
+
+    var runtime_gen = RuntimeGenerator.init(allocator);
+    defer runtime_gen.deinit();
+    const generated_runtime = try runtime_gen.generate();
+    defer allocator.free(generated_runtime);
+
+    const checksum = generated_header.computeChecksum(generated_runtime);
+    const header = try generated_header.renderNowWithChecksum(allocator, io, checksum);
+    defer allocator.free(header);
+    const output_code = try std.mem.concat(allocator, u8, &.{ header, generated_runtime });
+    defer allocator.free(output_code);
+
+    const output_path = args.output_path orelse default_output_file;
+    if (std.fs.path.dirname(output_path)) |dir_path| {
+        try cwd.createDirPath(io, dir_path);
+    }
+
+    if (!args.force) {
+        const full_path = try std.fs.path.join(allocator, &.{ ".", output_path });
+        defer allocator.free(full_path);
+        if (cwd.readFileAlloc(io, full_path, allocator, .limited(10 * 1024 * 1024))) |existing| {
+            defer allocator.free(existing);
+            if (!generated_header.hasChanged(existing, generated_runtime)) {
+                std.log.info("Skipping '{s}' (unchanged)", .{output_path});
+                return;
+            }
+        } else |_| {}
+    } else {
+        std.log.info("Force flag is set; overwriting '{s}'", .{output_path});
+    }
+
+    const output_file = try cwd.createFile(io, output_path, .{});
+    defer output_file.close(io);
+    try output_file.writeStreamingAll(io, output_code);
+    std.log.info("Code generated successfully and written to '{s}'.", .{output_path});
 }
 
 fn generateCodeFromDocument(allocator: std.mem.Allocator, io: std.Io, doc: anytype, args: cli.CliArgs, comptime Converter: type) !void {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -238,7 +238,21 @@ pub fn generateApi(allocator: std.mem.Allocator, unified_doc: UnifiedDocument, a
 ///
 /// Returns:
 /// - String containing complete generated Zig code
+pub fn generateRuntime(allocator: std.mem.Allocator, io: std.Io) ![]const u8 {
+    var runtime_gen = RuntimeGenerator.init(allocator);
+    defer runtime_gen.deinit();
+    const runtime_code = try runtime_gen.generate();
+    defer allocator.free(runtime_code);
+    const checksum = generated_header.computeChecksum(runtime_code);
+    const header = try generated_header.renderNowWithChecksum(allocator, io, checksum);
+    defer allocator.free(header);
+    return try std.mem.concat(allocator, u8, &.{ header, runtime_code });
+}
+
 pub fn generateCode(allocator: std.mem.Allocator, io: std.Io, unified_doc: UnifiedDocument, args: CliArgs) ![]const u8 {
+    if (args.runtime_only) {
+        return try generateRuntime(allocator, io);
+    }
     const models_code = try generateModels(allocator, unified_doc);
     defer allocator.free(models_code);
 
@@ -280,6 +294,29 @@ pub const GeneratedFiles = struct {
 /// args.models_only is true. `runtime` is also null when `args.runtime_module` is set
 /// to reuse an existing runtime module instead of generating one.
 pub fn generateCodeMultiple(allocator: std.mem.Allocator, io: std.Io, unified_doc: UnifiedDocument, args: CliArgs) !GeneratedFiles {
+    if (args.runtime_only) {
+        if (args.models_only) return error.InvalidArguments;
+        if (args.multiple_clients != null) return error.InvalidArguments;
+        if (args.runtime_module != null) return error.InvalidArguments;
+        if (args.file_names.models != null or args.file_names.client != null) return error.InvalidArguments;
+        const runtime_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.runtime) orelse cli.FileKind.runtime.defaultName(), "\\", "/");
+        defer allocator.free(runtime_file);
+        const r_alias = try cli.deriveAlias(allocator, runtime_file, "runtime");
+        defer allocator.free(r_alias);
+        const reserved = [_][]const u8{ "std", "Client", "_" };
+        for (reserved) |r| if (std.mem.eql(u8, r_alias, r)) return error.InvalidArguments;
+        var runtime_gen = RuntimeGenerator.init(allocator);
+        defer runtime_gen.deinit();
+        const runtime_code = try runtime_gen.generate();
+        defer allocator.free(runtime_code);
+        const runtime_checksum = generated_header.computeChecksum(runtime_code);
+        const runtime_header = try generated_header.renderNowWithChecksum(allocator, io, runtime_checksum);
+        defer allocator.free(runtime_header);
+        const runtime_with_header = try std.mem.concat(allocator, u8, &.{ runtime_header, runtime_code });
+        errdefer allocator.free(runtime_with_header);
+        const empty_models = try allocator.dupe(u8, "");
+        return .{ .models = empty_models, .runtime = runtime_with_header, .client = null };
+    }
     const models_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.models) orelse cli.FileKind.models.defaultName(), "\\", "/");
     defer allocator.free(models_file);
     const runtime_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.runtime) orelse cli.FileKind.runtime.defaultName(), "\\", "/");


### PR DESCRIPTION
Implements --runtime-only flag to generate only the runtime module.

- CLI: adds CliArgs.runtime_only, parses --runtime-only, makes --input optional when flag is set, adds mutual-exclusion checks (models-only, multiple-clients, runtime-module, file-name models/client), updates usage text (src/cli.zig)
- Generator: generateCode now short-circuits to generateRuntimeOnly which writes only runtime.zig (single-file or multiple-files with --file-name runtime=, respects --force and skips unchanged). Input file/extension/URL loading is bypassed so input doesn't matter (src/generator.zig)
- Library: adds generateRuntime and handles runtime_only in generateCode / generateCodeMultiple including validation (src/lib.zig)
- Docs: README updated with --runtime-only flag, examples, and mutual-exclusion notes
- TDD & nano-commits: failing tests for CLI parsing and generator file generation added first, then implementations committed as small logical steps

Testing:
- CLI: --runtime-only without -i succeeds, with nonexistent/invalid input still succeeds, defaults to generated.zig or generated/ dir
- Multiple-files: only runtime.zig emitted, custom runtime name honored, models/client not emitted
- Mutual exclusions return InvalidArguments
- zig build test: 369 pass, 6 skip