### PR TITLE
Add --runtime-only flag to generate just the runtime module

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The `generate` command reads a JSON or YAML OpenAPI/Swagger document from a loca
 
 | Flag | Description |
 | :--- | :--- |
-| `-i`, `--input <PATH_OR_URL>` | OpenAPI/Swagger JSON or YAML spec from a file path or `http`/`https` URL. Required. |
+| `-i`, `--input <PATH_OR_URL>` | OpenAPI/Swagger JSON or YAML spec from a file path or `http`/`https` URL. Required, except with `--runtime-only` where it is ignored. |
 | `-o`, `--output <path>` | Output file for the generated Zig code. Defaults to `generated.zig`. Parent directories are created when needed. |
 | `--base-url <url>` | Base URL baked into the generated `Client`. Defaults to the server URL from the OpenAPI/Swagger document. |
 | `--resource-wrappers <mode>` | Generate resource wrapper namespaces. Modes: `none`, `tags`, `paths`, `hybrid`. Defaults to `paths`. |
@@ -230,6 +230,7 @@ The `generate` command reads a JSON or YAML OpenAPI/Swagger document from a loca
 | `--multiple-files` | Generate separate output files for models, runtime, and API client into the output directory specified by `-o`. |
 | `--file-name <kind>=<name>` | Customize an output file name in `--multiple-files` mode. `<kind>` is `models`, `runtime`, or `client`. `<name>` may include a relative subpath (e.g. `models=gen/types.zig`); any required parent directories are created automatically. Can be specified multiple times. |
 | `--runtime-module <path>` | Re-use an existing `runtime.zig` instead of generating a new one. The path is a Zig import path relative to the generated `client.zig` (e.g. `../runtime.zig` or `../shared/my_runtime.zig`). Requires `--multiple-files` and is mutually exclusive with `--file-name runtime=...`. When given, no `runtime.zig` is emitted; the client imports the supplied path and derives the import alias from the file basename (`my_runtime` for `my_runtime.zig`). |
+| `--runtime-only` | Generate only the runtime module. No input spec is required; when `-i` is given it is ignored entirely. Without `--multiple-files`, writes the runtime module to `-o` (default `runtime.zig`). With `--multiple-files`, writes only the runtime file into the output directory (honors `--file-name runtime=...`). Mutually exclusive with `--models-only`, `--runtime-module`, and all client-related options. |
 | `--force` | Force overwriting output even when unchanged (skip unchanged-content check). |
 | `--parameters-as-struct` | Wrap the method parameters of each operation in a single `options` struct instead of emitting them as individual function arguments. Optional query parameters become nullable fields defaulting to `null`; required path and query parameters stay non-optional. The request body, when present, remains a separate `requestBody` argument. |
 
@@ -326,6 +327,8 @@ defer pet.deinit();
 ```bash
 # Generate a shared runtime once
 openapi2zig generate -i openapi/v3.0/petstore.json -o generated/shared --multiple-files
+# Or, without any spec at all:
+openapi2zig generate --runtime-only -o generated/shared --multiple-files
 
 # Re-use it from other clients via a client-relative import path
 openapi2zig generate -i openapi/v3.1/anthropic.json -o generated/anthropic --multiple-files --runtime-module ../shared/runtime.zig
@@ -333,7 +336,7 @@ openapi2zig generate -i openapi/v3.1/openai.json -o generated/openai --multiple-
 # With custom models file name, the same pattern applies:
 openapi2zig generate -i openapi/v3.1/lmstudio.json -o generated/lmstudio --multiple-files --file-name models=contracts.zig --runtime-module ../shared/runtime.zig
 ```
