### PR TITLE
Fix skip-unchanged-output to survive CRLF checkouts

### DIFF
--- a/src/generators/generated_header.zig
+++ b/src/generators/generated_header.zig
@@ -53,7 +53,7 @@ pub fn extractChecksum(content: []const u8) ?u64 {
     const start = std.mem.indexOf(u8, content, marker) orelse return null;
     const after = content[start + marker.len ..];
     const end = std.mem.indexOf(u8, after, "\n") orelse after.len;
-    const hex_str = std.mem.trim(u8, after[0..end], " ");
+    const hex_str = std.mem.trim(u8, after[0..end], " \r");
     return std.fmt.parseInt(u64, hex_str, 16) catch null;
 }
 

--- a/src/tests/generated_header_tests.zig
+++ b/src/tests/generated_header_tests.zig
@@ -93,6 +93,28 @@ test "hasChanged returns false when code has not changed" {
     try std.testing.expect(!generated_header.hasChanged(full_content, code));
 }
 
+test "hasChanged returns false when the existing file has CRLF line endings" {
+    var gpa = test_utils.createTestAllocator();
+    const allocator = gpa.allocator();
+    defer std.debug.assert(gpa.deinit() == .ok);
+
+    // Simulates a file checked out with core.autocrlf=true, which turns the
+    // repo's LF endings into CRLF on disk.
+    const code = "pub const Foo = struct {\n    name: []const u8,\n};\n";
+    const checksum = generated_header.computeChecksum(code);
+
+    const header = try generated_header.renderWithChecksum(allocator, "0.6.0 (a1b2c3d)", "2026-07-12 21:49:56 UTC", checksum);
+    defer allocator.free(header);
+
+    const crlf_header = try std.mem.replaceOwned(u8, allocator, header, "\n", "\r\n");
+    defer allocator.free(crlf_header);
+
+    const full_content = try std.mem.concat(allocator, u8, &.{ crlf_header, code });
+    defer allocator.free(full_content);
+
+    try std.testing.expect(!generated_header.hasChanged(full_content, code));
+}
+
 test "hasChanged returns true when code has changed" {
     var gpa = test_utils.createTestAllocator();
     const allocator = gpa.allocator();


### PR DESCRIPTION
## Problem

`zig build run-generate` was giving new timestamps to every file under `generated/` on every run, even when nothing actually changed, defeating the unchanged-output skip added in #106.

## Root cause

This repo has `core.autocrlf=true`, so a fresh checkout/pull converts the committed LF-only generated files to CRLF on disk.

`extractChecksum` in `src/generators/generated_header.zig` locates the checksum line by searching for `\n`, but only trimmed spaces off the parsed hex string — not the trailing `\r` left behind by a CRLF line ending. `std.fmt.parseInt` then failed on the `\r`-suffixed string, `extractChecksum` returned `null`, and `hasChanged` treated the file as "changed" (missing checksum ⇒ assume changed). So the first `run-generate` after any checkout rewrote every generated file (bumping the header's version/timestamp) even though the actual generated body was identical. Since the generator always writes LF, the files looked fine again until the next checkout reintroduced CRLF.

## Fix

Trim `\r` along with spaces when extracting the checksum, so CRLF-checked-out files are still recognized as unchanged.

## Testing

- Reproduced: converted `generated/openai.zig` to CRLF and ran `zig build run-generate-openai` — it rewrote the file before the fix, and correctly logged `Skipping ... (unchanged)` after the fix.
- Added a regression test (`hasChanged returns false when the existing file has CRLF line endings`) simulating an autocrlf checkout.
- `zig build test` passes; the only failure present both before and after this change is a pre-existing, unrelated Windows networking flake in a generated streaming-cancellation test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated-file checksum parsing for Windows-style (CRLF) line endings.
  * Prevented unchanged files from being incorrectly detected as modified when checked out with CRLF line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->