-When `--runtime-module` is given, no `runtime.zig` is emitted in the output directory; `client.zig` instead contains `const runtime = @import("../shared/runtime.zig");` (alias derived from the file basename, e.g. `my_runtime` for `my_runtime.zig`) and re-exports `Owned`, `RawResponse`, etc. from that module. The flag requires `--multiple-files` and is mutually exclusive with `--file-name runtime=...`. If the target file does not yet exist, generation still succeeds with an info log so you can generate the shared runtime first.
+When `--runtime-module` is given, no `runtime.zig` is emitted in the output directory; `client.zig` instead contains `const runtime = @import("../shared/runtime.zig");` (alias derived from the file basename, e.g. `my_runtime` for `my_runtime.zig`) and re-exports `Owned`, `RawResponse`, etc. from that module. The flag requires `--multiple-files` and is mutually exclusive with `--file-name runtime=...`. If the target file does not yet exist, generation still succeeds with an info log so you can generate the shared runtime first, for example with `openapi2zig generate --runtime-only -o generated/shared --multiple-files`.
 
 ### Upgrading
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -45,6 +45,9 @@ fn printUsage() void {
         \\                              client file (e.g. "../runtime.zig").
         \\                              Requires --multiple-files and is mutually exclusive with
         \\                              --file-name runtime=... .
+        \\   --runtime-only             Generate only the runtime module. No input spec is
+        \\                              required; when -i is given it is ignored.
+        \\                              (default output: runtime.zig)
         \\   --force                   Force overwriting output even when unchanged
         \\   --parameters-as-struct    Wrap method parameters in a single options struct
         \\                            instead of individual function arguments
@@ -356,6 +359,9 @@ pub const CliArgs = struct {
     /// Whether `tags` was allocated by the parser and must be freed.
     owns_tags: bool = false,
     force: bool = false,
+    /// Generate only the runtime module. The input spec is not required and,
+    /// when given, is ignored entirely.
+    runtime_only: bool = false,
     /// Wrap non-body method parameters in a single `options` struct instead of
     /// emitting them as individual function arguments.
     parameters_as_struct: bool = false,
@@ -385,7 +391,16 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
         };
     }
 
-    if (args.len < 4 or (args.len >= 1 and !std.mem.eql(u8, args[1], "generate"))) {
+    var has_runtime_only = false;
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--runtime-only")) {
+            has_runtime_only = true;
+            break;
+        }
+    }
+
+    const min_args: usize = if (has_runtime_only) 3 else 4;
+    if (args.len < min_args or (args.len >= 1 and !std.mem.eql(u8, args[1], "generate"))) {
         printUsage();
         return .{
             .help = true,
@@ -408,6 +423,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
     var tags: []const []const u8 = &.{};
     var tags_owned = false;
     var force = false;
+    var runtime_only = false;
     var parameters_as_struct = false;
 
     var i: usize = 2;
@@ -540,12 +556,14 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
             runtime_module = value;
         } else if (std.mem.eql(u8, arg, "--force")) {
             force = true;
+        } else if (std.mem.eql(u8, arg, "--runtime-only")) {
+            runtime_only = true;
         } else if (std.mem.eql(u8, arg, "--parameters-as-struct")) {
             parameters_as_struct = true;
         }
     }
 
-    if (input_path == null) {
+    if (input_path == null and !runtime_only) {
         printUsage();
         printError("OpenAPI spec path or URL required\n", .{});
         return error.InvalidArguments;
@@ -670,7 +688,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
 
     return .{
         .args = .{
-            .input_path = input_path.?,
+            .input_path = input_path orelse "",
             .output_path = output_path,
             .base_url = base_url,
             .resource_wrappers = resource_wrappers,
@@ -682,6 +700,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
             .tags = tags,
             .owns_tags = tags_owned,
             .force = force,
+            .runtime_only = runtime_only,
             .parameters_as_struct = parameters_as_struct,
         },
     };
@@ -1893,4 +1912,34 @@ test "resolveRuntimeModulePath normalizes dotdot segments" {
         defer std.testing.allocator.free(resolved);
         try std.testing.expectEqualStrings(c.expected, resolved);
     }
+}
+
+test "parse accepts --runtime-only without input" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "--runtime-only",
+    };
+
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
+    try std.testing.expect(parsed.args.runtime_only);
+    try std.testing.expectEqualStrings("", parsed.args.input_path);
+}
+
+test "parse accepts --runtime-only with output and ignores input" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "--runtime-only",
+        "-i",
+        "openapi.json",
+        "-o",
+        "runtime.zig",
+    };
+
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
+    try std.testing.expect(parsed.args.runtime_only);
+    try std.testing.expectEqualStrings("runtime.zig", parsed.args.output_path.?);
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -581,6 +581,39 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
         return error.InvalidArguments;
     }
 
+    if (runtime_only) {
+        if (multiple_clients != null) {
+            printUsage();
+            printError("--multiple-clients has no effect with --runtime-only\n", .{});
+            return error.InvalidArguments;
+        }
+        if (tags_list.items.len > 0) {
+            printUsage();
+            printError("--tag has no effect with --runtime-only\n", .{});
+            return error.InvalidArguments;
+        }
+        if (base_url != null) {
+            printUsage();
+            printError("--base-url has no effect with --runtime-only\n", .{});
+            return error.InvalidArguments;
+        }
+        if (parameters_as_struct) {
+            printUsage();
+            printError("--parameters-as-struct has no effect with --runtime-only\n", .{});
+            return error.InvalidArguments;
+        }
+        if (resource_wrappers_explicit) {
+            printUsage();
+            printError("--resource-wrappers has no effect with --runtime-only\n", .{});
+            return error.InvalidArguments;
+        }
+        if (file_names.models != null or file_names.client != null) {
+            printUsage();
+            printError("--file-name for models or client has no effect with --runtime-only\n", .{});
+            return error.InvalidArguments;
+        }
+    }
+
     if (!multiple_files and file_names.any()) {
         printUsage();
         printError("--file-name requires --multiple-files\n", .{});
@@ -1978,4 +2011,35 @@ test "parse rejects --runtime-only with --runtime-module" {
     };
 
     try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-only with client-only options" {
+    const cases = [_][]const [:0]const u8{
+        &.{ "openapi2zig", "generate", "--runtime-only", "--multiple-clients" },
+        &.{ "openapi2zig", "generate", "--runtime-only", "--tag", "pets" },
+        &.{ "openapi2zig", "generate", "--runtime-only", "--base-url", "https://example.com" },
+        &.{ "openapi2zig", "generate", "--runtime-only", "--parameters-as-struct" },
+        &.{ "openapi2zig", "generate", "--runtime-only", "--resource-wrappers", "none" },
+        &.{ "openapi2zig", "generate", "--runtime-only", "--multiple-files", "--file-name", "models=types.zig" },
+        &.{ "openapi2zig", "generate", "--runtime-only", "--multiple-files", "--file-name", "client=api.zig" },
+    };
+    for (cases) |argv| {
+        try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, argv));
+    }
+}
+
+test "parse accepts --runtime-only with --multiple-files and runtime file name" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "--runtime-only",
+        "--multiple-files",
+        "--file-name",
+        "runtime=http.zig",
+    };
+
+    var parsed = try parse(std.testing.allocator, &argv);
+    defer parsed.deinit(std.testing.allocator);
+    try std.testing.expect(parsed.args.runtime_only);
+    try std.testing.expectEqualStrings("http.zig", parsed.args.file_names.runtime.?);
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -569,6 +569,18 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !ParsedAr
         return error.InvalidArguments;
     }
 
+    if (runtime_only and models_only) {
+        printUsage();
+        printError("--runtime-only and --models-only are mutually exclusive\n", .{});
+        return error.InvalidArguments;
+    }
+
+    if (runtime_only and runtime_module != null) {
+        printUsage();
+        printError("--runtime-only and --runtime-module are mutually exclusive\n", .{});
+        return error.InvalidArguments;
+    }
+
     if (!multiple_files and file_names.any()) {
         printUsage();
         printError("--file-name requires --multiple-files\n", .{});
@@ -1942,4 +1954,28 @@ test "parse accepts --runtime-only with output and ignores input" {
     defer parsed.deinit(std.testing.allocator);
     try std.testing.expect(parsed.args.runtime_only);
     try std.testing.expectEqualStrings("runtime.zig", parsed.args.output_path.?);
+}
+
+test "parse rejects --runtime-only with --models-only" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "--runtime-only",
+        "--models-only",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
+}
+
+test "parse rejects --runtime-only with --runtime-module" {
+    const argv = [_][:0]const u8{
+        "openapi2zig",
+        "generate",
+        "--runtime-only",
+        "--multiple-files",
+        "--runtime-module",
+        "../runtime.zig",
+    };
+
+    try std.testing.expectError(error.InvalidArguments, parse(std.testing.allocator, &argv));
 }

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -183,6 +183,15 @@ fn generateRuntimeOnly(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.Dir
     const generated_runtime = try runtime_gen.generate();
     defer allocator.free(generated_runtime);
 
+    if (args.multiple_files) {
+        const dir_path = args.output_path orelse default_output_dir;
+        try cwd.createDirPath(io, dir_path);
+        const runtime_file = try std.mem.replaceOwned(u8, allocator, args.file_names.get(.runtime) orelse cli.FileKind.runtime.defaultName(), "\\", "/");
+        defer allocator.free(runtime_file);
+        try writeFile(allocator, io, cwd, dir_path, runtime_file, generated_runtime, args.force);
+        return;
+    }
+
     const output_path = args.output_path orelse default_runtime_only_file;
     try writeFile(allocator, io, cwd, ".", output_path, generated_runtime, args.force);
 }
@@ -1262,4 +1271,52 @@ test "generateRuntimeOnly defaults the output file name to runtime.zig" {
     const runtime = try tmp.dir.readFileAlloc(std.testing.io, "runtime.zig", allocator, .unlimited);
     defer allocator.free(runtime);
     try std.testing.expect(std.mem.indexOf(u8, runtime, "pub fn Owned") != null);
+}
+
+test "generateRuntimeOnly with multiple_files writes only the runtime file into the output dir" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try generateRuntimeOnly(allocator, std.testing.io, tmp.dir, .{
+        .input_path = "",
+        .runtime_only = true,
+        .multiple_files = true,
+        .output_path = "out",
+    });
+
+    const runtime = try tmp.dir.readFileAlloc(std.testing.io, "out/runtime.zig", allocator, .unlimited);
+    defer allocator.free(runtime);
+    try std.testing.expect(std.mem.indexOf(u8, runtime, "pub fn Owned") != null);
+
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "out/models.zig", .{}));
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "out/client.zig", .{}));
+}
+
+test "generateRuntimeOnly with multiple_files honors a custom runtime file name" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try generateRuntimeOnly(allocator, std.testing.io, tmp.dir, .{
+        .input_path = "",
+        .runtime_only = true,
+        .multiple_files = true,
+        .output_path = "out",
+        .file_names = .{ .runtime = "shared/http.zig" },
+    });
+
+    const runtime = try tmp.dir.readFileAlloc(std.testing.io, "out/shared/http.zig", allocator, .unlimited);
+    defer allocator.free(runtime);
+    try std.testing.expect(std.mem.indexOf(u8, runtime, "pub fn Owned") != null);
+
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "out/runtime.zig", .{}));
 }

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -193,7 +193,10 @@ fn generateRuntimeOnly(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.Dir
     }
 
     const output_path = args.output_path orelse default_runtime_only_file;
-    try writeFile(allocator, io, cwd, ".", output_path, generated_runtime, args.force);
+    // Split into dir + name so writeFile never prefixes an absolute path with
+    // "./", which the OS rejects as a malformed path.
+    const output_dir = std.fs.path.dirname(output_path) orelse ".";
+    try writeFile(allocator, io, cwd, output_dir, std.fs.path.basename(output_path), generated_runtime, args.force);
 }
 
 fn writeFile(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.Dir, dir_path: []const u8, file_name: []const u8, raw_code: []const u8, force: bool) !void {
@@ -1319,4 +1322,30 @@ test "generateRuntimeOnly with multiple_files honors a custom runtime file name"
     try std.testing.expect(std.mem.indexOf(u8, runtime, "pub fn Owned") != null);
 
     try std.testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "out/runtime.zig", .{}));
+}
+
+test "generateRuntimeOnly supports an absolute output path" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const cwd_path = try std.process.currentPathAlloc(std.testing.io, allocator);
+    defer allocator.free(cwd_path);
+    const output_path = try std.fs.path.join(allocator, &.{ cwd_path, ".zig-cache", "tmp", &tmp.sub_path, "abs", "runtime.zig" });
+    defer allocator.free(output_path);
+    try std.testing.expect(std.fs.path.isAbsolute(output_path));
+
+    try generateRuntimeOnly(allocator, std.testing.io, std.Io.Dir.cwd(), .{
+        .input_path = "",
+        .runtime_only = true,
+        .output_path = output_path,
+    });
+
+    const runtime = try tmp.dir.readFileAlloc(std.testing.io, "abs/runtime.zig", allocator, .unlimited);
+    defer allocator.free(runtime);
+    try std.testing.expect(std.mem.indexOf(u8, runtime, "pub fn Owned") != null);
 }

--- a/src/generator.zig
+++ b/src/generator.zig
@@ -18,6 +18,7 @@ const openapi2zig = @import("lib.zig");
 
 const default_output_file: []const u8 = "generated.zig";
 const default_output_dir: []const u8 = "generated";
+const default_runtime_only_file: []const u8 = "runtime.zig";
 
 const Extension = enum {
     YAML,
@@ -45,6 +46,12 @@ pub fn validateExtension(input_file_path: []const u8) !Extension {
 }
 
 pub fn generateCode(allocator: std.mem.Allocator, io: std.Io, args: cli.CliArgs) !void {
+    if (args.runtime_only) {
+        // The input spec is irrelevant for a runtime-only build: never
+        // validate its extension or read it.
+        return generateRuntimeOnly(allocator, io, std.Io.Dir.cwd(), args);
+    }
+
     const extension = try validateExtension(args.input_path);
 
     // Determine input source: URL or file path
@@ -166,6 +173,18 @@ fn generateCodeFromUnifiedDocument(allocator: std.mem.Allocator, io: std.Io, cwd
     defer output_file.close(io);
     try output_file.writeStreamingAll(io, output_code);
     std.log.info("Code generated successfully and written to '{s}'.", .{output_path});
+}
+
+/// Generate only the runtime module. The input spec plays no role here, so
+/// callers must not require or read one when `args.runtime_only` is set.
+fn generateRuntimeOnly(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.Dir, args: cli.CliArgs) !void {
+    var runtime_gen = RuntimeGenerator.init(allocator);
+    defer runtime_gen.deinit();
+    const generated_runtime = try runtime_gen.generate();
+    defer allocator.free(generated_runtime);
+
+    const output_path = args.output_path orelse default_runtime_only_file;
+    try writeFile(allocator, io, cwd, ".", output_path, generated_runtime, args.force);
 }
 
 fn writeFile(allocator: std.mem.Allocator, io: std.Io, cwd: std.Io.Dir, dir_path: []const u8, file_name: []const u8, raw_code: []const u8, force: bool) !void {
@@ -1198,4 +1217,49 @@ test "generateMultipleFiles normalizes backslash-separated models and runtime fi
     // Aliases are derived from the normalized path stems.
     try std.testing.expect(std.mem.indexOf(u8, client, "const gen_models = @import(\"gen/models.zig\");") != null);
     try std.testing.expect(std.mem.indexOf(u8, client, "const rt_runtime = @import(\"rt/runtime.zig\");") != null);
+}
+
+test "generateCode with runtime_only ignores the input and writes only the runtime module" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const output_path = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, "runtime.zig" });
+    defer allocator.free(output_path);
+
+    // A bogus input path with an unsupported extension proves the input is
+    // never validated or read when runtime_only is set.
+    try generateCode(allocator, std.testing.io, .{
+        .input_path = "does/not/exist.txt",
+        .runtime_only = true,
+        .output_path = output_path,
+    });
+
+    const runtime = try tmp.dir.readFileAlloc(std.testing.io, "runtime.zig", allocator, .unlimited);
+    defer allocator.free(runtime);
+    try std.testing.expect(std.mem.indexOf(u8, runtime, "pub fn Owned") != null);
+    try std.testing.expect(std.mem.indexOf(u8, runtime, "pub const Pet") == null);
+}
+
+test "generateRuntimeOnly defaults the output file name to runtime.zig" {
+    const test_utils = @import("tests/test_utils.zig");
+
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try generateRuntimeOnly(allocator, std.testing.io, tmp.dir, .{
+        .input_path = "",
+        .runtime_only = true,
+    });
+
+    const runtime = try tmp.dir.readFileAlloc(std.testing.io, "runtime.zig", allocator, .unlimited);
+    defer allocator.free(runtime);
+    try std.testing.expect(std.mem.indexOf(u8, runtime, "pub fn Owned") != null);
 }


### PR DESCRIPTION
## Why

The `--runtime-module` flag lets multiple generated clients share a single `runtime.zig`, but there was no way to produce that shared runtime on its own - you had to run a full generation against some arbitrary spec just to get the file. `--runtime-only` closes that gap: it emits only the runtime module, so the input spec is irrelevant and is neither required nor read.

## What

```bash
# Generate a shared runtime without any spec
openapi2zig generate --runtime-only -o generated/shared --multiple-files

# Or as a single file (default output: runtime.zig)
openapi2zig generate --runtime-only
```

- No `-i` required; when given, the input is ignored entirely (extension validation and input loading are skipped - `generateCode` short-circuits before both)
- Single-file mode: writes the runtime module to `-o` (default `runtime.zig`), with the usual generated-header, checksum-based skip-unchanged, and `--force` behavior
- With `--multiple-files`: writes only the runtime file into the output directory (default `runtime.zig`, honors `--file-name runtime=<name>`); no models/client files
- Fail-fast parse errors, matching the existing "has no effect with ..." style, when combined with `--models-only`, `--runtime-module`, `--multiple-clients`, `--tag`, `--base-url`, `--parameters-as-struct`, an explicit `--resource-wrappers`, or `--file-name models=/client=`

## Notes for reviewers

- Smoke testing surfaced a **pre-existing** bug: normal generation also panics on Windows when `-o` is an absolute path (the unchanged-check builds a malformed `.\C:\...` path). Out of scope here, but `generateRuntimeOnly` deliberately avoids the pattern by splitting `-o` into dirname/basename before writing, and a regression test covers absolute output paths.
- Developed TDD-style: each commit is one red -> green slice (parse, conflict validation, single-file generation, multi-file generation, absolute-path fix, docs).
- `lib.zig` needs no changes; `RuntimeGenerator` was already publicly exported for library consumers.

## Testing

- 9 new tests across `src/cli.zig` (parse/validation) and `src/generator.zig` (TmpDir-based end-to-end)
- Full `zig build test` green; `zig fmt --check` clean on changed files; Debug build OK
- Manual CLI smoke: default output, absolute `-o`, `--multiple-files`, skip-unchanged on rerun, conflict exit code, `zig ast-check` on generated output